### PR TITLE
Brew publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "test": "bats ${CI:+--tap} test",
     "verify-definitions": "script/verify-definitions",
     "write-definitions": "nodenv update-version-defs --destination $PWD/share/node-build/",
-    "publish:brew": "brew-publish $npm_package_name",
+    "publish:brew": "brew-publish $npm_package_name v$npm_package_version",
     "preversion": "script/release preversion",
-    "postversion": "script/release postversion"
+    "postversion": "git push origin master v$npm_package_version && npm run publish:brew"
   },
   "devDependencies": {
     "bats": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "verify-definitions": "script/verify-definitions",
     "write-definitions": "nodenv update-version-defs --destination $PWD/share/node-build/",
     "publish:brew": "brew-publish $npm_package_name v$npm_package_version",
-    "preversion": "script/release preversion",
+    "preversion": "script/release",
     "postversion": "git push origin master v$npm_package_version && npm run publish:brew"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,13 +19,15 @@
     "test": "bats ${CI:+--tap} test",
     "verify-definitions": "script/verify-definitions",
     "write-definitions": "nodenv update-version-defs --destination $PWD/share/node-build/",
+    "publish:brew": "brew-publish $npm_package_name",
     "preversion": "script/release preversion",
     "postversion": "script/release postversion"
   },
   "devDependencies": {
     "bats": "^0.4.2",
     "bats-assert": "^1.0.1",
-    "bats-mock": "^1.0.1"
+    "bats-mock": "^1.0.1",
+    "brew-publish": "git+https://github.com/jasonkarns/brew-publish.git"
   },
   "license": "MIT"
 }

--- a/script/release
+++ b/script/release
@@ -9,7 +9,7 @@
 # version (handled by npm)
 # - bumps version in package.json
 # - commits and tags
-# postversion
+# postversion (handled by npm-script)
 # - pushes master + tag to GitHub
 # - opens pull request to update the Homebrew formula
 #
@@ -17,46 +17,22 @@
 
 set -e
 
-new_tag="v${npm_package_version}"
+git fetch -q --tags origin master
 
-preversion() {
-  git fetch -q --tags origin master
+local existing="$(git tag --points-at HEAD)"
+if [ -n "$existing" ]; then
+  echo "Aborting: HEAD is already tagged as '${existing}'" >&2
+  exit 1
+fi
 
-  local existing="$(git tag --points-at HEAD)"
-  if [ -n "$existing" ]; then
-    echo "Aborting: HEAD is already tagged as '${existing}'" >&2
-    exit 1
-  fi
+local current_branch="$(git symbolic-ref --short HEAD)"
+if [ "$current_branch" != master ]; then
+  echo "Aborting: Not currently on master branch" >&2
+  exit 1
+fi
 
-  local current_branch="$(git symbolic-ref --short HEAD)"
-  if [ "$current_branch" != master ]; then
-    echo "Aborting: Not currently on master branch" >&2
-    exit 1
-  fi
-
-  previous_tag="$(git describe --tags --abbrev=0)"
-  if git diff --quiet "${previous_tag}..HEAD" -- bin share; then
-    echo "Aborting: No features to release since '${previous_tag}'" >&2
-    exit 1
-  fi
-}
-
-postversion() {
-  git push origin master "${new_tag}"
-
-  script/brew-publish node-build "$new_tag"
-}
-
-
-cmd="$1"
-
-case "$cmd" in
-  preversion | postversion )
-    shift 1
-    "$cmd" "$@"
-    ;;
-  * )
-    echo "should be invoked via npm-version" >&2
-    exit 1
-    ;;
-esac
+previous_tag="$(git describe --tags --abbrev=0)"
+if git diff --quiet "${previous_tag}..HEAD" -- bin share; then
+  echo "Aborting: No features to release since '${previous_tag}'" >&2
+  exit 1
+fi

--- a/script/release
+++ b/script/release
@@ -19,13 +19,13 @@ set -e
 
 git fetch -q --tags origin master
 
-local existing="$(git tag --points-at HEAD)"
+existing="$(git tag --points-at HEAD)"
 if [ -n "$existing" ]; then
   echo "Aborting: HEAD is already tagged as '${existing}'" >&2
   exit 1
 fi
 
-local current_branch="$(git symbolic-ref --short HEAD)"
+current_branch="$(git symbolic-ref --short HEAD)"
 if [ "$current_branch" != master ]; then
   echo "Aborting: Not currently on master branch" >&2
   exit 1


### PR DESCRIPTION
I've extracted the brew-publish script out of node-build/ruby-build into its own repo. The end goal being to leverage the brew-publish script in all of our nodenv plugin repos as well.

Since node-build was already leveraging this script, it will be the first consumer of the extracted script.