### PR TITLE
Update node-build to not disable curlrc reading.

### DIFF
--- a/bin/node-build
+++ b/bin/node-build
@@ -201,11 +201,11 @@ http() {
 }
 
 http_head_curl() {
-  curl -qsILf "$1" >&4 2>&1
+  curl -sILf "$1" >&4 2>&1
 }
 
 http_get_curl() {
-  curl -qsSLf "$1"
+  curl -sSLf "$1"
 }
 
 http_head_wget() {


### PR DESCRIPTION
Not sure why this would want to be done, but it causes problems for those of us behind corporate firewalls.
