### PR TITLE
Release changelog

### DIFF
--- a/script/release
+++ b/script/release
@@ -13,8 +13,6 @@
 # postversion (handled by npm-script)
 # - pushes master + tag to GitHub
 # - opens pull request to update the Homebrew formula
-#
-# TODO: publish release notes to GitHub
 
 set -e
 
@@ -37,3 +35,9 @@ if git diff --quiet "${previous_tag}..HEAD" -- bin share; then
   echo "Aborting: No features to release since '${previous_tag}'" >&2
   exit 1
 fi
+
+{ echo "ruby-build ${npm_package_version}"
+  echo
+  git log --no-merges --format='%w(0,0,2)* %B' --reverse "${previous_tag}..HEAD^" -- bin share/node-build
+} | hub release create -dF - -c "$(git rev-parse HEAD)" "v${npm_package_version}" || true
+hub browse -- "releases/v${npm_package_version}"


### PR DESCRIPTION
Cool change that uses hub to push release notes to github's release api.

Updated per our release script. As of yet, untested.