### PR TITLE
Warn when installing EOL/unsupported releases

### DIFF
--- a/bin/node-build
+++ b/bin/node-build
@@ -602,6 +602,26 @@ package_option() {
   eval "$variable=( \"\${value[@]}\" )"
 }
 
+build_package_warn_eol() {
+  local package_name="$1"
+
+  { echo
+    echo "WARNING: $package_name is past its end of life and is now unsupported."
+    echo "It no longer receives bug fixes or critical security updates."
+    echo
+  } >&3
+}
+
+build_package_warn_unsupported() {
+  local package_name="$1"
+
+  { echo
+    echo "WARNING: $package_name is nearing its end of life."
+    echo "It only receives critical security updates, no bug fixes."
+    echo
+  } >&3
+}
+
 build_package_standard() {
   local package_name="$1"
 

--- a/share/node-build/0.1.100
+++ b/share/node-build/0.1.100
@@ -1,1 +1,1 @@
-install_package "node-v0.1.100" "https://nodejs.org/dist/v0.1.100/node-v0.1.100.tar.gz#623d9157017ca3805cbbca653724f8e25a52be689f821d0c608f94717342e1e2"
+install_package "node-v0.1.100" "https://nodejs.org/dist/v0.1.100/node-v0.1.100.tar.gz#623d9157017ca3805cbbca653724f8e25a52be689f821d0c608f94717342e1e2" warn_eol

--- a/share/node-build/0.1.101
+++ b/share/node-build/0.1.101
@@ -1,1 +1,1 @@
-install_package "node-v0.1.101" "https://nodejs.org/dist/v0.1.101/node-v0.1.101.tar.gz#44b08c5c9bd0c23d79d447bc67e1767ec1350a02cec0da6e5ce4c7f790b4e773"
+install_package "node-v0.1.101" "https://nodejs.org/dist/v0.1.101/node-v0.1.101.tar.gz#44b08c5c9bd0c23d79d447bc67e1767ec1350a02cec0da6e5ce4c7f790b4e773" warn_eol

--- a/share/node-build/0.1.102
+++ b/share/node-build/0.1.102
@@ -1,1 +1,1 @@
-install_package "node-v0.1.102" "https://nodejs.org/dist/v0.1.102/node-v0.1.102.tar.gz#bd9b1d09ad40ceaef4bdd46019960c5c2fe87026c9598a6fb23c66457510a22d"
+install_package "node-v0.1.102" "https://nodejs.org/dist/v0.1.102/node-v0.1.102.tar.gz#bd9b1d09ad40ceaef4bdd46019960c5c2fe87026c9598a6fb23c66457510a22d" warn_eol

--- a/share/node-build/0.1.103
+++ b/share/node-build/0.1.103
@@ -1,1 +1,1 @@
-install_package "node-v0.1.103" "https://nodejs.org/dist/v0.1.103/node-v0.1.103.tar.gz#7482b898a0f9514c74137b490c3ad0810ee5ce1586e8886c5182f6446e56711e"
+install_package "node-v0.1.103" "https://nodejs.org/dist/v0.1.103/node-v0.1.103.tar.gz#7482b898a0f9514c74137b490c3ad0810ee5ce1586e8886c5182f6446e56711e" warn_eol

--- a/share/node-build/0.1.104
+++ b/share/node-build/0.1.104
@@ -1,1 +1,1 @@
-install_package "node-v0.1.104" "https://nodejs.org/dist/v0.1.104/node-v0.1.104.tar.gz#a1c776f44bc07305dc0e56df17cc3260eaafa0394c3b06c27448ad85bec272df"
+install_package "node-v0.1.104" "https://nodejs.org/dist/v0.1.104/node-v0.1.104.tar.gz#a1c776f44bc07305dc0e56df17cc3260eaafa0394c3b06c27448ad85bec272df" warn_eol

--- a/share/node-build/0.1.14
+++ b/share/node-build/0.1.14
@@ -1,1 +1,1 @@
-install_package "node-v0.1.14" "https://nodejs.org/dist/v0.1.14/node-v0.1.14.tar.gz#ff74848a9d444923e378e45ec46d6d0867889e78a045c43fa33080fe47c85004"
+install_package "node-v0.1.14" "https://nodejs.org/dist/v0.1.14/node-v0.1.14.tar.gz#ff74848a9d444923e378e45ec46d6d0867889e78a045c43fa33080fe47c85004" warn_eol

--- a/share/node-build/0.1.15
+++ b/share/node-build/0.1.15
@@ -1,1 +1,1 @@
-install_package "node-v0.1.15" "https://nodejs.org/dist/v0.1.15/node-v0.1.15.tar.gz#aaf90fb73ba9246adce7ea066ecbf954cb8fa1868246b73871adbe1dd3fcc8e0"
+install_package "node-v0.1.15" "https://nodejs.org/dist/v0.1.15/node-v0.1.15.tar.gz#aaf90fb73ba9246adce7ea066ecbf954cb8fa1868246b73871adbe1dd3fcc8e0" warn_eol

--- a/share/node-build/0.1.16
+++ b/share/node-build/0.1.16
@@ -1,1 +1,1 @@
-install_package "node-v0.1.16" "https://nodejs.org/dist/v0.1.16/node-v0.1.16.tar.gz#3e2088120bbd45881778d105ec53241bd15b0a90f4061d0e3bec2d7faa2955c2"
+install_package "node-v0.1.16" "https://nodejs.org/dist/v0.1.16/node-v0.1.16.tar.gz#3e2088120bbd45881778d105ec53241bd15b0a90f4061d0e3bec2d7faa2955c2" warn_eol

--- a/share/node-build/0.1.17
+++ b/share/node-build/0.1.17
@@ -1,1 +1,1 @@
-install_package "node-v0.1.17" "https://nodejs.org/dist/v0.1.17/node-v0.1.17.tar.gz#86765206da369900663976b215ff6aa38a6b7518474f60c382b3926a0186528a"
+install_package "node-v0.1.17" "https://nodejs.org/dist/v0.1.17/node-v0.1.17.tar.gz#86765206da369900663976b215ff6aa38a6b7518474f60c382b3926a0186528a" warn_eol

--- a/share/node-build/0.1.18
+++ b/share/node-build/0.1.18
@@ -1,1 +1,1 @@
-install_package "node-v0.1.18" "https://nodejs.org/dist/v0.1.18/node-v0.1.18.tar.gz#08b2db2dc4f0bb97fc51d79675803e1e4756209531b3c4a9b0f9850802155587"
+install_package "node-v0.1.18" "https://nodejs.org/dist/v0.1.18/node-v0.1.18.tar.gz#08b2db2dc4f0bb97fc51d79675803e1e4756209531b3c4a9b0f9850802155587" warn_eol

--- a/share/node-build/0.1.19
+++ b/share/node-build/0.1.19
@@ -1,1 +1,1 @@
-install_package "node-v0.1.19" "https://nodejs.org/dist/v0.1.19/node-v0.1.19.tar.gz#5eff91296a705f72bed6dd493e20af49fd56987e16928f45005605bc6736480a"
+install_package "node-v0.1.19" "https://nodejs.org/dist/v0.1.19/node-v0.1.19.tar.gz#5eff91296a705f72bed6dd493e20af49fd56987e16928f45005605bc6736480a" warn_eol

--- a/share/node-build/0.1.20
+++ b/share/node-build/0.1.20
@@ -1,1 +1,1 @@
-install_package "node-v0.1.20" "https://nodejs.org/dist/v0.1.20/node-v0.1.20.tar.gz#4f6684d831554508b2ec4ab3ebe3c417a5f55174a3a00cb5ad67b90d473942fc"
+install_package "node-v0.1.20" "https://nodejs.org/dist/v0.1.20/node-v0.1.20.tar.gz#4f6684d831554508b2ec4ab3ebe3c417a5f55174a3a00cb5ad67b90d473942fc" warn_eol

--- a/share/node-build/0.1.21
+++ b/share/node-build/0.1.21
@@ -1,1 +1,1 @@
-install_package "node-v0.1.21" "https://nodejs.org/dist/v0.1.21/node-v0.1.21.tar.gz#f7a7cc74c7b3eff74056bfa4710ae0bde65bf2d86ed9f9fdbc0406e14c0a5100"
+install_package "node-v0.1.21" "https://nodejs.org/dist/v0.1.21/node-v0.1.21.tar.gz#f7a7cc74c7b3eff74056bfa4710ae0bde65bf2d86ed9f9fdbc0406e14c0a5100" warn_eol

--- a/share/node-build/0.1.22
+++ b/share/node-build/0.1.22
@@ -1,1 +1,1 @@
-install_package "node-v0.1.22" "https://nodejs.org/dist/v0.1.22/node-v0.1.22.tar.gz#7884d315b318cdd4e45abe76d42cc44aabb792cce1d2974ff7b4669561fb28ba"
+install_package "node-v0.1.22" "https://nodejs.org/dist/v0.1.22/node-v0.1.22.tar.gz#7884d315b318cdd4e45abe76d42cc44aabb792cce1d2974ff7b4669561fb28ba" warn_eol

--- a/share/node-build/0.1.23
+++ b/share/node-build/0.1.23
@@ -1,1 +1,1 @@
-install_package "node-v0.1.23" "https://nodejs.org/dist/v0.1.23/node-v0.1.23.tar.gz#69b416d60f288389d25d04797a030b4db6a1ca0cafbd545ca2b8824afaba3035"
+install_package "node-v0.1.23" "https://nodejs.org/dist/v0.1.23/node-v0.1.23.tar.gz#69b416d60f288389d25d04797a030b4db6a1ca0cafbd545ca2b8824afaba3035" warn_eol

--- a/share/node-build/0.1.24
+++ b/share/node-build/0.1.24
@@ -1,1 +1,1 @@
-install_package "node-v0.1.24" "https://nodejs.org/dist/v0.1.24/node-v0.1.24.tar.gz#a1bb4bda5c43142485ea4b0f725bae6319132daf90a243635f626f2d191374f4"
+install_package "node-v0.1.24" "https://nodejs.org/dist/v0.1.24/node-v0.1.24.tar.gz#a1bb4bda5c43142485ea4b0f725bae6319132daf90a243635f626f2d191374f4" warn_eol

--- a/share/node-build/0.1.25
+++ b/share/node-build/0.1.25
@@ -1,1 +1,1 @@
-install_package "node-v0.1.25" "https://nodejs.org/dist/v0.1.25/node-v0.1.25.tar.gz#48cb603bd55182c22a0030db78be146e137bcf396ff78dc1b7fe748adc9d59a6"
+install_package "node-v0.1.25" "https://nodejs.org/dist/v0.1.25/node-v0.1.25.tar.gz#48cb603bd55182c22a0030db78be146e137bcf396ff78dc1b7fe748adc9d59a6" warn_eol

--- a/share/node-build/0.1.26
+++ b/share/node-build/0.1.26
@@ -1,1 +1,1 @@
-install_package "node-v0.1.26" "https://nodejs.org/dist/v0.1.26/node-v0.1.26.tar.gz#8c6e5858bcf1e401af50a7f71d6cbffb3af2f4e41813c46a138edb489bbd84f0"
+install_package "node-v0.1.26" "https://nodejs.org/dist/v0.1.26/node-v0.1.26.tar.gz#8c6e5858bcf1e401af50a7f71d6cbffb3af2f4e41813c46a138edb489bbd84f0" warn_eol

--- a/share/node-build/0.1.27
+++ b/share/node-build/0.1.27
@@ -1,1 +1,1 @@
-install_package "node-v0.1.27" "https://nodejs.org/dist/v0.1.27/node-v0.1.27.tar.gz#1f83401b9ede7558350e183fc4386234a803d1253e7fe99bce0aba7138270806"
+install_package "node-v0.1.27" "https://nodejs.org/dist/v0.1.27/node-v0.1.27.tar.gz#1f83401b9ede7558350e183fc4386234a803d1253e7fe99bce0aba7138270806" warn_eol

--- a/share/node-build/0.1.28
+++ b/share/node-build/0.1.28
@@ -1,1 +1,1 @@
-install_package "node-v0.1.28" "https://nodejs.org/dist/v0.1.28/node-v0.1.28.tar.gz#06f8a8d5246d34629b1355497c2f0f9f779c7dd9830e3ec51c67cbdae46c9069"
+install_package "node-v0.1.28" "https://nodejs.org/dist/v0.1.28/node-v0.1.28.tar.gz#06f8a8d5246d34629b1355497c2f0f9f779c7dd9830e3ec51c67cbdae46c9069" warn_eol

--- a/share/node-build/0.1.29
+++ b/share/node-build/0.1.29
@@ -1,1 +1,1 @@
-install_package "node-v0.1.29" "https://nodejs.org/dist/v0.1.29/node-v0.1.29.tar.gz#b56ddee6fbd89f674df7d38295563f4124e728dbf2dc4e7fb359fd1f6fe9bb06"
+install_package "node-v0.1.29" "https://nodejs.org/dist/v0.1.29/node-v0.1.29.tar.gz#b56ddee6fbd89f674df7d38295563f4124e728dbf2dc4e7fb359fd1f6fe9bb06" warn_eol

--- a/share/node-build/0.1.30
+++ b/share/node-build/0.1.30
@@ -1,1 +1,1 @@
-install_package "node-v0.1.30" "https://nodejs.org/dist/v0.1.30/node-v0.1.30.tar.gz#37ee475b43609b9052300472ea33cf027f6777975bc90611837e54ecdad3f22c"
+install_package "node-v0.1.30" "https://nodejs.org/dist/v0.1.30/node-v0.1.30.tar.gz#37ee475b43609b9052300472ea33cf027f6777975bc90611837e54ecdad3f22c" warn_eol

--- a/share/node-build/0.1.31
+++ b/share/node-build/0.1.31
@@ -1,1 +1,1 @@
-install_package "node-v0.1.31" "https://nodejs.org/dist/v0.1.31/node-v0.1.31.tar.gz#260972bedf789580b56433ca27a1e3717b131a531a4b3688980a16e65d79abbd"
+install_package "node-v0.1.31" "https://nodejs.org/dist/v0.1.31/node-v0.1.31.tar.gz#260972bedf789580b56433ca27a1e3717b131a531a4b3688980a16e65d79abbd" warn_eol

--- a/share/node-build/0.1.32
+++ b/share/node-build/0.1.32
@@ -1,1 +1,1 @@
-install_package "node-v0.1.32" "https://nodejs.org/dist/v0.1.32/node-v0.1.32.tar.gz#1fda75df1f2c15df3d24c59b8cb3f0c649b6476a59354b9ddad25287cb57f73e"
+install_package "node-v0.1.32" "https://nodejs.org/dist/v0.1.32/node-v0.1.32.tar.gz#1fda75df1f2c15df3d24c59b8cb3f0c649b6476a59354b9ddad25287cb57f73e" warn_eol

--- a/share/node-build/0.1.33
+++ b/share/node-build/0.1.33
@@ -1,1 +1,1 @@
-install_package "node-v0.1.33" "https://nodejs.org/dist/v0.1.33/node-v0.1.33.tar.gz#4a5db1dbacb22baf3a43a77a9c089bd3eb6b903ccc83e874541c48984310c5a7"
+install_package "node-v0.1.33" "https://nodejs.org/dist/v0.1.33/node-v0.1.33.tar.gz#4a5db1dbacb22baf3a43a77a9c089bd3eb6b903ccc83e874541c48984310c5a7" warn_eol

--- a/share/node-build/0.1.90
+++ b/share/node-build/0.1.90
@@ -1,1 +1,1 @@
-install_package "node-v0.1.90" "https://nodejs.org/dist/v0.1.90/node-v0.1.90.tar.gz#0dbd47f6be45049a54de6ff268b25a8ccf8cac38bd75788e713dab35a14695c3"
+install_package "node-v0.1.90" "https://nodejs.org/dist/v0.1.90/node-v0.1.90.tar.gz#0dbd47f6be45049a54de6ff268b25a8ccf8cac38bd75788e713dab35a14695c3" warn_eol

--- a/share/node-build/0.1.91
+++ b/share/node-build/0.1.91
@@ -1,1 +1,1 @@
-install_package "node-v0.1.91" "https://nodejs.org/dist/v0.1.91/node-v0.1.91.tar.gz#dcdbd47c9bbe508c86f2dad4f751e5caaf1247a013cb55b8d5e75f47e800f38a"
+install_package "node-v0.1.91" "https://nodejs.org/dist/v0.1.91/node-v0.1.91.tar.gz#dcdbd47c9bbe508c86f2dad4f751e5caaf1247a013cb55b8d5e75f47e800f38a" warn_eol

--- a/share/node-build/0.1.92
+++ b/share/node-build/0.1.92
@@ -1,1 +1,1 @@
-install_package "node-v0.1.92" "https://nodejs.org/dist/v0.1.92/node-v0.1.92.tar.gz#f23ba3e4596fa22dabe2f5d5718a55e3100badeb2de2ef623440d9288ce88e04"
+install_package "node-v0.1.92" "https://nodejs.org/dist/v0.1.92/node-v0.1.92.tar.gz#f23ba3e4596fa22dabe2f5d5718a55e3100badeb2de2ef623440d9288ce88e04" warn_eol

--- a/share/node-build/0.1.93
+++ b/share/node-build/0.1.93
@@ -1,1 +1,1 @@
-install_package "node-v0.1.93" "https://nodejs.org/dist/v0.1.93/node-v0.1.93.tar.gz#7f0574212b2addb53adb47422b7343ac0872e0fd9618b8e8877f61579686a95a"
+install_package "node-v0.1.93" "https://nodejs.org/dist/v0.1.93/node-v0.1.93.tar.gz#7f0574212b2addb53adb47422b7343ac0872e0fd9618b8e8877f61579686a95a" warn_eol

--- a/share/node-build/0.1.94
+++ b/share/node-build/0.1.94
@@ -1,1 +1,1 @@
-install_package "node-v0.1.94" "https://nodejs.org/dist/v0.1.94/node-v0.1.94.tar.gz#93d19477e069171307f66dffc665c900d80382bca021536451c785f78dba1b3d"
+install_package "node-v0.1.94" "https://nodejs.org/dist/v0.1.94/node-v0.1.94.tar.gz#93d19477e069171307f66dffc665c900d80382bca021536451c785f78dba1b3d" warn_eol

--- a/share/node-build/0.1.95
+++ b/share/node-build/0.1.95
@@ -1,1 +1,1 @@
-install_package "node-v0.1.95" "https://nodejs.org/dist/v0.1.95/node-v0.1.95.tar.gz#d215477805fc7f48522f97813f0757dcc85b5b9423db1b3e6a16ea78afa375b8"
+install_package "node-v0.1.95" "https://nodejs.org/dist/v0.1.95/node-v0.1.95.tar.gz#d215477805fc7f48522f97813f0757dcc85b5b9423db1b3e6a16ea78afa375b8" warn_eol

--- a/share/node-build/0.1.96
+++ b/share/node-build/0.1.96
@@ -1,1 +1,1 @@
-install_package "node-v0.1.96" "https://nodejs.org/dist/v0.1.96/node-v0.1.96.tar.gz#b58c607a3f2549722acc9c7cf1f3ccd57c3c15ca7a8ca4a9e6fe3567e8a0b500"
+install_package "node-v0.1.96" "https://nodejs.org/dist/v0.1.96/node-v0.1.96.tar.gz#b58c607a3f2549722acc9c7cf1f3ccd57c3c15ca7a8ca4a9e6fe3567e8a0b500" warn_eol

--- a/share/node-build/0.1.97
+++ b/share/node-build/0.1.97
@@ -1,1 +1,1 @@
-install_package "node-v0.1.97" "https://nodejs.org/dist/v0.1.97/node-v0.1.97.tar.gz#8ad00afa4d43c479a5025293ef83fd69e94ddef5ee2795263ca46222d1c2a954"
+install_package "node-v0.1.97" "https://nodejs.org/dist/v0.1.97/node-v0.1.97.tar.gz#8ad00afa4d43c479a5025293ef83fd69e94ddef5ee2795263ca46222d1c2a954" warn_eol

--- a/share/node-build/0.1.98
+++ b/share/node-build/0.1.98
@@ -1,1 +1,1 @@
-install_package "node-v0.1.98" "https://nodejs.org/dist/v0.1.98/node-v0.1.98.tar.gz#6ce54b2e81ba1f4085d165bf3e853111a77e2a20de9493a0d7092665a5c9fda8"
+install_package "node-v0.1.98" "https://nodejs.org/dist/v0.1.98/node-v0.1.98.tar.gz#6ce54b2e81ba1f4085d165bf3e853111a77e2a20de9493a0d7092665a5c9fda8" warn_eol

--- a/share/node-build/0.1.99
+++ b/share/node-build/0.1.99
@@ -1,1 +1,1 @@
-install_package "node-v0.1.99" "https://nodejs.org/dist/v0.1.99/node-v0.1.99.tar.gz#fcd771a873609096c33e297869c52799bbcd4038b68112a9185785ca73a235d0"
+install_package "node-v0.1.99" "https://nodejs.org/dist/v0.1.99/node-v0.1.99.tar.gz#fcd771a873609096c33e297869c52799bbcd4038b68112a9185785ca73a235d0" warn_eol

--- a/share/node-build/0.10-dev
+++ b/share/node-build/0.10-dev
@@ -1,1 +1,1 @@
-install_git "0.10-dev" "https://github.com/nodejs/node.git" "v0.10-staging" standard
+install_git "0.10-dev" "https://github.com/nodejs/node.git" "v0.10-staging" standard warn_unsupported

--- a/share/node-build/0.10-next
+++ b/share/node-build/0.10-next
@@ -1,1 +1,1 @@
-install_git "0.10-next" "https://github.com/nodejs/node.git" "v0.10" standard
+install_git "0.10-next" "https://github.com/nodejs/node.git" "v0.10" standard warn_unsupported

--- a/share/node-build/0.10.0
+++ b/share/node-build/0.10.0
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.0/node-v0.10.0-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.10.0/node-v0.10.0-sunos-x64.tar.gz#6fe0569bdc90d3d2a4cf49fe03ab4213085cfc60bc1714d3bbe058543e8c95be"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.0/node-v0.10.0-sunos-x86.tar.gz#bc4dd51c9daba761b2eac5af8ce31184f9ecc2036e8e0a2ca1d03a800c275582"
 
-install_package "node-v0.10.0" "https://nodejs.org/dist/v0.10.0/node-v0.10.0.tar.gz#1624dc37866ebfb5431e3393e6b049cf238cac8ad4d20c6d567263b1259177ab"
+install_package "node-v0.10.0" "https://nodejs.org/dist/v0.10.0/node-v0.10.0.tar.gz#1624dc37866ebfb5431e3393e6b049cf238cac8ad4d20c6d567263b1259177ab" warn_unsupported

--- a/share/node-build/0.10.1
+++ b/share/node-build/0.10.1
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.1/node-v0.10.1-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.10.1/node-v0.10.1-sunos-x64.tar.gz#0908f81bb72c986e5b80b6a6f4c7848d37a46b360f83f2bdddc090e810196a5b"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.1/node-v0.10.1-sunos-x86.tar.gz#e90bb06af4262bf770bb0e2cbaa5689e1b6bf0ff7c8cfae069d27739f3ba0680"
 
-install_package "node-v0.10.1" "https://nodejs.org/dist/v0.10.1/node-v0.10.1.tar.gz#2628dbf42fb3ec3927e595dc66f2f96e3c23455990dea690e300296d92afe4d3"
+install_package "node-v0.10.1" "https://nodejs.org/dist/v0.10.1/node-v0.10.1.tar.gz#2628dbf42fb3ec3927e595dc66f2f96e3c23455990dea690e300296d92afe4d3" warn_unsupported

--- a/share/node-build/0.10.10
+++ b/share/node-build/0.10.10
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.10/node-v0.10.10-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.10/node-v0.10.10-sunos-x64.tar.gz#7dafccd4548b4829f31c77cd9261f3cd64d7799422d03d9903a6fe7b402f7b2b"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.10/node-v0.10.10-sunos-x86.tar.gz#2f38f3229d1efbd13326e9ed7ec0b00ce82fbe6699c3f76f7d90dbee2a7a9b69"
 
-install_package "node-v0.10.10" "https://nodejs.org/dist/v0.10.10/node-v0.10.10.tar.gz#a54de71d2c3ac7ae864ab9640b6eecb27d7d49c190ac1ca6526243fd7a8ad15c"
+install_package "node-v0.10.10" "https://nodejs.org/dist/v0.10.10/node-v0.10.10.tar.gz#a54de71d2c3ac7ae864ab9640b6eecb27d7d49c190ac1ca6526243fd7a8ad15c" warn_unsupported

--- a/share/node-build/0.10.11
+++ b/share/node-build/0.10.11
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.11/node-v0.10.11-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.11/node-v0.10.11-sunos-x64.tar.gz#2ef86b94f0abc16ffb49cff6444fc4f6eb32b476cc06938e1aeb64f705001c91"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.11/node-v0.10.11-sunos-x86.tar.gz#60237169d3b698c09d4a8ad5260065f338296e592bbce9ee768ea455c33f65f8"
 
-install_package "node-v0.10.11" "https://nodejs.org/dist/v0.10.11/node-v0.10.11.tar.gz#ee4b398efde1fa7a334435910447422dae58e93da8711602c2228485f2b58cb1"
+install_package "node-v0.10.11" "https://nodejs.org/dist/v0.10.11/node-v0.10.11.tar.gz#ee4b398efde1fa7a334435910447422dae58e93da8711602c2228485f2b58cb1" warn_unsupported

--- a/share/node-build/0.10.12
+++ b/share/node-build/0.10.12
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.12/node-v0.10.12-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.12/node-v0.10.12-sunos-x64.tar.gz#eb50e180f02f4fa8157527d7d906b28c3ae9ccc7c081b72d28159c90f2f5a861"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.12/node-v0.10.12-sunos-x86.tar.gz#8d0c36f5a15464ede5c8fe487c81c245def3a772fa014380d506d6bec7f268c5"
 
-install_package "node-v0.10.12" "https://nodejs.org/dist/v0.10.12/node-v0.10.12.tar.gz#7339a7c333454a567a41c900b6ef2f6c89e8c778062c173beb029611b29496b6"
+install_package "node-v0.10.12" "https://nodejs.org/dist/v0.10.12/node-v0.10.12.tar.gz#7339a7c333454a567a41c900b6ef2f6c89e8c778062c173beb029611b29496b6" warn_unsupported

--- a/share/node-build/0.10.13
+++ b/share/node-build/0.10.13
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.13/node-v0.10.13-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.13/node-v0.10.13-sunos-x64.tar.gz#04ec26f8b20606781a08d6afefc17e83f377e59d188b5e491fdacefd1cfb73fa"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.13/node-v0.10.13-sunos-x86.tar.gz#8a86ef4770aada5d21dd9848c43c036dfd7e13a8423861844a165df0c2b72870"
 
-install_package "node-v0.10.13" "https://nodejs.org/dist/v0.10.13/node-v0.10.13.tar.gz#a102fad260d216b95611ddd57aeb6531c92ad1038508390654423feb1b51c059"
+install_package "node-v0.10.13" "https://nodejs.org/dist/v0.10.13/node-v0.10.13.tar.gz#a102fad260d216b95611ddd57aeb6531c92ad1038508390654423feb1b51c059" warn_unsupported

--- a/share/node-build/0.10.14
+++ b/share/node-build/0.10.14
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.14/node-v0.10.14-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.14/node-v0.10.14-sunos-x64.tar.gz#5e2796a91441eb7a5326eb35b35e1bd404b45fc125f7a3b0f7efa812957c5040"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.14/node-v0.10.14-sunos-x86.tar.gz#ff49a2b8ab36b041889adbebb9e9b72cf79f73264810f057e00500780bb89497"
 
-install_package "node-v0.10.14" "https://nodejs.org/dist/v0.10.14/node-v0.10.14.tar.gz#5b022575b9f6e5c3c704dfa9ecaf511e1b14eaca196edb3eaf89d246efeb70d9"
+install_package "node-v0.10.14" "https://nodejs.org/dist/v0.10.14/node-v0.10.14.tar.gz#5b022575b9f6e5c3c704dfa9ecaf511e1b14eaca196edb3eaf89d246efeb70d9" warn_unsupported

--- a/share/node-build/0.10.15
+++ b/share/node-build/0.10.15
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.15/node-v0.10.15-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.15/node-v0.10.15-sunos-x64.tar.gz#bcfff390eb599536114d2697272c6f1b19daa88677428cef5ff9535d6cc24551"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.15/node-v0.10.15-sunos-x86.tar.gz#766eefedc60f7fbd0b96f71738710021570f52ae2c68e936d165312084da84ed"
 
-install_package "node-v0.10.15" "https://nodejs.org/dist/v0.10.15/node-v0.10.15.tar.gz#87345ab3b96aa02c5250d7b5ae1d80e620e8ae2a7f509f7fa18c4aaa340953e8"
+install_package "node-v0.10.15" "https://nodejs.org/dist/v0.10.15/node-v0.10.15.tar.gz#87345ab3b96aa02c5250d7b5ae1d80e620e8ae2a7f509f7fa18c4aaa340953e8" warn_unsupported

--- a/share/node-build/0.10.16
+++ b/share/node-build/0.10.16
@@ -6,4 +6,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.16/node-v0.10.16-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.16/node-v0.10.16-sunos-x64.tar.gz#2e00695ee36a90c52aa63233827128faf76f93c2d9128220198a344ab3c79a13"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.16/node-v0.10.16-sunos-x86.tar.gz#9fe6130a62de0c8d9c58a5e7eaa274a413176fce8c8128a3435f5839d629fcdc"
 
-install_package "node-v0.10.16" "https://nodejs.org/dist/v0.10.16/node-v0.10.16.tar.gz#62db6ec83f34733bffdae2f8ee50d7273d568bba8814be29e78a042c1d64f31a"
+install_package "node-v0.10.16" "https://nodejs.org/dist/v0.10.16/node-v0.10.16.tar.gz#62db6ec83f34733bffdae2f8ee50d7273d568bba8814be29e78a042c1d64f31a" warn_unsupported

--- a/share/node-build/0.10.17
+++ b/share/node-build/0.10.17
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.17/node-v0.10.17-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.17/node-v0.10.17-sunos-x64.tar.gz#b7b57bb51f0439c2df72a001e2dc6ed5ce2172c2417bac1df4c87d531508128f"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.17/node-v0.10.17-sunos-x86.tar.gz#8a7a2f43a28260bbcc02b0cb3d8a1689f5fdda847c35cce09fb98a47ae62157a"
 
-install_package "node-v0.10.17" "https://nodejs.org/dist/v0.10.17/node-v0.10.17.tar.gz#1f9de40dd2d98bc984a4970ef399ed3ad67f040feaafc711e549f3265bcce61c"
+install_package "node-v0.10.17" "https://nodejs.org/dist/v0.10.17/node-v0.10.17.tar.gz#1f9de40dd2d98bc984a4970ef399ed3ad67f040feaafc711e549f3265bcce61c" warn_unsupported

--- a/share/node-build/0.10.18
+++ b/share/node-build/0.10.18
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.18/node-v0.10.18-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.18/node-v0.10.18-sunos-x64.tar.gz#a70735329c07c3cc462011721fc81302e2a4cd7b3c71b5e8586b82dd05df253e"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.18/node-v0.10.18-sunos-x86.tar.gz#d8b0a69fed8d2181dda3c730e4b00d070b23552da2bc939f3dd0ebbaa4ff418d"
 
-install_package "node-v0.10.18" "https://nodejs.org/dist/v0.10.18/node-v0.10.18.tar.gz#3ee4436473869d4d84bb5cad4352b09ace00656467eca7d6db7cd7da5b8c5495"
+install_package "node-v0.10.18" "https://nodejs.org/dist/v0.10.18/node-v0.10.18.tar.gz#3ee4436473869d4d84bb5cad4352b09ace00656467eca7d6db7cd7da5b8c5495" warn_unsupported

--- a/share/node-build/0.10.19
+++ b/share/node-build/0.10.19
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.19/node-v0.10.19-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.19/node-v0.10.19-sunos-x64.tar.gz#aed9156f656d692e6cc6a40e600df0021e846c58fa0e0b023debe9fc542c0496"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.19/node-v0.10.19-sunos-x86.tar.gz#92a7627d6faefa8474610ba53c9065f841cde5620528f1b0b73d0750d08dd0e6"
 
-install_package "node-v0.10.19" "https://nodejs.org/dist/v0.10.19/node-v0.10.19.tar.gz#e50787672cdf6afa6caeef9345ca40c4a69f96a31829a0884ea6ed63dfdde21e"
+install_package "node-v0.10.19" "https://nodejs.org/dist/v0.10.19/node-v0.10.19.tar.gz#e50787672cdf6afa6caeef9345ca40c4a69f96a31829a0884ea6ed63dfdde21e" warn_unsupported

--- a/share/node-build/0.10.2
+++ b/share/node-build/0.10.2
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.2/node-v0.10.2-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.10.2/node-v0.10.2-sunos-x64.tar.gz#d5f211013177b65115364419bbdc95b68aabb293e115ae127a9c3f31404feeaa"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.2/node-v0.10.2-sunos-x86.tar.gz#8689f820535a84e7b488abb9d83c153f1c591b87a7b89a0e6b88e024a1b3d445"
 
-install_package "node-v0.10.2" "https://nodejs.org/dist/v0.10.2/node-v0.10.2.tar.gz#4eb642897fdb945b49720f2604afc493587aec7a9ff1537e882df659e4dd8aa2"
+install_package "node-v0.10.2" "https://nodejs.org/dist/v0.10.2/node-v0.10.2.tar.gz#4eb642897fdb945b49720f2604afc493587aec7a9ff1537e882df659e4dd8aa2" warn_unsupported

--- a/share/node-build/0.10.20
+++ b/share/node-build/0.10.20
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.20/node-v0.10.20-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.20/node-v0.10.20-sunos-x64.tar.gz#0cb7827eb73165a22e9c770d4b27aaa47ec13eeb8e49ddd8b5d7111f099bab21"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.20/node-v0.10.20-sunos-x86.tar.gz#0bc199ab554e28536eba659b931471d69048f3d5c01f5d14cc9cb88dc1f0e0f7"
 
-install_package "node-v0.10.20" "https://nodejs.org/dist/v0.10.20/node-v0.10.20.tar.gz#b5af00d4d43644f37caa2dad5fa81e6f898ebb7b238f02a1cddfcff11c81e649"
+install_package "node-v0.10.20" "https://nodejs.org/dist/v0.10.20/node-v0.10.20.tar.gz#b5af00d4d43644f37caa2dad5fa81e6f898ebb7b238f02a1cddfcff11c81e649" warn_unsupported

--- a/share/node-build/0.10.21
+++ b/share/node-build/0.10.21
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.21/node-v0.10.21-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.21/node-v0.10.21-sunos-x64.tar.gz#1f6eb3674fbd370f1d5db2d00af39c6805dfa725a2f727adfcdea757f51155e4"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.21/node-v0.10.21-sunos-x86.tar.gz#11bfafb20045589dddff2bb12e23f2ae98e877a4a4dcc82a76bf2ad4a28ad93f"
 
-install_package "node-v0.10.21" "https://nodejs.org/dist/v0.10.21/node-v0.10.21.tar.gz#7c125bf22c1756064f2a68310d4822f77c8134ce178b2faa6155671a8124140d"
+install_package "node-v0.10.21" "https://nodejs.org/dist/v0.10.21/node-v0.10.21.tar.gz#7c125bf22c1756064f2a68310d4822f77c8134ce178b2faa6155671a8124140d" warn_unsupported

--- a/share/node-build/0.10.22
+++ b/share/node-build/0.10.22
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.22/node-v0.10.22-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.22/node-v0.10.22-sunos-x64.tar.gz#550bf8a08074e0260a8c700b377fc7e14253d3f690d8c7d8dc9becc02d406bc7"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.22/node-v0.10.22-sunos-x86.tar.gz#bb556888914f3d249176dc3a30bf3dbb9a7ce4073f326549b1379f191c1aa610"
 
-install_package "node-v0.10.22" "https://nodejs.org/dist/v0.10.22/node-v0.10.22.tar.gz#157fc58b3f1d109baefac4eb1d32ae747de5e6d55d87d0e9bec8f8dd10679e7e"
+install_package "node-v0.10.22" "https://nodejs.org/dist/v0.10.22/node-v0.10.22.tar.gz#157fc58b3f1d109baefac4eb1d32ae747de5e6d55d87d0e9bec8f8dd10679e7e" warn_unsupported

--- a/share/node-build/0.10.23
+++ b/share/node-build/0.10.23
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.23/node-v0.10.23-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.23/node-v0.10.23-sunos-x64.tar.gz#7f41c56a699d48dab5fc725a39f3b399c3244aadba5ba7ee8f3a0ea0f39387fc"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.23/node-v0.10.23-sunos-x86.tar.gz#d3a55483d7675a335f9c69db8a21995cab2fa371f5870d774bc3ee3ae7f1b75e"
 
-install_package "node-v0.10.23" "https://nodejs.org/dist/v0.10.23/node-v0.10.23.tar.gz#1a370c86720441d227e7aad3c0223da7166ab2e0900bec7158aac633ffebb4dd"
+install_package "node-v0.10.23" "https://nodejs.org/dist/v0.10.23/node-v0.10.23.tar.gz#1a370c86720441d227e7aad3c0223da7166ab2e0900bec7158aac633ffebb4dd" warn_unsupported

--- a/share/node-build/0.10.24
+++ b/share/node-build/0.10.24
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.24/node-v0.10.24-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.24/node-v0.10.24-sunos-x64.tar.gz#7cb714df92055b93a908b3b6587ca388a2884b1a9b5247c708a867516994a373"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.24/node-v0.10.24-sunos-x86.tar.gz#af69ab26aae42b05841c098f5d11d17e21d22d980cd32666e2db45a53ddffe34"
 
-install_package "node-v0.10.24" "https://nodejs.org/dist/v0.10.24/node-v0.10.24.tar.gz#610cd733186842cb7f554336d6851a61b2d3d956050d62e49fa359a47640377a"
+install_package "node-v0.10.24" "https://nodejs.org/dist/v0.10.24/node-v0.10.24.tar.gz#610cd733186842cb7f554336d6851a61b2d3d956050d62e49fa359a47640377a" warn_unsupported

--- a/share/node-build/0.10.25
+++ b/share/node-build/0.10.25
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.25/node-v0.10.25-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.25/node-v0.10.25-sunos-x64.tar.gz#931059671413872c5c5e862df5f7a56066fdb1fe2b678b9ee3c3b242b23a4198"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.25/node-v0.10.25-sunos-x86.tar.gz#61d187416814dd10074d1db5666fd0ca61be6152fbb7920f0aaa4e285db10717"
 
-install_package "node-v0.10.25" "https://nodejs.org/dist/v0.10.25/node-v0.10.25.tar.gz#46eef3b9d5475a2081dc2b2f7cf1f4c3a56824d1fc9b04e7ed1d7a88e8f6b36f"
+install_package "node-v0.10.25" "https://nodejs.org/dist/v0.10.25/node-v0.10.25.tar.gz#46eef3b9d5475a2081dc2b2f7cf1f4c3a56824d1fc9b04e7ed1d7a88e8f6b36f" warn_unsupported

--- a/share/node-build/0.10.26
+++ b/share/node-build/0.10.26
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.26/node-v0.10.26-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.26/node-v0.10.26-sunos-x64.tar.gz#9d9c05a76cb3353b459e7204d5283ed3988b7a363105ef9698dc0f94243aabf9"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.26/node-v0.10.26-sunos-x86.tar.gz#ac7ec92eb6839fa9aa45f0be2c586a0787d26fbdaefdcbaedc912f7c5fd17f3d"
 
-install_package "node-v0.10.26" "https://nodejs.org/dist/v0.10.26/node-v0.10.26.tar.gz#ef5e4ea6f2689ed7f781355012b942a2347e0299da0804a58de8e6281c4b1daa"
+install_package "node-v0.10.26" "https://nodejs.org/dist/v0.10.26/node-v0.10.26.tar.gz#ef5e4ea6f2689ed7f781355012b942a2347e0299da0804a58de8e6281c4b1daa" warn_unsupported

--- a/share/node-build/0.10.27
+++ b/share/node-build/0.10.27
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.27/node-v0.10.27-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.27/node-v0.10.27-sunos-x64.tar.gz#37a3a1834c3b7a776ff166c070fa3b84a53b9951bc5ea3b417f62bf3a0970d9b"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.27/node-v0.10.27-sunos-x86.tar.gz#5ec564db1c643c5207c539593d1c37254d9e99f8efee04e35e110f05d190b921"
 
-install_package "node-v0.10.27" "https://nodejs.org/dist/v0.10.27/node-v0.10.27.tar.gz#911876c38974a77e1ddf141285b0a994d8c98bddac7229802d7f16600d69d1fe"
+install_package "node-v0.10.27" "https://nodejs.org/dist/v0.10.27/node-v0.10.27.tar.gz#911876c38974a77e1ddf141285b0a994d8c98bddac7229802d7f16600d69d1fe" warn_unsupported

--- a/share/node-build/0.10.28
+++ b/share/node-build/0.10.28
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.28/node-v0.10.28-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.28/node-v0.10.28-sunos-x64.tar.gz#dadde2dde10ca1429564ac125cb67fd7f34d1e5332c82ed67abbf5e6224ded15"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.28/node-v0.10.28-sunos-x86.tar.gz#a1820e23a9f9e908079c3b4379a73b884ab4f56acefe28c7593301f51c794d0a"
 
-install_package "node-v0.10.28" "https://nodejs.org/dist/v0.10.28/node-v0.10.28.tar.gz#abddc6441e0f208f6ed8a045e0293f713ea7f6dfb2d6a9a2024bf8b1b4617710"
+install_package "node-v0.10.28" "https://nodejs.org/dist/v0.10.28/node-v0.10.28.tar.gz#abddc6441e0f208f6ed8a045e0293f713ea7f6dfb2d6a9a2024bf8b1b4617710" warn_unsupported

--- a/share/node-build/0.10.29
+++ b/share/node-build/0.10.29
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.29/node-v0.10.29-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.29/node-v0.10.29-sunos-x64.tar.gz#988d48b7f65a94c0ee7edbef555156f555d13cf302fff54d27424fd4c0d4392f"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.29/node-v0.10.29-sunos-x86.tar.gz#ef5c2a9237c3a2b7c7ce9d4817fbcf63dd223370d2072da8f7ab2f4b46849e17"
 
-install_package "node-v0.10.29" "https://nodejs.org/dist/v0.10.29/node-v0.10.29.tar.gz#47379d01f765f87c1a1498b4e65de30e45201de50334954860d7375a8258b15d"
+install_package "node-v0.10.29" "https://nodejs.org/dist/v0.10.29/node-v0.10.29.tar.gz#47379d01f765f87c1a1498b4e65de30e45201de50334954860d7375a8258b15d" warn_unsupported

--- a/share/node-build/0.10.3
+++ b/share/node-build/0.10.3
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.3/node-v0.10.3-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.10.3/node-v0.10.3-sunos-x64.tar.gz#d9bed27c97968dc54047ef6f09161d6a1a7dee702301fa65add97ff1dee6e2af"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.3/node-v0.10.3-sunos-x86.tar.gz#5a4b8e6460a446481fe3fb8eb681d7408711fb3cfbb8bcc06a436706567bc76c"
 
-install_package "node-v0.10.3" "https://nodejs.org/dist/v0.10.3/node-v0.10.3.tar.gz#bc8796ff6414231fa0603e0383404f14648dfd2fe9fb0fa4d4a6043dfddbb328"
+install_package "node-v0.10.3" "https://nodejs.org/dist/v0.10.3/node-v0.10.3.tar.gz#bc8796ff6414231fa0603e0383404f14648dfd2fe9fb0fa4d4a6043dfddbb328" warn_unsupported

--- a/share/node-build/0.10.30
+++ b/share/node-build/0.10.30
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.30/node-v0.10.30-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.30/node-v0.10.30-sunos-x64.tar.gz#a7fd48d2461ce2c0673ae49140692764dc12a9c80ae5cdf6437a353b18895da4"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.30/node-v0.10.30-sunos-x86.tar.gz#63599ba80410abb30d27bc1360048607bf43d548eb762ec384f673bff2169a48"
 
-install_package "node-v0.10.30" "https://nodejs.org/dist/v0.10.30/node-v0.10.30.tar.gz#3dfcbd307f5f5f266ef174e1443107da853cd3d0aa0b2493a44235d5908625d2"
+install_package "node-v0.10.30" "https://nodejs.org/dist/v0.10.30/node-v0.10.30.tar.gz#3dfcbd307f5f5f266ef174e1443107da853cd3d0aa0b2493a44235d5908625d2" warn_unsupported

--- a/share/node-build/0.10.31
+++ b/share/node-build/0.10.31
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.31/node-v0.10.31-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.31/node-v0.10.31-sunos-x64.tar.gz#9334ffbad58b01e892831b44f122a61fd5453781299793eeb48e59dffdabd989"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.31/node-v0.10.31-sunos-x86.tar.gz#0362c780c56eb814bc5ae0d4e393663b9accdb4760e1aacd03ed76604559087b"
 
-install_package "node-v0.10.31" "https://nodejs.org/dist/v0.10.31/node-v0.10.31.tar.gz#06c781718a674dfdfb59d646b2629a46af2644bdbf52534fab8d4a0fe34c21f1"
+install_package "node-v0.10.31" "https://nodejs.org/dist/v0.10.31/node-v0.10.31.tar.gz#06c781718a674dfdfb59d646b2629a46af2644bdbf52534fab8d4a0fe34c21f1" warn_unsupported

--- a/share/node-build/0.10.32
+++ b/share/node-build/0.10.32
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.32/node-v0.10.32-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.32/node-v0.10.32-sunos-x64.tar.gz#3abd0a03e6894a7515a6a13b5ffabe9dc98d5f86feb03b9d7c499e47250e0cfa"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.32/node-v0.10.32-sunos-x86.tar.gz#03925e461542e2601bbe1efb7434334a817c1a0c6b071fb81ab1d9a1805c7e58"
 
-install_package "node-v0.10.32" "https://nodejs.org/dist/v0.10.32/node-v0.10.32.tar.gz#c2120d0e3d2d191654cb11dbc0a33a7216d53732173317681da9502be0030f10"
+install_package "node-v0.10.32" "https://nodejs.org/dist/v0.10.32/node-v0.10.32.tar.gz#c2120d0e3d2d191654cb11dbc0a33a7216d53732173317681da9502be0030f10" warn_unsupported

--- a/share/node-build/0.10.33
+++ b/share/node-build/0.10.33
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.33/node-v0.10.33-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.33/node-v0.10.33-sunos-x64.tar.gz#2ae96ea055262a265e6b32e4ec611efbabeedb9944fabc727035ec73025546aa"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.33/node-v0.10.33-sunos-x86.tar.gz#f01ba3a4c81c264a7f0052a4ec031f715b5e35e0337cc3686da874f4ffa91ddb"
 
-install_package "node-v0.10.33" "https://nodejs.org/dist/v0.10.33/node-v0.10.33.tar.gz#75dc26c33144e6d0dc91cb0d68aaf0570ed0a7e4b0c35f3a7a726b500edd081e"
+install_package "node-v0.10.33" "https://nodejs.org/dist/v0.10.33/node-v0.10.33.tar.gz#75dc26c33144e6d0dc91cb0d68aaf0570ed0a7e4b0c35f3a7a726b500edd081e" warn_unsupported

--- a/share/node-build/0.10.34
+++ b/share/node-build/0.10.34
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.34/node-v0.10.34-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.34/node-v0.10.34-sunos-x64.tar.gz#4e1d09ec38413380b5297edc3dc5a1fe4b28bddda3c189dbaceabadb42cae98f"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.34/node-v0.10.34-sunos-x86.tar.gz#36db9122efa7130fa5bcdb1d9660f145c3880432f86c9ced52bd898c53a448f6"
 
-install_package "node-v0.10.34" "https://nodejs.org/dist/v0.10.34/node-v0.10.34.tar.gz#d7f8473b5849873039f7e62595e12dcdb78c8dffda317e1253b3123876bf3415"
+install_package "node-v0.10.34" "https://nodejs.org/dist/v0.10.34/node-v0.10.34.tar.gz#d7f8473b5849873039f7e62595e12dcdb78c8dffda317e1253b3123876bf3415" warn_unsupported

--- a/share/node-build/0.10.35
+++ b/share/node-build/0.10.35
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.35/node-v0.10.35-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.35/node-v0.10.35-sunos-x64.tar.gz#0cb651edf73601d35ba48316a36a34662a6412bc54fd4ea4ce019b50d6374720"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.35/node-v0.10.35-sunos-x86.tar.gz#909ae0755d9c9bfbc7a2a2feb24b4df23fab5801924d4061768c07375b4e7f73"
 
-install_package "node-v0.10.35" "https://nodejs.org/dist/v0.10.35/node-v0.10.35.tar.gz#0043656bb1724cb09dbdc960a2fd6ee37d3badb2f9c75562b2d11235daa40a03"
+install_package "node-v0.10.35" "https://nodejs.org/dist/v0.10.35/node-v0.10.35.tar.gz#0043656bb1724cb09dbdc960a2fd6ee37d3badb2f9c75562b2d11235daa40a03" warn_unsupported

--- a/share/node-build/0.10.36
+++ b/share/node-build/0.10.36
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.36/node-v0.10.36-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.36/node-v0.10.36-sunos-x64.tar.gz#0b4edef67c9ace5f2846b465a26d225850416db7b5272066c08574f28ac15444"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.36/node-v0.10.36-sunos-x86.tar.gz#8186cf8261d3135a3431cacd0de086c73774d99b27c0ab00110565653945ff06"
 
-install_package "node-v0.10.36" "https://nodejs.org/dist/v0.10.36/node-v0.10.36.tar.gz#b9d7d1d0294bce46686b13a05da6fc5b1e7743b597544aa888e8e64a9f178c81"
+install_package "node-v0.10.36" "https://nodejs.org/dist/v0.10.36/node-v0.10.36.tar.gz#b9d7d1d0294bce46686b13a05da6fc5b1e7743b597544aa888e8e64a9f178c81" warn_unsupported

--- a/share/node-build/0.10.37
+++ b/share/node-build/0.10.37
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.37/node-v0.10.37-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.37/node-v0.10.37-sunos-x64.tar.gz#464c664215213a88d73cadd4a2822c76dae498069f867283e11f3f7debcb3d10"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.37/node-v0.10.37-sunos-x86.tar.gz#635e219f453ccddb16d2e53cf049687e1d5ea92b087eb820067a0f009e53751c"
 
-install_package "node-v0.10.37" "https://nodejs.org/dist/v0.10.37/node-v0.10.37.tar.gz#a5afad14117bb194731e73b4b6635f36950e9476d3873638856cba8dbb4783a5"
+install_package "node-v0.10.37" "https://nodejs.org/dist/v0.10.37/node-v0.10.37.tar.gz#a5afad14117bb194731e73b4b6635f36950e9476d3873638856cba8dbb4783a5" warn_unsupported

--- a/share/node-build/0.10.38
+++ b/share/node-build/0.10.38
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.38/node-v0.10.38-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.38/node-v0.10.38-sunos-x64.tar.gz#d277ae4995bc56f39f09240e102e09257d4e7d00b5e9b60428d28fe6ca057e43"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.38/node-v0.10.38-sunos-x86.tar.gz#3930ad6e6e005a347fdf96d6721e52ebf291dabf9531348d8bb60403b1475701"
 
-install_package "node-v0.10.38" "https://nodejs.org/dist/v0.10.38/node-v0.10.38.tar.gz#513da8ed5e48abefdfab664f1cabc160238d314a0481148804aff8fc6552b78b"
+install_package "node-v0.10.38" "https://nodejs.org/dist/v0.10.38/node-v0.10.38.tar.gz#513da8ed5e48abefdfab664f1cabc160238d314a0481148804aff8fc6552b78b" warn_unsupported

--- a/share/node-build/0.10.39
+++ b/share/node-build/0.10.39
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.39/node-v0.10.39-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.39/node-v0.10.39-sunos-x64.tar.gz#d016ef2ccf10f1be625b7b62898e4c4aa91fe35c03dc3a7cc96a481a07fc5728"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.39/node-v0.10.39-sunos-x86.tar.gz#e0f2b65ae59341c34c401c41ec3d937c16ff32c6b17e32e5e7b9be3a716bd4c5"
 
-install_package "node-v0.10.39" "https://nodejs.org/dist/v0.10.39/node-v0.10.39.tar.gz#68f8d8f9515c4e77e2a06034b742e19e9848c1fee5bcadedc1d68f3e4302df37"
+install_package "node-v0.10.39" "https://nodejs.org/dist/v0.10.39/node-v0.10.39.tar.gz#68f8d8f9515c4e77e2a06034b742e19e9848c1fee5bcadedc1d68f3e4302df37" warn_unsupported

--- a/share/node-build/0.10.4
+++ b/share/node-build/0.10.4
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.4/node-v0.10.4-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.10.4/node-v0.10.4-sunos-x64.tar.gz#db639ab5e3e309278e9728d899aab00d9ebaa40458a0964282c5457d09bdce49"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.4/node-v0.10.4-sunos-x86.tar.gz#ef52596d5c6cc3fa25cb43fd6820437473e1bd036d3f3b8c6d75916a34b4930a"
 
-install_package "node-v0.10.4" "https://nodejs.org/dist/v0.10.4/node-v0.10.4.tar.gz#1c960d2822447a9e4f7c46b832ff05e86743033c6643d644975af1cbf6a44fb8"
+install_package "node-v0.10.4" "https://nodejs.org/dist/v0.10.4/node-v0.10.4.tar.gz#1c960d2822447a9e4f7c46b832ff05e86743033c6643d644975af1cbf6a44fb8" warn_unsupported

--- a/share/node-build/0.10.40
+++ b/share/node-build/0.10.40
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.40/node-v0.10.40-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.40/node-v0.10.40-sunos-x64.tar.gz#4f90a86d869957592a73b548e1bfad960513f4928b41549f0e19c1e536e1bf3f"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.40/node-v0.10.40-sunos-x86.tar.gz#fc4ff51c3d1549601d421689ec4c504a62d9fd71945fe588a49ef68e3902eb4c"
 
-install_package "node-v0.10.40" "https://nodejs.org/dist/v0.10.40/node-v0.10.40.tar.gz#bae79c2fd959aebe1629af36077bebbb760128db753da226d2344cd91499149f"
+install_package "node-v0.10.40" "https://nodejs.org/dist/v0.10.40/node-v0.10.40.tar.gz#bae79c2fd959aebe1629af36077bebbb760128db753da226d2344cd91499149f" warn_unsupported

--- a/share/node-build/0.10.41
+++ b/share/node-build/0.10.41
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.41/node-v0.10.41-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.41/node-v0.10.41-sunos-x64.tar.gz#9621df2ffed088f87632c5f4d176e5d49438fce5aeb7b4ce8d2eff0de153a5bf"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.41/node-v0.10.41-sunos-x86.tar.gz#a5f5ed4d8200e231323db083f3f2735cec13ac6584523b94ac953ad0e4874b66"
 
-install_package "node-v0.10.41" "https://nodejs.org/dist/v0.10.41/node-v0.10.41.tar.gz#79f694e2a5c42543b75d0c69f6860499d7593136d0f6b59e7163b9e66fb2c995"
+install_package "node-v0.10.41" "https://nodejs.org/dist/v0.10.41/node-v0.10.41.tar.gz#79f694e2a5c42543b75d0c69f6860499d7593136d0f6b59e7163b9e66fb2c995" warn_unsupported

--- a/share/node-build/0.10.42
+++ b/share/node-build/0.10.42
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.42/node-v0.10.42-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.42/node-v0.10.42-sunos-x64.tar.gz#af15246d6889db4449dc46d5c4a549bb56b19481cbb801d30a09153ba71b88e1"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.42/node-v0.10.42-sunos-x86.tar.gz#3333f1fd394bdde5aafa424d945b002b0d0876e17396f864af9c230c81aac08b"
 
-install_package "node-v0.10.42" "https://nodejs.org/dist/v0.10.42/node-v0.10.42.tar.gz#ebc1d53698f80c5a7b0b948e1108d7858f93d2d9ebf4541c12688d85704de105"
+install_package "node-v0.10.42" "https://nodejs.org/dist/v0.10.42/node-v0.10.42.tar.gz#ebc1d53698f80c5a7b0b948e1108d7858f93d2d9ebf4541c12688d85704de105" warn_unsupported

--- a/share/node-build/0.10.43
+++ b/share/node-build/0.10.43
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.43/node-v0.10.43-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.43/node-v0.10.43-sunos-x64.tar.gz#f6cf66e77e1def7fa854ddb83a176d89f9a5b349fbb1e0bcdb742778c31e1510"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.43/node-v0.10.43-sunos-x86.tar.gz#b3badbc35d085723a2ad30847c5109398363b13649e199db6d22fe5f56e74c52"
 
-install_package "node-v0.10.43" "https://nodejs.org/dist/v0.10.43/node-v0.10.43.tar.gz#c672452a61dd37cf2779bc158b65a5a22af343da19fec1cddf9bced382a2595a"
+install_package "node-v0.10.43" "https://nodejs.org/dist/v0.10.43/node-v0.10.43.tar.gz#c672452a61dd37cf2779bc158b65a5a22af343da19fec1cddf9bced382a2595a" warn_unsupported

--- a/share/node-build/0.10.44
+++ b/share/node-build/0.10.44
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.44/node-v0.10.44-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.44/node-v0.10.44-sunos-x64.tar.gz#ee2867b193b53ffab308bea6f0e4c197222903ae308b1748eceaa786402d6c15"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.44/node-v0.10.44-sunos-x86.tar.gz#0b385a3aa1f9122bca205515917a2406ab24782ecbbb886ceb5dcba93f3a9758"
 
-install_package "node-v0.10.44" "https://nodejs.org/dist/v0.10.44/node-v0.10.44.tar.gz#4155639d71e690cafd885f58a8be3bf97a93c28875212aac991923d3ee589be8"
+install_package "node-v0.10.44" "https://nodejs.org/dist/v0.10.44/node-v0.10.44.tar.gz#4155639d71e690cafd885f58a8be3bf97a93c28875212aac991923d3ee589be8" warn_unsupported

--- a/share/node-build/0.10.45
+++ b/share/node-build/0.10.45
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.45/node-v0.10.45-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.45/node-v0.10.45-sunos-x64.tar.gz#019a1c40daff7b05efb2bd27c586d9ba9c5fe5048550b74e67e171d1495d4e30"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.45/node-v0.10.45-sunos-x86.tar.gz#39a0790a7e533dd77f473c009c11458a5205cfc438777139a5e9658be63dfee2"
 
-install_package "node-v0.10.45" "https://nodejs.org/dist/v0.10.45/node-v0.10.45.tar.gz#d184bb74758d4ac69826823934cda1d46e81402fc16ebdb2ecacdc1a8fe0b568"
+install_package "node-v0.10.45" "https://nodejs.org/dist/v0.10.45/node-v0.10.45.tar.gz#d184bb74758d4ac69826823934cda1d46e81402fc16ebdb2ecacdc1a8fe0b568" warn_unsupported

--- a/share/node-build/0.10.5
+++ b/share/node-build/0.10.5
@@ -6,4 +6,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.5/node-v0.10.5-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.10.5/node-v0.10.5-sunos-x64.tar.gz#508d295599796814a9cbe79d1a254f8a2072d702ffcb1c288376cfec1dd317fd"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.5/node-v0.10.5-sunos-x86.tar.gz#3b7626bcd8550b95a08695bae781debebd06d575ac17c8404b388d949c8f3d55"
 
-install_package "node-v0.10.5" "https://nodejs.org/dist/v0.10.5/node-v0.10.5.tar.gz#1c22bd15cb13b1109610ee256699300ec6999b335f3bc85dc3c0312ec9312cfd"
+install_package "node-v0.10.5" "https://nodejs.org/dist/v0.10.5/node-v0.10.5.tar.gz#1c22bd15cb13b1109610ee256699300ec6999b335f3bc85dc3c0312ec9312cfd" warn_unsupported

--- a/share/node-build/0.10.6
+++ b/share/node-build/0.10.6
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.6/node-v0.10.6-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.10.6/node-v0.10.6-sunos-x64.tar.gz#554ff5ade28f20b4cb17ed18a7265a7a5486de29b971f1228ed8984b40900e95"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.6/node-v0.10.6-sunos-x86.tar.gz#a0a7412f7087ebbc726e4fffe8205fbc775ec3b59c890e425ebb00c782eb11e2"
 
-install_package "node-v0.10.6" "https://nodejs.org/dist/v0.10.6/node-v0.10.6.tar.gz#7e2079394efe82f62798178f617888c9d6a39150c76122c432ae9ea73ce28e79"
+install_package "node-v0.10.6" "https://nodejs.org/dist/v0.10.6/node-v0.10.6.tar.gz#7e2079394efe82f62798178f617888c9d6a39150c76122c432ae9ea73ce28e79" warn_unsupported

--- a/share/node-build/0.10.7
+++ b/share/node-build/0.10.7
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.7/node-v0.10.7-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.10.7/node-v0.10.7-sunos-x64.tar.gz#1c858bf96ebbd2c88e0a5e47c49fe0e4e679746e81b11ade9adc155a8d8466ff"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.7/node-v0.10.7-sunos-x86.tar.gz#a947ac0b8eeae290ab3e06d4fa69d9f6424ac793ea2786b9423f5b199c36c7fa"
 
-install_package "node-v0.10.7" "https://nodejs.org/dist/v0.10.7/node-v0.10.7.tar.gz#22d1d211f5260dfa5b842cebdb04633f28df180843105ff3eb792ca35ed425e0"
+install_package "node-v0.10.7" "https://nodejs.org/dist/v0.10.7/node-v0.10.7.tar.gz#22d1d211f5260dfa5b842cebdb04633f28df180843105ff3eb792ca35ed425e0" warn_unsupported

--- a/share/node-build/0.10.8
+++ b/share/node-build/0.10.8
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.8/node-v0.10.8-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.10.8/node-v0.10.8-sunos-x64.tar.gz#67ed50f8c1d80fd7601c7c2acd3b7fe9cbe667be3210075851b682f1f4b26d04"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.8/node-v0.10.8-sunos-x86.tar.gz#9d9b4b003df50e856614f104cf38681bd6c2f6c391e8210649b576ee0dc763cb"
 
-install_package "node-v0.10.8" "https://nodejs.org/dist/v0.10.8/node-v0.10.8.tar.gz#edf6f766c8ccc7ef5b02a50c94567343eb1ffae479db93684ba89976e3f18354"
+install_package "node-v0.10.8" "https://nodejs.org/dist/v0.10.8/node-v0.10.8.tar.gz#edf6f766c8ccc7ef5b02a50c94567343eb1ffae479db93684ba89976e3f18354" warn_unsupported

--- a/share/node-build/0.10.9
+++ b/share/node-build/0.10.9
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.9/node-v0.10.9-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.10.9/node-v0.10.9-sunos-x64.tar.gz#35cefbee05e13ce6fc78641c0cf5437eee07df844af0d6c0ae56db3e51f907fe"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.9/node-v0.10.9-sunos-x86.tar.gz#a802e9614349c2b33c0b713dcace56b6aa747107669a3899f97be9e542ffab1c"
 
-install_package "node-v0.10.9" "https://nodejs.org/dist/v0.10.9/node-v0.10.9.tar.gz#25fb276ac6765ebb19f44d3e3775ed1c0275f874c896755d0d619226caee9c30"
+install_package "node-v0.10.9" "https://nodejs.org/dist/v0.10.9/node-v0.10.9.tar.gz#25fb276ac6765ebb19f44d3e3775ed1c0275f874c896755d0d619226caee9c30" warn_unsupported

--- a/share/node-build/0.11.0
+++ b/share/node-build/0.11.0
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.0/node-v0.11.0-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.11.0/node-v0.11.0-sunos-x64.tar.gz#e6756250650d286da47e9113b2e8a767dcb5fe5f2544fedda36eeb4fbc60a0e9"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.0/node-v0.11.0-sunos-x86.tar.gz#eddc6728d6f7739b213e23462c7f62f35059d5145713f81858322c890208457f"
 
-install_package "node-v0.11.0" "https://nodejs.org/dist/v0.11.0/node-v0.11.0.tar.gz#a1887957fd6f0091379d1317f1daeb791bbf4301e58d693d17ad1d0fdbfa7898"
+install_package "node-v0.11.0" "https://nodejs.org/dist/v0.11.0/node-v0.11.0.tar.gz#a1887957fd6f0091379d1317f1daeb791bbf4301e58d693d17ad1d0fdbfa7898" warn_eol

--- a/share/node-build/0.11.1
+++ b/share/node-build/0.11.1
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.1/node-v0.11.1-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.11.1/node-v0.11.1-sunos-x64.tar.gz#22453736b491481eb270ec273e1a938ce73534e5f7a9979c831291865822d726"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.1/node-v0.11.1-sunos-x86.tar.gz#7d566f108e1b1115aedec5abc988720b75f23f4abee9b638a8c4f8074077bd2e"
 
-install_package "node-v0.11.1" "https://nodejs.org/dist/v0.11.1/node-v0.11.1.tar.gz#1042853f6f288185e9dda60eaf57de50768aec5d32df7c7f462b713c56bd096f"
+install_package "node-v0.11.1" "https://nodejs.org/dist/v0.11.1/node-v0.11.1.tar.gz#1042853f6f288185e9dda60eaf57de50768aec5d32df7c7f462b713c56bd096f" warn_eol

--- a/share/node-build/0.11.10
+++ b/share/node-build/0.11.10
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.10/node-v0.11.10-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.11.10/node-v0.11.10-sunos-x64.tar.gz#eb921e47fcb0deddb9f2c75f8d087ec16de11c3cd3b50ecd6ec68a7ac08c7873"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.10/node-v0.11.10-sunos-x86.tar.gz#bf4bef098f7fddec5692f9c7aefdab916c2ff8a5e6856423429dfb008b957b4c"
 
-install_package "node-v0.11.10" "https://nodejs.org/dist/v0.11.10/node-v0.11.10.tar.gz#6f7b5971c23049645bb955ad787714bf1e8ead14bab2d4e30da328f13fa86040"
+install_package "node-v0.11.10" "https://nodejs.org/dist/v0.11.10/node-v0.11.10.tar.gz#6f7b5971c23049645bb955ad787714bf1e8ead14bab2d4e30da328f13fa86040" warn_eol

--- a/share/node-build/0.11.11
+++ b/share/node-build/0.11.11
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.11/node-v0.11.11-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.11.11/node-v0.11.11-sunos-x64.tar.gz#cc0e76fe45755885c606939ae63be113ddc698bad65820cd19044e128b6fb270"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.11/node-v0.11.11-sunos-x86.tar.gz#cd58120e6660931ad24eed0534f499edbf152265c64a83b629bd501768f4f579"
 
-install_package "node-v0.11.11" "https://nodejs.org/dist/v0.11.11/node-v0.11.11.tar.gz#7098763353011a92bca25192c0ed4a7cae5a115805223bcc6d5a81e4d20dc87a"
+install_package "node-v0.11.11" "https://nodejs.org/dist/v0.11.11/node-v0.11.11.tar.gz#7098763353011a92bca25192c0ed4a7cae5a115805223bcc6d5a81e4d20dc87a" warn_eol

--- a/share/node-build/0.11.12
+++ b/share/node-build/0.11.12
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.12/node-v0.11.12-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.11.12/node-v0.11.12-sunos-x64.tar.gz#7cc56ba26dd0429deb2e72632629b051162d355cfae0bf6732c620595f684ac8"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.12/node-v0.11.12-sunos-x86.tar.gz#58cbe6416d4dba4c76d68d088d1741133242fb9825e5d3d7ba39e20d334312ed"
 
-install_package "node-v0.11.12" "https://nodejs.org/dist/v0.11.12/node-v0.11.12.tar.gz#c40968981d9f5f6fbc4abb836557acda74ecb8f8a1e9a30e84ebd2529a8c1b6a"
+install_package "node-v0.11.12" "https://nodejs.org/dist/v0.11.12/node-v0.11.12.tar.gz#c40968981d9f5f6fbc4abb836557acda74ecb8f8a1e9a30e84ebd2529a8c1b6a" warn_eol

--- a/share/node-build/0.11.13
+++ b/share/node-build/0.11.13
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.13/node-v0.11.13-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.11.13/node-v0.11.13-sunos-x64.tar.gz#71186ff69b914f005641742676e5f65b2c0853fdb09f2c5f8cd6696e85e76763"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.13/node-v0.11.13-sunos-x86.tar.gz#2e9c0eacd1cb699360b3abd01272314dfb6d7e4ddfd3897c10822f6ac336220c"
 
-install_package "node-v0.11.13" "https://nodejs.org/dist/v0.11.13/node-v0.11.13.tar.gz#15d6e90c16adf907c0401cd5a77841b5264e90dfdaa1051d75184aa587fc8298"
+install_package "node-v0.11.13" "https://nodejs.org/dist/v0.11.13/node-v0.11.13.tar.gz#15d6e90c16adf907c0401cd5a77841b5264e90dfdaa1051d75184aa587fc8298" warn_eol

--- a/share/node-build/0.11.14
+++ b/share/node-build/0.11.14
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.14/node-v0.11.14-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.11.14/node-v0.11.14-sunos-x64.tar.gz#96cbb3f5b8a19cde8fc9855baf1e2c5664cfdaf9062675661c5920f51eb85319"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.14/node-v0.11.14-sunos-x86.tar.gz#eae7646ae5d94f055698a271daa5092dcc02fe284de01cc9e0688190d6e06a83"
 
-install_package "node-v0.11.14" "https://nodejs.org/dist/v0.11.14/node-v0.11.14.tar.gz#ce08b0a2769bcc135ca25639c9d411a038e93e0f5f5a83000ecde9b763c4dd83"
+install_package "node-v0.11.14" "https://nodejs.org/dist/v0.11.14/node-v0.11.14.tar.gz#ce08b0a2769bcc135ca25639c9d411a038e93e0f5f5a83000ecde9b763c4dd83" warn_eol

--- a/share/node-build/0.11.15
+++ b/share/node-build/0.11.15
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.15/node-v0.11.15-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.11.15/node-v0.11.15-sunos-x64.tar.gz#08ee809bdb1800a4fd629b795038040222ee2233cdf1adb1297a3abdd18d2584"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.15/node-v0.11.15-sunos-x86.tar.gz#6b4969200aeb10532d4d23c20af4b10eb20b08ee1aa37cc486172b7237dfa0a6"
 
-install_package "node-v0.11.15" "https://nodejs.org/dist/v0.11.15/node-v0.11.15.tar.gz#e613d274baa4c99a0518038192491433f7877493a66d8505af263f6310991d01"
+install_package "node-v0.11.15" "https://nodejs.org/dist/v0.11.15/node-v0.11.15.tar.gz#e613d274baa4c99a0518038192491433f7877493a66d8505af263f6310991d01" warn_eol

--- a/share/node-build/0.11.16
+++ b/share/node-build/0.11.16
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.16/node-v0.11.16-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.11.16/node-v0.11.16-sunos-x64.tar.gz#ba806e941aa532ace89a0868374dec5ec97d6abd1d3d9d97fd686b419aeb6d05"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.16/node-v0.11.16-sunos-x86.tar.gz#7a15668536ba979ebcbda23beee3e7350544d4b5e15a96afdc928dbb6d423d5a"
 
-install_package "node-v0.11.16" "https://nodejs.org/dist/v0.11.16/node-v0.11.16.tar.gz#f0d141faa1f7da3aff53e9615d76040d29c0650542be3b09ee80aca2f2cc61f6"
+install_package "node-v0.11.16" "https://nodejs.org/dist/v0.11.16/node-v0.11.16.tar.gz#f0d141faa1f7da3aff53e9615d76040d29c0650542be3b09ee80aca2f2cc61f6" warn_eol

--- a/share/node-build/0.11.2
+++ b/share/node-build/0.11.2
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.2/node-v0.11.2-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.11.2/node-v0.11.2-sunos-x64.tar.gz#f315d1c5ffa8152eeaafc602d0265c9fde19c338c159e1166e981a0bf34d39eb"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.2/node-v0.11.2-sunos-x86.tar.gz#125c52610c41638c740a71d564132e56b986d208dff04a72b7ebb97f3347df04"
 
-install_package "node-v0.11.2" "https://nodejs.org/dist/v0.11.2/node-v0.11.2.tar.gz#d115f01fea0b2c5a4c4ca489d0cc8cec70300f0212f08905d881ac55f642554a"
+install_package "node-v0.11.2" "https://nodejs.org/dist/v0.11.2/node-v0.11.2.tar.gz#d115f01fea0b2c5a4c4ca489d0cc8cec70300f0212f08905d881ac55f642554a" warn_eol

--- a/share/node-build/0.11.3
+++ b/share/node-build/0.11.3
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.3/node-v0.11.3-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.11.3/node-v0.11.3-sunos-x64.tar.gz#94e68581c673993901381c212cf255ad3f945a1b5a98d7d122ad40ebd9a9c23d"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.3/node-v0.11.3-sunos-x86.tar.gz#d94c49bc39e0a9c8c184d5326c7e059ead5e6be89555a5cabcdbad43f5e919c0"
 
-install_package "node-v0.11.3" "https://nodejs.org/dist/v0.11.3/node-v0.11.3.tar.gz#aa3189c4e42d3e5dae86c132b28dbe04163d53a480949ea9f1985ddfeaf39955"
+install_package "node-v0.11.3" "https://nodejs.org/dist/v0.11.3/node-v0.11.3.tar.gz#aa3189c4e42d3e5dae86c132b28dbe04163d53a480949ea9f1985ddfeaf39955" warn_eol

--- a/share/node-build/0.11.4
+++ b/share/node-build/0.11.4
@@ -5,4 +5,4 @@ binary darwin-x64 "https://nodejs.org/dist/v0.11.4/node-v0.11.4-darwin-x64.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.11.4/node-v0.11.4-sunos-x64.tar.gz#b7ace7b597704d3b9cad1f581734c1afe51db2aca0da80739b06c557c26fce79"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.4/node-v0.11.4-sunos-x86.tar.gz#9041a18c7eecea05fd8ce331f9f8294af1725a25dd705b0410f81f948d73757c"
 
-install_package "node-v0.11.4" "https://nodejs.org/dist/v0.11.4/node-v0.11.4.tar.gz#81f36aafa4a31fa59e0301358699d82766ea7ba178be810ce00444a7fc10db47"
+install_package "node-v0.11.4" "https://nodejs.org/dist/v0.11.4/node-v0.11.4.tar.gz#81f36aafa4a31fa59e0301358699d82766ea7ba178be810ce00444a7fc10db47" warn_eol

--- a/share/node-build/0.11.5
+++ b/share/node-build/0.11.5
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.5/node-v0.11.5-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.11.5/node-v0.11.5-sunos-x64.tar.gz#efe9e4d9e84805f2ce485cebcfac4ee683066ae80f53c4a050e41845a3bf7de5"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.5/node-v0.11.5-sunos-x86.tar.gz#7b1a06208026da14b394dafb607408e116a93a1d2dd0d2923870cdc24007fdef"
 
-install_package "node-v0.11.5" "https://nodejs.org/dist/v0.11.5/node-v0.11.5.tar.gz#72b89f9146a2dd57e1712f1fb822f62bdf00b2d5482689510dc2e4d19ae6559e"
+install_package "node-v0.11.5" "https://nodejs.org/dist/v0.11.5/node-v0.11.5.tar.gz#72b89f9146a2dd57e1712f1fb822f62bdf00b2d5482689510dc2e4d19ae6559e" warn_eol

--- a/share/node-build/0.11.6
+++ b/share/node-build/0.11.6
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.6/node-v0.11.6-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.11.6/node-v0.11.6-sunos-x64.tar.gz#a20a411403d693d174860140add6c20499ccefd3c7b41e78a4e7fbf349f03f61"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.6/node-v0.11.6-sunos-x86.tar.gz#21ab274fe11405dd2997763e9b4fd065604931150c47c039f22de73ed59f2902"
 
-install_package "node-v0.11.6" "https://nodejs.org/dist/v0.11.6/node-v0.11.6.tar.gz#35552aec60077270306c73507effeb4b7d9ef02f03f45681442c0d4e1951e75d"
+install_package "node-v0.11.6" "https://nodejs.org/dist/v0.11.6/node-v0.11.6.tar.gz#35552aec60077270306c73507effeb4b7d9ef02f03f45681442c0d4e1951e75d" warn_eol

--- a/share/node-build/0.11.7
+++ b/share/node-build/0.11.7
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.7/node-v0.11.7-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.11.7/node-v0.11.7-sunos-x64.tar.gz#4d4f10266e05b3d8081d3674d0d35f75703037bda85d4a10cc721d31b72ed77e"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.7/node-v0.11.7-sunos-x86.tar.gz#c1ecf77d9a9f15cd16667a76cea2e950781853e7d4ea0466481bdec82cdd602a"
 
-install_package "node-v0.11.7" "https://nodejs.org/dist/v0.11.7/node-v0.11.7.tar.gz#d915345639e340405b01f259971f386aafb5a10544b162826514cf56ddd371fe"
+install_package "node-v0.11.7" "https://nodejs.org/dist/v0.11.7/node-v0.11.7.tar.gz#d915345639e340405b01f259971f386aafb5a10544b162826514cf56ddd371fe" warn_eol

--- a/share/node-build/0.11.8
+++ b/share/node-build/0.11.8
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.8/node-v0.11.8-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.11.8/node-v0.11.8-sunos-x64.tar.gz#0599412586981586bddc2686f3f1a41c48862ae8dd770f810cec83d7453dc8be"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.8/node-v0.11.8-sunos-x86.tar.gz#66e20972dcd44efbfe51404b7a9e5b67e03f71b439fc966bd4e6d2524ce9c886"
 
-install_package "node-v0.11.8" "https://nodejs.org/dist/v0.11.8/node-v0.11.8.tar.gz#87c809dea764d5d66f925626fba403fb2fb0c0ccfad408bf79fdb62dc246d65b"
+install_package "node-v0.11.8" "https://nodejs.org/dist/v0.11.8/node-v0.11.8.tar.gz#87c809dea764d5d66f925626fba403fb2fb0c0ccfad408bf79fdb62dc246d65b" warn_eol

--- a/share/node-build/0.11.9
+++ b/share/node-build/0.11.9
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.9/node-v0.11.9-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.11.9/node-v0.11.9-sunos-x64.tar.gz#b37fa67fe332c32759be413dbad9e4f8231267ac3afa7afc1d74388d9859dc73"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.9/node-v0.11.9-sunos-x86.tar.gz#158bafae549cbaac88bd85bc6e00104f3fdbc84ac2562018050d9131b44d7e4f"
 
-install_package "node-v0.11.9" "https://nodejs.org/dist/v0.11.9/node-v0.11.9.tar.gz#cfcab9735a7e04a67671a96a8b0b7e71954c60c586ced5e3fe37d5c1a235b444"
+install_package "node-v0.11.9" "https://nodejs.org/dist/v0.11.9/node-v0.11.9.tar.gz#cfcab9735a7e04a67671a96a8b0b7e71954c60c586ced5e3fe37d5c1a235b444" warn_eol

--- a/share/node-build/0.12-dev
+++ b/share/node-build/0.12-dev
@@ -1,1 +1,1 @@
-install_git "0.12-dev" "https://github.com/nodejs/node.git" "v0.12-staging" standard
+install_git "0.12-dev" "https://github.com/nodejs/node.git" "v0.12-staging" standard warn_unsupported

--- a/share/node-build/0.12-next
+++ b/share/node-build/0.12-next
@@ -1,1 +1,1 @@
-install_git "0.12-next" "https://github.com/nodejs/node.git" "v0.12" standard
+install_git "0.12-next" "https://github.com/nodejs/node.git" "v0.12" standard warn_unsupported

--- a/share/node-build/0.12.0
+++ b/share/node-build/0.12.0
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.0/node-v0.12.0-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.12.0/node-v0.12.0-sunos-x64.tar.gz#b775ba850a950ad405bc92f57325aae5b3a692f241bb1f01a94b1291c9b43246"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.0/node-v0.12.0-sunos-x86.tar.gz#c910021a6b756ffe89f3a91a51f5f6ed6fcebae51fd12a5dc2070b06bb400244"
 
-install_package "node-v0.12.0" "https://nodejs.org/dist/v0.12.0/node-v0.12.0.tar.gz#9700e23af4e9b3643af48cef5f2ad20a1331ff531a12154eef2bfb0bb1682e32"
+install_package "node-v0.12.0" "https://nodejs.org/dist/v0.12.0/node-v0.12.0.tar.gz#9700e23af4e9b3643af48cef5f2ad20a1331ff531a12154eef2bfb0bb1682e32" warn_unsupported

--- a/share/node-build/0.12.1
+++ b/share/node-build/0.12.1
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.1/node-v0.12.1-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.12.1/node-v0.12.1-sunos-x64.tar.gz#d93ddc3f2d17da8320cfff40ef39edb4a19e0877f31254e1bf66988bae0a0616"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.1/node-v0.12.1-sunos-x86.tar.gz#b7cd96f4791e95b3698e1a6e0461acd040f14138e9fde1e64a76b279da5ea9bb"
 
-install_package "node-v0.12.1" "https://nodejs.org/dist/v0.12.1/node-v0.12.1.tar.gz#30693376519c9736bcb22d44513252aee1d9463d78ac6c744ecb6d13fd91d680"
+install_package "node-v0.12.1" "https://nodejs.org/dist/v0.12.1/node-v0.12.1.tar.gz#30693376519c9736bcb22d44513252aee1d9463d78ac6c744ecb6d13fd91d680" warn_unsupported

--- a/share/node-build/0.12.10
+++ b/share/node-build/0.12.10
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.10/node-v0.12.10-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.12.10/node-v0.12.10-sunos-x64.tar.gz#d67f17540c711eb150b8a389af1b4e6ecdcab66a1648b7ce925af98ab52b2698"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.10/node-v0.12.10-sunos-x86.tar.gz#beca24cc3615c5b1858817d121bd91eecdc3af5b98ed0c4c171e1ef60afac049"
 
-install_package "node-v0.12.10" "https://nodejs.org/dist/v0.12.10/node-v0.12.10.tar.gz#edbd3710512ec7518a3de4cabf9bfee6d12f278eef2e4b53422c7b063f6b976d"
+install_package "node-v0.12.10" "https://nodejs.org/dist/v0.12.10/node-v0.12.10.tar.gz#edbd3710512ec7518a3de4cabf9bfee6d12f278eef2e4b53422c7b063f6b976d" warn_unsupported

--- a/share/node-build/0.12.11
+++ b/share/node-build/0.12.11
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.11/node-v0.12.11-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.12.11/node-v0.12.11-sunos-x64.tar.gz#6a68d6ad04c9b73ed72e88e39002bbaa95ffc423c6cf47e3c3da5edd0abbc701"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.11/node-v0.12.11-sunos-x86.tar.gz#9e61254d7437c2498817225c62dc6cfc065bd3b2404a213d8d305419bca07a6c"
 
-install_package "node-v0.12.11" "https://nodejs.org/dist/v0.12.11/node-v0.12.11.tar.gz#e49049d82f2a11fa164549d907d4739fe1293d53c07f48bd70e1df237b238a68"
+install_package "node-v0.12.11" "https://nodejs.org/dist/v0.12.11/node-v0.12.11.tar.gz#e49049d82f2a11fa164549d907d4739fe1293d53c07f48bd70e1df237b238a68" warn_unsupported

--- a/share/node-build/0.12.12
+++ b/share/node-build/0.12.12
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.12/node-v0.12.12-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.12.12/node-v0.12.12-sunos-x64.tar.gz#ef361aec4a2c1e3789662e7605928717af76b4d0ed360d4facb75a606ac0a2de"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.12/node-v0.12.12-sunos-x86.tar.gz#f6d0fa1fe8cfc197fbe86c8f7517b42d610efb341218fad1b24bc7f08cc4433f"
 
-install_package "node-v0.12.12" "https://nodejs.org/dist/v0.12.12/node-v0.12.12.tar.gz#61e4c176fd882498778b1a3907a5fe5c9e95e6cc8438b0d053d953aed3620273"
+install_package "node-v0.12.12" "https://nodejs.org/dist/v0.12.12/node-v0.12.12.tar.gz#61e4c176fd882498778b1a3907a5fe5c9e95e6cc8438b0d053d953aed3620273" warn_unsupported

--- a/share/node-build/0.12.13
+++ b/share/node-build/0.12.13
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.13/node-v0.12.13-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.12.13/node-v0.12.13-sunos-x64.tar.gz#9b40e2b657e560901c6cccf3c93d01a5055cb4d011ccfefe1b977dae7935ea42"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.13/node-v0.12.13-sunos-x86.tar.gz#83f862b0383ba6c9a15f32a043de48288b087c0f368117eac36d66779491a910"
 
-install_package "node-v0.12.13" "https://nodejs.org/dist/v0.12.13/node-v0.12.13.tar.gz#0a972ed6442cb526aa7aa1bcb10aa536b65bd90ab4956b5a1aa51b4b7bb071bd"
+install_package "node-v0.12.13" "https://nodejs.org/dist/v0.12.13/node-v0.12.13.tar.gz#0a972ed6442cb526aa7aa1bcb10aa536b65bd90ab4956b5a1aa51b4b7bb071bd" warn_unsupported

--- a/share/node-build/0.12.14
+++ b/share/node-build/0.12.14
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.14/node-v0.12.14-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.12.14/node-v0.12.14-sunos-x64.tar.gz#906a44e9f6024c3f9af05a8aac5ba10c25d84bf56b9fb08c5fc1c26c5a8b9d27"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.14/node-v0.12.14-sunos-x86.tar.gz#f042bee409d4da3114571dfff496a954ea6cd614e7fb78fd3d9b50d799396757"
 
-install_package "node-v0.12.14" "https://nodejs.org/dist/v0.12.14/node-v0.12.14.tar.gz#0a55e57cbd3ffa67525c0d93ac7076d3b2ac70887b11c5c97be3e1953cb50b1d"
+install_package "node-v0.12.14" "https://nodejs.org/dist/v0.12.14/node-v0.12.14.tar.gz#0a55e57cbd3ffa67525c0d93ac7076d3b2ac70887b11c5c97be3e1953cb50b1d" warn_unsupported

--- a/share/node-build/0.12.2
+++ b/share/node-build/0.12.2
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.2/node-v0.12.2-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.12.2/node-v0.12.2-sunos-x64.tar.gz#48112116f4d7ba15c47cf269d72df1f402efaccde1b0bce41d6176c6b653f1b3"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.2/node-v0.12.2-sunos-x86.tar.gz#86b07380c92fa4f2a82db7cd5089c63fe9b6235193c5c670736243aa015b9c8a"
 
-install_package "node-v0.12.2" "https://nodejs.org/dist/v0.12.2/node-v0.12.2.tar.gz#ac7e78ade93e633e7ed628532bb8e650caba0c9c33af33581957f3382e2a772d"
+install_package "node-v0.12.2" "https://nodejs.org/dist/v0.12.2/node-v0.12.2.tar.gz#ac7e78ade93e633e7ed628532bb8e650caba0c9c33af33581957f3382e2a772d" warn_unsupported

--- a/share/node-build/0.12.3
+++ b/share/node-build/0.12.3
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.3/node-v0.12.3-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.12.3/node-v0.12.3-sunos-x64.tar.gz#376318f3e3c14543f4419d0e8c190cebbcb6052882980beeb9203d13548f6cc1"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.3/node-v0.12.3-sunos-x86.tar.gz#8d6e3400fdfa9fe0df7f441c5f51d25fb2a8975b9ae6c43560c3bf3a71d1497d"
 
-install_package "node-v0.12.3" "https://nodejs.org/dist/v0.12.3/node-v0.12.3.tar.gz#e65d83c6f2c874e28f65c5e192ac0acd2bbb52bfcf9d77e33442d6765a3eb9da"
+install_package "node-v0.12.3" "https://nodejs.org/dist/v0.12.3/node-v0.12.3.tar.gz#e65d83c6f2c874e28f65c5e192ac0acd2bbb52bfcf9d77e33442d6765a3eb9da" warn_unsupported

--- a/share/node-build/0.12.4
+++ b/share/node-build/0.12.4
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.4/node-v0.12.4-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.12.4/node-v0.12.4-sunos-x64.tar.gz#308cb46091c613f8068a8aa30980ce4a1ac6e85ac14aa464728e83727a981f13"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.4/node-v0.12.4-sunos-x86.tar.gz#b9bd9a590f73d8c82704676794eb64a17fba01c35b285bc99c14af547dbc3fab"
 
-install_package "node-v0.12.4" "https://nodejs.org/dist/v0.12.4/node-v0.12.4.tar.gz#3298d0997613a04ac64343e8316da134d04588132554ae402eb344e3369ec912"
+install_package "node-v0.12.4" "https://nodejs.org/dist/v0.12.4/node-v0.12.4.tar.gz#3298d0997613a04ac64343e8316da134d04588132554ae402eb344e3369ec912" warn_unsupported

--- a/share/node-build/0.12.5
+++ b/share/node-build/0.12.5
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.5/node-v0.12.5-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.12.5/node-v0.12.5-sunos-x64.tar.gz#ceb0d587ff4f85e47ed7f85fac96ada51bc42199725a218f72e109adb12766c0"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.5/node-v0.12.5-sunos-x86.tar.gz#e39121eebb362ea619de354af802bf5428105a96a87dc5f40fc20c2979e5b772"
 
-install_package "node-v0.12.5" "https://nodejs.org/dist/v0.12.5/node-v0.12.5.tar.gz#4bc1e25f4c62ac65324d3cf4aa9de2d801cd708757c3567b6ad2ced7df30cdd2"
+install_package "node-v0.12.5" "https://nodejs.org/dist/v0.12.5/node-v0.12.5.tar.gz#4bc1e25f4c62ac65324d3cf4aa9de2d801cd708757c3567b6ad2ced7df30cdd2" warn_unsupported

--- a/share/node-build/0.12.6
+++ b/share/node-build/0.12.6
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.6/node-v0.12.6-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.12.6/node-v0.12.6-sunos-x64.tar.gz#cd0d0dd1ec646ac41c5b2486392662910930779b29a90e9650189b0bc2ca2a7e"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.6/node-v0.12.6-sunos-x86.tar.gz#f168959b26c0b1074d5fe24899f070d352741bfa624a556e263890b624af68c5"
 
-install_package "node-v0.12.6" "https://nodejs.org/dist/v0.12.6/node-v0.12.6.tar.gz#7a3b5ac351973a9dee8edbf0684bc8d0dea44b231e42274ffb008141ffa19ad2"
+install_package "node-v0.12.6" "https://nodejs.org/dist/v0.12.6/node-v0.12.6.tar.gz#7a3b5ac351973a9dee8edbf0684bc8d0dea44b231e42274ffb008141ffa19ad2" warn_unsupported

--- a/share/node-build/0.12.7
+++ b/share/node-build/0.12.7
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.7/node-v0.12.7-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.12.7/node-v0.12.7-sunos-x64.tar.gz#e5cb2f36c1e6899c6e8b268d1019459bc9dd125d8144e47fb0d740e8601e5ddb"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.7/node-v0.12.7-sunos-x86.tar.gz#c7c7af04ca624a7a08c308f172e26a7fd3182187d3da0025e0108c67c2e5c6c9"
 
-install_package "node-v0.12.7" "https://nodejs.org/dist/v0.12.7/node-v0.12.7.tar.gz#b23d64df051c9c969b0c583f802d5d71de342e53067127a5061415be7e12f39d"
+install_package "node-v0.12.7" "https://nodejs.org/dist/v0.12.7/node-v0.12.7.tar.gz#b23d64df051c9c969b0c583f802d5d71de342e53067127a5061415be7e12f39d" warn_unsupported

--- a/share/node-build/0.12.8
+++ b/share/node-build/0.12.8
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.8/node-v0.12.8-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.12.8/node-v0.12.8-sunos-x64.tar.gz#c8ca60698f99b7dc7722b94c5b4110636d08d3a20cb3df80807bd420e2c34376"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.8/node-v0.12.8-sunos-x86.tar.gz#8d9553a684b6717f0f0f2f5dcc8ed78139db50129e1402ce6033e2494c06cfd3"
 
-install_package "node-v0.12.8" "https://nodejs.org/dist/v0.12.8/node-v0.12.8.tar.gz#e0c96a6702978e2ed7f031315bebeb86b042e2c80e66d99af8ad864dc0e56436"
+install_package "node-v0.12.8" "https://nodejs.org/dist/v0.12.8/node-v0.12.8.tar.gz#e0c96a6702978e2ed7f031315bebeb86b042e2c80e66d99af8ad864dc0e56436" warn_unsupported

--- a/share/node-build/0.12.9
+++ b/share/node-build/0.12.9
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.9/node-v0.12.9-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.12.9/node-v0.12.9-sunos-x64.tar.gz#460a75865d6155dc39794204214c567a239b319122caf116a60f870f0987b720"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.9/node-v0.12.9-sunos-x86.tar.gz#039c710094ac76bea7027cf37daceb5708e46cac0bd082d7004c9710ad77ad1f"
 
-install_package "node-v0.12.9" "https://nodejs.org/dist/v0.12.9/node-v0.12.9.tar.gz#35daad301191e5f8dd7e5d2fbb711d081b82d1837d59837b8ee224c256cfe5e4"
+install_package "node-v0.12.9" "https://nodejs.org/dist/v0.12.9/node-v0.12.9.tar.gz#35daad301191e5f8dd7e5d2fbb711d081b82d1837d59837b8ee224c256cfe5e4" warn_unsupported

--- a/share/node-build/0.2.0
+++ b/share/node-build/0.2.0
@@ -1,1 +1,1 @@
-install_package "node-v0.2.0" "https://nodejs.org/dist/v0.2.0/node-v0.2.0.tar.gz#3d3eff9287c9917af4044f3cef99ae5b17946710a71e83039de4fcb4b0a26631"
+install_package "node-v0.2.0" "https://nodejs.org/dist/v0.2.0/node-v0.2.0.tar.gz#3d3eff9287c9917af4044f3cef99ae5b17946710a71e83039de4fcb4b0a26631" warn_eol

--- a/share/node-build/0.2.1
+++ b/share/node-build/0.2.1
@@ -1,1 +1,1 @@
-install_package "node-v0.2.1" "https://nodejs.org/dist/v0.2.1/node-v0.2.1.tar.gz#5bb7d084b2138ce43fcb34739ed894379c450a1dd569a1c710405bc39d2861c2"
+install_package "node-v0.2.1" "https://nodejs.org/dist/v0.2.1/node-v0.2.1.tar.gz#5bb7d084b2138ce43fcb34739ed894379c450a1dd569a1c710405bc39d2861c2" warn_eol

--- a/share/node-build/0.2.2
+++ b/share/node-build/0.2.2
@@ -1,1 +1,1 @@
-install_package "node-v0.2.2" "https://nodejs.org/dist/v0.2.2/node-v0.2.2.tar.gz#21dc8e18cd678f55773a2dbe309a559882bf6f3b969c9e5b39f6977fb85ee480"
+install_package "node-v0.2.2" "https://nodejs.org/dist/v0.2.2/node-v0.2.2.tar.gz#21dc8e18cd678f55773a2dbe309a559882bf6f3b969c9e5b39f6977fb85ee480" warn_eol

--- a/share/node-build/0.2.3
+++ b/share/node-build/0.2.3
@@ -1,1 +1,1 @@
-install_package "node-v0.2.3" "https://nodejs.org/dist/v0.2.3/node-v0.2.3.tar.gz#7358f8969b7bf6da7b066185bfa72d3bbc92e80b174ff5ea0e2b536fd357c8cf"
+install_package "node-v0.2.3" "https://nodejs.org/dist/v0.2.3/node-v0.2.3.tar.gz#7358f8969b7bf6da7b066185bfa72d3bbc92e80b174ff5ea0e2b536fd357c8cf" warn_eol

--- a/share/node-build/0.2.4
+++ b/share/node-build/0.2.4
@@ -1,1 +1,1 @@
-install_package "node-v0.2.4" "https://nodejs.org/dist/v0.2.4/node-v0.2.4.tar.gz#e6952007dacf18d9d85ae8ede8228e25cfe46e00be21b31c4d166239ec1fa533"
+install_package "node-v0.2.4" "https://nodejs.org/dist/v0.2.4/node-v0.2.4.tar.gz#e6952007dacf18d9d85ae8ede8228e25cfe46e00be21b31c4d166239ec1fa533" warn_eol

--- a/share/node-build/0.2.5
+++ b/share/node-build/0.2.5
@@ -1,1 +1,1 @@
-install_package "node-v0.2.5" "https://nodejs.org/dist/v0.2.5/node-v0.2.5.tar.gz#6c964096e2fb7bfa9108b31bdd2a920465a1b7f7a603e3937128eee9538b44bb"
+install_package "node-v0.2.5" "https://nodejs.org/dist/v0.2.5/node-v0.2.5.tar.gz#6c964096e2fb7bfa9108b31bdd2a920465a1b7f7a603e3937128eee9538b44bb" warn_eol

--- a/share/node-build/0.2.6
+++ b/share/node-build/0.2.6
@@ -1,1 +1,1 @@
-install_package "node-v0.2.6" "https://nodejs.org/dist/v0.2.6/node-v0.2.6.tar.gz#e97fe9c81ff4b569ae9a0d46e64a0572a1f171293573a5b5290bcc3996a19701"
+install_package "node-v0.2.6" "https://nodejs.org/dist/v0.2.6/node-v0.2.6.tar.gz#e97fe9c81ff4b569ae9a0d46e64a0572a1f171293573a5b5290bcc3996a19701" warn_eol

--- a/share/node-build/0.3.0
+++ b/share/node-build/0.3.0
@@ -1,1 +1,1 @@
-install_package "node-v0.3.0" "https://nodejs.org/dist/v0.3.0/node-v0.3.0.tar.gz#aa53c3d136ceaa02108ad013d9d9917e6e2ea22f10e3bd7414f4ba6f6a1427b5"
+install_package "node-v0.3.0" "https://nodejs.org/dist/v0.3.0/node-v0.3.0.tar.gz#aa53c3d136ceaa02108ad013d9d9917e6e2ea22f10e3bd7414f4ba6f6a1427b5" warn_eol

--- a/share/node-build/0.3.1
+++ b/share/node-build/0.3.1
@@ -1,1 +1,1 @@
-install_package "node-v0.3.1" "https://nodejs.org/dist/v0.3.1/node-v0.3.1.tar.gz#19c4c6144af143fbe37f80ec5d2843c4e19b5b6054fb10225bec314b60d2d012"
+install_package "node-v0.3.1" "https://nodejs.org/dist/v0.3.1/node-v0.3.1.tar.gz#19c4c6144af143fbe37f80ec5d2843c4e19b5b6054fb10225bec314b60d2d012" warn_eol

--- a/share/node-build/0.3.2
+++ b/share/node-build/0.3.2
@@ -1,1 +1,1 @@
-install_package "node-v0.3.2" "https://nodejs.org/dist/v0.3.2/node-v0.3.2.tar.gz#0cfb16b60c3c32c5fe0644108abb09e9425597a192c23844f29782b3ef7f7de2"
+install_package "node-v0.3.2" "https://nodejs.org/dist/v0.3.2/node-v0.3.2.tar.gz#0cfb16b60c3c32c5fe0644108abb09e9425597a192c23844f29782b3ef7f7de2" warn_eol

--- a/share/node-build/0.3.3
+++ b/share/node-build/0.3.3
@@ -1,1 +1,1 @@
-install_package "node-v0.3.3" "https://nodejs.org/dist/v0.3.3/node-v0.3.3.tar.gz#7f0dd072fbfa2dca8d873f56a4f57fdecbf4aba794b821654bec86daf3f980bc"
+install_package "node-v0.3.3" "https://nodejs.org/dist/v0.3.3/node-v0.3.3.tar.gz#7f0dd072fbfa2dca8d873f56a4f57fdecbf4aba794b821654bec86daf3f980bc" warn_eol

--- a/share/node-build/0.3.4
+++ b/share/node-build/0.3.4
@@ -1,1 +1,1 @@
-install_package "node-v0.3.4" "https://nodejs.org/dist/v0.3.4/node-v0.3.4.tar.gz#6980300d371ea182d719722a92706a495d19bd2efc6e1c3cdfe1c8fff74b5717"
+install_package "node-v0.3.4" "https://nodejs.org/dist/v0.3.4/node-v0.3.4.tar.gz#6980300d371ea182d719722a92706a495d19bd2efc6e1c3cdfe1c8fff74b5717" warn_eol

--- a/share/node-build/0.3.5
+++ b/share/node-build/0.3.5
@@ -1,1 +1,1 @@
-install_package "node-v0.3.5" "https://nodejs.org/dist/v0.3.5/node-v0.3.5.tar.gz#affdf4cbe8aaab74f99ea0a534d913a6203de353652c2fe01e1ce75707d730c7"
+install_package "node-v0.3.5" "https://nodejs.org/dist/v0.3.5/node-v0.3.5.tar.gz#affdf4cbe8aaab74f99ea0a534d913a6203de353652c2fe01e1ce75707d730c7" warn_eol

--- a/share/node-build/0.3.6
+++ b/share/node-build/0.3.6
@@ -1,1 +1,1 @@
-install_package "node-v0.3.6" "https://nodejs.org/dist/v0.3.6/node-v0.3.6.tar.gz#682709b86be119927015a95418a519542caadb95cbadb635ef51f7d0732fe305"
+install_package "node-v0.3.6" "https://nodejs.org/dist/v0.3.6/node-v0.3.6.tar.gz#682709b86be119927015a95418a519542caadb95cbadb635ef51f7d0732fe305" warn_eol

--- a/share/node-build/0.3.7
+++ b/share/node-build/0.3.7
@@ -1,1 +1,1 @@
-install_package "node-v0.3.7" "https://nodejs.org/dist/v0.3.7/node-v0.3.7.tar.gz#21c53e74684a8a3c3d14d14a49a07fa8250f0e41514b448182ef0d1f5bbba52f"
+install_package "node-v0.3.7" "https://nodejs.org/dist/v0.3.7/node-v0.3.7.tar.gz#21c53e74684a8a3c3d14d14a49a07fa8250f0e41514b448182ef0d1f5bbba52f" warn_eol

--- a/share/node-build/0.3.8
+++ b/share/node-build/0.3.8
@@ -1,1 +1,1 @@
-install_package "node-v0.3.8" "https://nodejs.org/dist/v0.3.8/node-v0.3.8.tar.gz#fc71861d339ec9ced9c85cb714f14e3e6e51651833ef0fec2abf41ad113172f1"
+install_package "node-v0.3.8" "https://nodejs.org/dist/v0.3.8/node-v0.3.8.tar.gz#fc71861d339ec9ced9c85cb714f14e3e6e51651833ef0fec2abf41ad113172f1" warn_eol

--- a/share/node-build/0.4.0
+++ b/share/node-build/0.4.0
@@ -1,1 +1,1 @@
-install_package "node-v0.4.0" "https://nodejs.org/dist/v0.4.0/node-v0.4.0.tar.gz#4a30bd9963373cb86a994479bdd451ab3b6f2124f0089493366315da79d3408e"
+install_package "node-v0.4.0" "https://nodejs.org/dist/v0.4.0/node-v0.4.0.tar.gz#4a30bd9963373cb86a994479bdd451ab3b6f2124f0089493366315da79d3408e" warn_eol

--- a/share/node-build/0.4.1
+++ b/share/node-build/0.4.1
@@ -1,1 +1,1 @@
-install_package "node-v0.4.1" "https://nodejs.org/dist/v0.4.1/node-v0.4.1.tar.gz#fdd61c479a0c9f30102454ee53d2ba0c5fc9f6d06d1073958ae2fd3fc314de23"
+install_package "node-v0.4.1" "https://nodejs.org/dist/v0.4.1/node-v0.4.1.tar.gz#fdd61c479a0c9f30102454ee53d2ba0c5fc9f6d06d1073958ae2fd3fc314de23" warn_eol

--- a/share/node-build/0.4.10
+++ b/share/node-build/0.4.10
@@ -1,1 +1,1 @@
-install_package "node-v0.4.10" "https://nodejs.org/dist/v0.4.10/node-v0.4.10.tar.gz#57fa7ed5a818308ff485bb1c1a8ec8f1eb6a7800e14201dff65d88ce657da50a"
+install_package "node-v0.4.10" "https://nodejs.org/dist/v0.4.10/node-v0.4.10.tar.gz#57fa7ed5a818308ff485bb1c1a8ec8f1eb6a7800e14201dff65d88ce657da50a" warn_eol

--- a/share/node-build/0.4.11
+++ b/share/node-build/0.4.11
@@ -1,1 +1,1 @@
-install_package "node-v0.4.11" "https://nodejs.org/dist/v0.4.11/node-v0.4.11.tar.gz#e009522d52c4a844c46e51c63b852899d1b7e6d949d1a139cdc16b4f6c4ab63f"
+install_package "node-v0.4.11" "https://nodejs.org/dist/v0.4.11/node-v0.4.11.tar.gz#e009522d52c4a844c46e51c63b852899d1b7e6d949d1a139cdc16b4f6c4ab63f" warn_eol

--- a/share/node-build/0.4.12
+++ b/share/node-build/0.4.12
@@ -1,1 +1,1 @@
-install_package "node-v0.4.12" "https://nodejs.org/dist/v0.4.12/node-v0.4.12.tar.gz#c01af05b933ad4d2ca39f63cac057f54f032a4d83cff8711e42650ccee24fce4"
+install_package "node-v0.4.12" "https://nodejs.org/dist/v0.4.12/node-v0.4.12.tar.gz#c01af05b933ad4d2ca39f63cac057f54f032a4d83cff8711e42650ccee24fce4" warn_eol

--- a/share/node-build/0.4.2
+++ b/share/node-build/0.4.2
@@ -1,1 +1,1 @@
-install_package "node-v0.4.2" "https://nodejs.org/dist/v0.4.2/node-v0.4.2.tar.gz#09b1100ca6828eedbe52418fbeb3352d71c0b1ff3344c44a5af3efb80c5b908c"
+install_package "node-v0.4.2" "https://nodejs.org/dist/v0.4.2/node-v0.4.2.tar.gz#09b1100ca6828eedbe52418fbeb3352d71c0b1ff3344c44a5af3efb80c5b908c" warn_eol

--- a/share/node-build/0.4.3
+++ b/share/node-build/0.4.3
@@ -1,1 +1,1 @@
-install_package "node-v0.4.3" "https://nodejs.org/dist/v0.4.3/node-v0.4.3.tar.gz#945cd6743336933bdd1843c28e6d4c896483c8ffc899555079c1eca7a69bd81c"
+install_package "node-v0.4.3" "https://nodejs.org/dist/v0.4.3/node-v0.4.3.tar.gz#945cd6743336933bdd1843c28e6d4c896483c8ffc899555079c1eca7a69bd81c" warn_eol

--- a/share/node-build/0.4.4
+++ b/share/node-build/0.4.4
@@ -1,1 +1,1 @@
-install_package "node-v0.4.4" "https://nodejs.org/dist/v0.4.4/node-v0.4.4.tar.gz#ea4430909601340cb3e8adb15569facfeca4e1d59129f1932254535bb4bf3e17"
+install_package "node-v0.4.4" "https://nodejs.org/dist/v0.4.4/node-v0.4.4.tar.gz#ea4430909601340cb3e8adb15569facfeca4e1d59129f1932254535bb4bf3e17" warn_eol

--- a/share/node-build/0.4.5
+++ b/share/node-build/0.4.5
@@ -1,1 +1,1 @@
-install_package "node-v0.4.5" "https://nodejs.org/dist/v0.4.5/node-v0.4.5.tar.gz#63fa6acd7dbf1ea816dc5fd64ba4d066f85380396571d29934b8b9141dc2a0ee"
+install_package "node-v0.4.5" "https://nodejs.org/dist/v0.4.5/node-v0.4.5.tar.gz#63fa6acd7dbf1ea816dc5fd64ba4d066f85380396571d29934b8b9141dc2a0ee" warn_eol

--- a/share/node-build/0.4.6
+++ b/share/node-build/0.4.6
@@ -1,1 +1,1 @@
-install_package "node-v0.4.6" "https://nodejs.org/dist/v0.4.6/node-v0.4.6.tar.gz#0f07823f1eb32a51351739763a73a66e2b8c80ed6e3e787a1f68eec255b481f6"
+install_package "node-v0.4.6" "https://nodejs.org/dist/v0.4.6/node-v0.4.6.tar.gz#0f07823f1eb32a51351739763a73a66e2b8c80ed6e3e787a1f68eec255b481f6" warn_eol

--- a/share/node-build/0.4.7
+++ b/share/node-build/0.4.7
@@ -1,1 +1,1 @@
-install_package "node-v0.4.7" "https://nodejs.org/dist/v0.4.7/node-v0.4.7.tar.gz#5c405ff85549ebff49ee06d4e4391f02ed65b2b1177dc0f617f727ab48593dee"
+install_package "node-v0.4.7" "https://nodejs.org/dist/v0.4.7/node-v0.4.7.tar.gz#5c405ff85549ebff49ee06d4e4391f02ed65b2b1177dc0f617f727ab48593dee" warn_eol

--- a/share/node-build/0.4.8
+++ b/share/node-build/0.4.8
@@ -1,1 +1,1 @@
-install_package "node-v0.4.8" "https://nodejs.org/dist/v0.4.8/node-v0.4.8.tar.gz#c72a0136a022581e9ca5d26fd4a9af277525204547bcf06276dbe6b66e1fa112"
+install_package "node-v0.4.8" "https://nodejs.org/dist/v0.4.8/node-v0.4.8.tar.gz#c72a0136a022581e9ca5d26fd4a9af277525204547bcf06276dbe6b66e1fa112" warn_eol

--- a/share/node-build/0.4.9
+++ b/share/node-build/0.4.9
@@ -1,1 +1,1 @@
-install_package "node-v0.4.9" "https://nodejs.org/dist/v0.4.9/node-v0.4.9.tar.gz#f231ea6d19ea9ea4c7f8e7ff5061e7d301f1635bec7ed0ff1eef2512576ea442"
+install_package "node-v0.4.9" "https://nodejs.org/dist/v0.4.9/node-v0.4.9.tar.gz#f231ea6d19ea9ea4c7f8e7ff5061e7d301f1635bec7ed0ff1eef2512576ea442" warn_eol

--- a/share/node-build/0.5.0
+++ b/share/node-build/0.5.0
@@ -1,1 +1,1 @@
-install_package "node-v0.5.0" "https://nodejs.org/dist/v0.5.0/node-v0.5.0.tar.gz#ac7e786f69343654dff091e1d5a85ee001f48b7b0fe145c0a0e14040b82978b9"
+install_package "node-v0.5.0" "https://nodejs.org/dist/v0.5.0/node-v0.5.0.tar.gz#ac7e786f69343654dff091e1d5a85ee001f48b7b0fe145c0a0e14040b82978b9" warn_eol

--- a/share/node-build/0.5.1
+++ b/share/node-build/0.5.1
@@ -1,1 +1,1 @@
-install_package "node-v0.5.1" "https://nodejs.org/dist/v0.5.1/node-v0.5.1.tar.gz#a788469bbfd52ba56f1fa76ff28f796aff8aec9ce1cd92aca62853e72d187839"
+install_package "node-v0.5.1" "https://nodejs.org/dist/v0.5.1/node-v0.5.1.tar.gz#a788469bbfd52ba56f1fa76ff28f796aff8aec9ce1cd92aca62853e72d187839" warn_eol

--- a/share/node-build/0.5.10
+++ b/share/node-build/0.5.10
@@ -1,1 +1,1 @@
-install_package "node-v0.5.10" "https://nodejs.org/dist/v0.5.10/node-v0.5.10.tar.gz#56396854f85a0d2fafc038436be3d84041f991f59613761e61295fc02d662a40"
+install_package "node-v0.5.10" "https://nodejs.org/dist/v0.5.10/node-v0.5.10.tar.gz#56396854f85a0d2fafc038436be3d84041f991f59613761e61295fc02d662a40" warn_eol

--- a/share/node-build/0.5.2
+++ b/share/node-build/0.5.2
@@ -1,1 +1,1 @@
-install_package "node-v0.5.2" "https://nodejs.org/dist/v0.5.2/node-v0.5.2.tar.gz#198f9109bf22a9f8d88cf0b696bd36fc897dfa6b655f30102d7cc55bf033e19b"
+install_package "node-v0.5.2" "https://nodejs.org/dist/v0.5.2/node-v0.5.2.tar.gz#198f9109bf22a9f8d88cf0b696bd36fc897dfa6b655f30102d7cc55bf033e19b" warn_eol

--- a/share/node-build/0.5.3
+++ b/share/node-build/0.5.3
@@ -1,1 +1,1 @@
-install_package "node-v0.5.3" "https://nodejs.org/dist/v0.5.3/node-v0.5.3.tar.gz#27e5a488040e59e192b3db6675c5f0b6b00cccdd53f1a7cdf98b6477220fbb1e"
+install_package "node-v0.5.3" "https://nodejs.org/dist/v0.5.3/node-v0.5.3.tar.gz#27e5a488040e59e192b3db6675c5f0b6b00cccdd53f1a7cdf98b6477220fbb1e" warn_eol

--- a/share/node-build/0.5.4
+++ b/share/node-build/0.5.4
@@ -1,1 +1,1 @@
-install_package "node-v0.5.4" "https://nodejs.org/dist/v0.5.4/node-v0.5.4.tar.gz#d32d3af4e3286b383640df857d76c2fcca1a2e2cb85abb484483a0a49d09ae71"
+install_package "node-v0.5.4" "https://nodejs.org/dist/v0.5.4/node-v0.5.4.tar.gz#d32d3af4e3286b383640df857d76c2fcca1a2e2cb85abb484483a0a49d09ae71" warn_eol

--- a/share/node-build/0.5.5
+++ b/share/node-build/0.5.5
@@ -1,1 +1,1 @@
-install_package "node-v0.5.5" "https://nodejs.org/dist/v0.5.5/node-v0.5.5.tar.gz#6f7ef8859e43545ff9a0e178e39a070f22c6a2abcf46b2cae079f446b5750e65"
+install_package "node-v0.5.5" "https://nodejs.org/dist/v0.5.5/node-v0.5.5.tar.gz#6f7ef8859e43545ff9a0e178e39a070f22c6a2abcf46b2cae079f446b5750e65" warn_eol

--- a/share/node-build/0.5.6
+++ b/share/node-build/0.5.6
@@ -1,1 +1,1 @@
-install_package "node-v0.5.6" "https://nodejs.org/dist/v0.5.6/node-v0.5.6.tar.gz#f9745ab3b19be29d3ddf40c40cec6d4c4685ae94d9943389d6b67178f11ecd9b"
+install_package "node-v0.5.6" "https://nodejs.org/dist/v0.5.6/node-v0.5.6.tar.gz#f9745ab3b19be29d3ddf40c40cec6d4c4685ae94d9943389d6b67178f11ecd9b" warn_eol

--- a/share/node-build/0.5.7
+++ b/share/node-build/0.5.7
@@ -1,1 +1,1 @@
-install_package "node-v0.5.7" "https://nodejs.org/dist/v0.5.7/node-v0.5.7.tar.gz#bd5c1f8029517bd8070001e3099a2330bcea696fcf1855b6c857b6fb58e676c6"
+install_package "node-v0.5.7" "https://nodejs.org/dist/v0.5.7/node-v0.5.7.tar.gz#bd5c1f8029517bd8070001e3099a2330bcea696fcf1855b6c857b6fb58e676c6" warn_eol

--- a/share/node-build/0.5.8
+++ b/share/node-build/0.5.8
@@ -1,1 +1,1 @@
-install_package "node-v0.5.8" "https://nodejs.org/dist/v0.5.8/node-v0.5.8.tar.gz#e15214605c473d14cf73ebac4df1c8ff54d88f405b20b473bda719728e217fd2"
+install_package "node-v0.5.8" "https://nodejs.org/dist/v0.5.8/node-v0.5.8.tar.gz#e15214605c473d14cf73ebac4df1c8ff54d88f405b20b473bda719728e217fd2" warn_eol

--- a/share/node-build/0.5.9
+++ b/share/node-build/0.5.9
@@ -1,1 +1,1 @@
-install_package "node-v0.5.9" "https://nodejs.org/dist/v0.5.9/node-v0.5.9.tar.gz#5659cde8b36cf5c29433e73a351b0bacfac16be1b0b47e64ea138fe270b5607f"
+install_package "node-v0.5.9" "https://nodejs.org/dist/v0.5.9/node-v0.5.9.tar.gz#5659cde8b36cf5c29433e73a351b0bacfac16be1b0b47e64ea138fe270b5607f" warn_eol

--- a/share/node-build/0.6.0
+++ b/share/node-build/0.6.0
@@ -1,1 +1,1 @@
-install_package "node-v0.6.0" "https://nodejs.org/dist/v0.6.0/node-v0.6.0.tar.gz#1b6a34b6f2099145c44a0c20d3a5cab7c9ec063de1a195ddeda61ad55d601d7f"
+install_package "node-v0.6.0" "https://nodejs.org/dist/v0.6.0/node-v0.6.0.tar.gz#1b6a34b6f2099145c44a0c20d3a5cab7c9ec063de1a195ddeda61ad55d601d7f" warn_eol

--- a/share/node-build/0.6.1
+++ b/share/node-build/0.6.1
@@ -1,1 +1,1 @@
-install_package "node-v0.6.1" "https://nodejs.org/dist/v0.6.1/node-v0.6.1.tar.gz#b161050ed8cdb2d45f601181d146821e5535a8fcbf5978b2ff064e5476a8e606"
+install_package "node-v0.6.1" "https://nodejs.org/dist/v0.6.1/node-v0.6.1.tar.gz#b161050ed8cdb2d45f601181d146821e5535a8fcbf5978b2ff064e5476a8e606" warn_eol

--- a/share/node-build/0.6.10
+++ b/share/node-build/0.6.10
@@ -1,1 +1,1 @@
-install_package "node-v0.6.10" "https://nodejs.org/dist/v0.6.10/node-v0.6.10.tar.gz#d1d060ab53c6079409403530009a2095036f19920aabd3a1c20542e0db586bd5"
+install_package "node-v0.6.10" "https://nodejs.org/dist/v0.6.10/node-v0.6.10.tar.gz#d1d060ab53c6079409403530009a2095036f19920aabd3a1c20542e0db586bd5" warn_eol

--- a/share/node-build/0.6.11
+++ b/share/node-build/0.6.11
@@ -1,1 +1,1 @@
-install_package "node-v0.6.11" "https://nodejs.org/dist/v0.6.11/node-v0.6.11.tar.gz#94bbdb2d62645fd2ad5b96e41cfec68abf004fd03fabaaf7d71c48b39013cbd1"
+install_package "node-v0.6.11" "https://nodejs.org/dist/v0.6.11/node-v0.6.11.tar.gz#94bbdb2d62645fd2ad5b96e41cfec68abf004fd03fabaaf7d71c48b39013cbd1" warn_eol

--- a/share/node-build/0.6.12
+++ b/share/node-build/0.6.12
@@ -1,1 +1,1 @@
-install_package "node-v0.6.12" "https://nodejs.org/dist/v0.6.12/node-v0.6.12.tar.gz#a16392fb83b288bd40cb64593253756a44f8111478edf5e8cc439a64622281c4"
+install_package "node-v0.6.12" "https://nodejs.org/dist/v0.6.12/node-v0.6.12.tar.gz#a16392fb83b288bd40cb64593253756a44f8111478edf5e8cc439a64622281c4" warn_eol

--- a/share/node-build/0.6.13
+++ b/share/node-build/0.6.13
@@ -1,1 +1,1 @@
-install_package "node-v0.6.13" "https://nodejs.org/dist/v0.6.13/node-v0.6.13.tar.gz#fc4f3ceacfd2cfc4ec75fc59d97f1f2d04947efd5e191efaddeb552df486245b"
+install_package "node-v0.6.13" "https://nodejs.org/dist/v0.6.13/node-v0.6.13.tar.gz#fc4f3ceacfd2cfc4ec75fc59d97f1f2d04947efd5e191efaddeb552df486245b" warn_eol

--- a/share/node-build/0.6.14
+++ b/share/node-build/0.6.14
@@ -1,1 +1,1 @@
-install_package "node-v0.6.14" "https://nodejs.org/dist/v0.6.14/node-v0.6.14.tar.gz#e41922308155c5197c2d048948ca9cd76ea5f9a51f977e1591bd93fe17d4cf1f"
+install_package "node-v0.6.14" "https://nodejs.org/dist/v0.6.14/node-v0.6.14.tar.gz#e41922308155c5197c2d048948ca9cd76ea5f9a51f977e1591bd93fe17d4cf1f" warn_eol

--- a/share/node-build/0.6.15
+++ b/share/node-build/0.6.15
@@ -1,1 +1,1 @@
-install_package "node-v0.6.15" "https://nodejs.org/dist/v0.6.15/node-v0.6.15.tar.gz#78859a1a31c8e7a64d0efa040326d93c6624cc344d39b2e47e14e9c4dc3136e0"
+install_package "node-v0.6.15" "https://nodejs.org/dist/v0.6.15/node-v0.6.15.tar.gz#78859a1a31c8e7a64d0efa040326d93c6624cc344d39b2e47e14e9c4dc3136e0" warn_eol

--- a/share/node-build/0.6.16
+++ b/share/node-build/0.6.16
@@ -1,1 +1,1 @@
-install_package "node-v0.6.16" "https://nodejs.org/dist/v0.6.16/node-v0.6.16.tar.gz#21d9cccaa642794db69619d813adf00b3533080a8928370c2b1a4b3a6478eaa7"
+install_package "node-v0.6.16" "https://nodejs.org/dist/v0.6.16/node-v0.6.16.tar.gz#21d9cccaa642794db69619d813adf00b3533080a8928370c2b1a4b3a6478eaa7" warn_eol

--- a/share/node-build/0.6.17
+++ b/share/node-build/0.6.17
@@ -1,1 +1,1 @@
-install_package "node-v0.6.17" "https://nodejs.org/dist/v0.6.17/node-v0.6.17.tar.gz#8dfe5948de27e37a14af184f06e7bd89a23c3b248af44c8ef5cffcd0e4c65778"
+install_package "node-v0.6.17" "https://nodejs.org/dist/v0.6.17/node-v0.6.17.tar.gz#8dfe5948de27e37a14af184f06e7bd89a23c3b248af44c8ef5cffcd0e4c65778" warn_eol

--- a/share/node-build/0.6.18
+++ b/share/node-build/0.6.18
@@ -1,1 +1,1 @@
-install_package "node-v0.6.18" "https://nodejs.org/dist/v0.6.18/node-v0.6.18.tar.gz#6cf4311ecbc1700e88f4382a31b3a7017c1572cd641fd06e653fc1692c2cffff"
+install_package "node-v0.6.18" "https://nodejs.org/dist/v0.6.18/node-v0.6.18.tar.gz#6cf4311ecbc1700e88f4382a31b3a7017c1572cd641fd06e653fc1692c2cffff" warn_eol

--- a/share/node-build/0.6.19
+++ b/share/node-build/0.6.19
@@ -1,1 +1,1 @@
-install_package "node-v0.6.19" "https://nodejs.org/dist/v0.6.19/node-v0.6.19.tar.gz#4e33292477b01dfcf50bc628d580fd5af3e5ff807490ec46472b84100fb52fbb"
+install_package "node-v0.6.19" "https://nodejs.org/dist/v0.6.19/node-v0.6.19.tar.gz#4e33292477b01dfcf50bc628d580fd5af3e5ff807490ec46472b84100fb52fbb" warn_eol

--- a/share/node-build/0.6.2
+++ b/share/node-build/0.6.2
@@ -1,1 +1,1 @@
-install_package "node-v0.6.2" "https://nodejs.org/dist/v0.6.2/node-v0.6.2.tar.gz#3a24f6f91bb806a230a7b200ca638459a9680ea2daf9a427098c61f847016139"
+install_package "node-v0.6.2" "https://nodejs.org/dist/v0.6.2/node-v0.6.2.tar.gz#3a24f6f91bb806a230a7b200ca638459a9680ea2daf9a427098c61f847016139" warn_eol

--- a/share/node-build/0.6.20
+++ b/share/node-build/0.6.20
@@ -1,1 +1,1 @@
-install_package "node-v0.6.20" "https://nodejs.org/dist/v0.6.20/node-v0.6.20.tar.gz#b7bf4cf143ddf46ba5e975761b98a38dd3d72b176fd5d4bb2f9c9e7bbe6c4b15"
+install_package "node-v0.6.20" "https://nodejs.org/dist/v0.6.20/node-v0.6.20.tar.gz#b7bf4cf143ddf46ba5e975761b98a38dd3d72b176fd5d4bb2f9c9e7bbe6c4b15" warn_eol

--- a/share/node-build/0.6.21
+++ b/share/node-build/0.6.21
@@ -1,1 +1,1 @@
-install_package "node-v0.6.21" "https://nodejs.org/dist/v0.6.21/node-v0.6.21.tar.gz#22265fd07e09c22f1d058156d548e7398c9740210f534e2f848eeab5b9772117"
+install_package "node-v0.6.21" "https://nodejs.org/dist/v0.6.21/node-v0.6.21.tar.gz#22265fd07e09c22f1d058156d548e7398c9740210f534e2f848eeab5b9772117" warn_eol

--- a/share/node-build/0.6.3
+++ b/share/node-build/0.6.3
@@ -1,1 +1,1 @@
-install_package "node-v0.6.3" "https://nodejs.org/dist/v0.6.3/node-v0.6.3.tar.gz#fe5642d26d04cc7e7d47daa426da2a79e244bdcbae1594a12578f0d6fe03082e"
+install_package "node-v0.6.3" "https://nodejs.org/dist/v0.6.3/node-v0.6.3.tar.gz#fe5642d26d04cc7e7d47daa426da2a79e244bdcbae1594a12578f0d6fe03082e" warn_eol

--- a/share/node-build/0.6.4
+++ b/share/node-build/0.6.4
@@ -1,1 +1,1 @@
-install_package "node-v0.6.4" "https://nodejs.org/dist/v0.6.4/node-v0.6.4.tar.gz#67b029f0da10ffa706cda23d6a3bb7c682ca589cd7f6647a578dcfb74a78f916"
+install_package "node-v0.6.4" "https://nodejs.org/dist/v0.6.4/node-v0.6.4.tar.gz#67b029f0da10ffa706cda23d6a3bb7c682ca589cd7f6647a578dcfb74a78f916" warn_eol

--- a/share/node-build/0.6.5
+++ b/share/node-build/0.6.5
@@ -1,1 +1,1 @@
-install_package "node-v0.6.5" "https://nodejs.org/dist/v0.6.5/node-v0.6.5.tar.gz#72364d240fb61e678897c099df6f2913857c5931aa9b1f44e73e432d4629ca2f"
+install_package "node-v0.6.5" "https://nodejs.org/dist/v0.6.5/node-v0.6.5.tar.gz#72364d240fb61e678897c099df6f2913857c5931aa9b1f44e73e432d4629ca2f" warn_eol

--- a/share/node-build/0.6.6
+++ b/share/node-build/0.6.6
@@ -1,1 +1,1 @@
-install_package "node-v0.6.6" "https://nodejs.org/dist/v0.6.6/node-v0.6.6.tar.gz#7abea518b1b63fd669c9ca436bf33d0bb0b09b252f06d700ccbd290fe5222102"
+install_package "node-v0.6.6" "https://nodejs.org/dist/v0.6.6/node-v0.6.6.tar.gz#7abea518b1b63fd669c9ca436bf33d0bb0b09b252f06d700ccbd290fe5222102" warn_eol

--- a/share/node-build/0.6.7
+++ b/share/node-build/0.6.7
@@ -1,1 +1,1 @@
-install_package "node-v0.6.7" "https://nodejs.org/dist/v0.6.7/node-v0.6.7.tar.gz#b34387449723352d2f5b7a51d8c1358c247908a5f7acd7849cac45f980246d54"
+install_package "node-v0.6.7" "https://nodejs.org/dist/v0.6.7/node-v0.6.7.tar.gz#b34387449723352d2f5b7a51d8c1358c247908a5f7acd7849cac45f980246d54" warn_eol

--- a/share/node-build/0.6.8
+++ b/share/node-build/0.6.8
@@ -1,1 +1,1 @@
-install_package "node-v0.6.8" "https://nodejs.org/dist/v0.6.8/node-v0.6.8.tar.gz#e6cbfc5ccdbe10128dbbd4dc7a88c154d80f8a39c3a8477092cf7d25eef78c9c"
+install_package "node-v0.6.8" "https://nodejs.org/dist/v0.6.8/node-v0.6.8.tar.gz#e6cbfc5ccdbe10128dbbd4dc7a88c154d80f8a39c3a8477092cf7d25eef78c9c" warn_eol

--- a/share/node-build/0.6.9
+++ b/share/node-build/0.6.9
@@ -1,1 +1,1 @@
-install_package "node-v0.6.9" "https://nodejs.org/dist/v0.6.9/node-v0.6.9.tar.gz#484ab6b3da6195339544c16aff17f747aa85d1dd15d765d6724aa8a4ecda03ca"
+install_package "node-v0.6.9" "https://nodejs.org/dist/v0.6.9/node-v0.6.9.tar.gz#484ab6b3da6195339544c16aff17f747aa85d1dd15d765d6724aa8a4ecda03ca" warn_eol

--- a/share/node-build/0.7.0
+++ b/share/node-build/0.7.0
@@ -1,1 +1,1 @@
-install_package "node-v0.7.0" "https://nodejs.org/dist/v0.7.0/node-v0.7.0.tar.gz#0c716d7c61f77c53b0383e82da3f3ca8a4187f7d1c9831aec95efe7cfda9cafb"
+install_package "node-v0.7.0" "https://nodejs.org/dist/v0.7.0/node-v0.7.0.tar.gz#0c716d7c61f77c53b0383e82da3f3ca8a4187f7d1c9831aec95efe7cfda9cafb" warn_eol

--- a/share/node-build/0.7.1
+++ b/share/node-build/0.7.1
@@ -1,1 +1,1 @@
-install_package "node-v0.7.1" "https://nodejs.org/dist/v0.7.1/node-v0.7.1.tar.gz#903224a2c9e4510b2281d0fa72cbd930b6dfb97a750e6d02bd12442a5aa30032"
+install_package "node-v0.7.1" "https://nodejs.org/dist/v0.7.1/node-v0.7.1.tar.gz#903224a2c9e4510b2281d0fa72cbd930b6dfb97a750e6d02bd12442a5aa30032" warn_eol

--- a/share/node-build/0.7.10
+++ b/share/node-build/0.7.10
@@ -1,1 +1,1 @@
-install_package "node-v0.7.10" "https://nodejs.org/dist/v0.7.10/node-v0.7.10.tar.gz#9094dcd47dba984b6c2ca89a5361bd6664d1990edf41419f9a8a6d26ae774c6e"
+install_package "node-v0.7.10" "https://nodejs.org/dist/v0.7.10/node-v0.7.10.tar.gz#9094dcd47dba984b6c2ca89a5361bd6664d1990edf41419f9a8a6d26ae774c6e" warn_eol

--- a/share/node-build/0.7.11
+++ b/share/node-build/0.7.11
@@ -1,1 +1,1 @@
-install_package "node-v0.7.11" "https://nodejs.org/dist/v0.7.11/node-v0.7.11.tar.gz#add0db06f628ed8330b1a3450efa39f18d08c5a54d5827004c76ae23522ca842"
+install_package "node-v0.7.11" "https://nodejs.org/dist/v0.7.11/node-v0.7.11.tar.gz#add0db06f628ed8330b1a3450efa39f18d08c5a54d5827004c76ae23522ca842" warn_eol

--- a/share/node-build/0.7.12
+++ b/share/node-build/0.7.12
@@ -1,1 +1,1 @@
-install_package "node-v0.7.12" "https://nodejs.org/dist/v0.7.12/node-v0.7.12.tar.gz#e0be9f001467e2a9e728d53969a3c7f079da4af1ff896155822479ad92b3efbe"
+install_package "node-v0.7.12" "https://nodejs.org/dist/v0.7.12/node-v0.7.12.tar.gz#e0be9f001467e2a9e728d53969a3c7f079da4af1ff896155822479ad92b3efbe" warn_eol

--- a/share/node-build/0.7.2
+++ b/share/node-build/0.7.2
@@ -1,1 +1,1 @@
-install_package "node-v0.7.2" "https://nodejs.org/dist/v0.7.2/node-v0.7.2.tar.gz#de0bff9067f4cd63c4bd5fb847352725b86122eac7483aa88b764eb8272807a3"
+install_package "node-v0.7.2" "https://nodejs.org/dist/v0.7.2/node-v0.7.2.tar.gz#de0bff9067f4cd63c4bd5fb847352725b86122eac7483aa88b764eb8272807a3" warn_eol

--- a/share/node-build/0.7.3
+++ b/share/node-build/0.7.3
@@ -1,1 +1,1 @@
-install_package "node-v0.7.3" "https://nodejs.org/dist/v0.7.3/node-v0.7.3.tar.gz#292204f73b4007fecf7aa9d065a0360abc43a1fc007ea1138cf4fa8d553cca58"
+install_package "node-v0.7.3" "https://nodejs.org/dist/v0.7.3/node-v0.7.3.tar.gz#292204f73b4007fecf7aa9d065a0360abc43a1fc007ea1138cf4fa8d553cca58" warn_eol

--- a/share/node-build/0.7.4
+++ b/share/node-build/0.7.4
@@ -1,1 +1,1 @@
-install_package "node-v0.7.4" "https://nodejs.org/dist/v0.7.4/node-v0.7.4.tar.gz#14bd37525dab52d28271211002fe102ebbcc9afa01064f93d9945d66e3989660"
+install_package "node-v0.7.4" "https://nodejs.org/dist/v0.7.4/node-v0.7.4.tar.gz#14bd37525dab52d28271211002fe102ebbcc9afa01064f93d9945d66e3989660" warn_eol

--- a/share/node-build/0.7.5
+++ b/share/node-build/0.7.5
@@ -1,1 +1,1 @@
-install_package "node-v0.7.5" "https://nodejs.org/dist/v0.7.5/node-v0.7.5.tar.gz#f855ba273ea8d4b036f811008dc205e0070358584185dbc79abd09ffcb99d12b"
+install_package "node-v0.7.5" "https://nodejs.org/dist/v0.7.5/node-v0.7.5.tar.gz#f855ba273ea8d4b036f811008dc205e0070358584185dbc79abd09ffcb99d12b" warn_eol

--- a/share/node-build/0.7.6
+++ b/share/node-build/0.7.6
@@ -1,1 +1,1 @@
-install_package "node-v0.7.6" "https://nodejs.org/dist/v0.7.6/node-v0.7.6.tar.gz#ce1772b7b649121a04dbb36c94e4e4d8850a109d07746cff6bab5c4d1ed38e1c"
+install_package "node-v0.7.6" "https://nodejs.org/dist/v0.7.6/node-v0.7.6.tar.gz#ce1772b7b649121a04dbb36c94e4e4d8850a109d07746cff6bab5c4d1ed38e1c" warn_eol

--- a/share/node-build/0.7.7
+++ b/share/node-build/0.7.7
@@ -1,1 +1,1 @@
-install_package "node-v0.7.7" "https://nodejs.org/dist/v0.7.7/node-v0.7.7.tar.gz#40d67cdaba5fdef522fc49e31220ffc3278c90cb5ca1dc5dbb6e43cbc938f8d1"
+install_package "node-v0.7.7" "https://nodejs.org/dist/v0.7.7/node-v0.7.7.tar.gz#40d67cdaba5fdef522fc49e31220ffc3278c90cb5ca1dc5dbb6e43cbc938f8d1" warn_eol

--- a/share/node-build/0.7.8
+++ b/share/node-build/0.7.8
@@ -1,1 +1,1 @@
-install_package "node-v0.7.8" "https://nodejs.org/dist/v0.7.8/node-v0.7.8.tar.gz#59722d4a71c26963a8bbd31aadc64aeff2c0a2902fb4d9542d161f458487355e"
+install_package "node-v0.7.8" "https://nodejs.org/dist/v0.7.8/node-v0.7.8.tar.gz#59722d4a71c26963a8bbd31aadc64aeff2c0a2902fb4d9542d161f458487355e" warn_eol

--- a/share/node-build/0.7.9
+++ b/share/node-build/0.7.9
@@ -1,1 +1,1 @@
-install_package "node-v0.7.9" "https://nodejs.org/dist/v0.7.9/node-v0.7.9.tar.gz#0a94de8743420c0a664b3bc9bec876098e4035b5079a4b2b4e3e3dc1acc9f926"
+install_package "node-v0.7.9" "https://nodejs.org/dist/v0.7.9/node-v0.7.9.tar.gz#0a94de8743420c0a664b3bc9bec876098e4035b5079a4b2b4e3e3dc1acc9f926" warn_eol

--- a/share/node-build/0.8.0
+++ b/share/node-build/0.8.0
@@ -1,1 +1,1 @@
-install_package "node-v0.8.0" "https://nodejs.org/dist/v0.8.0/node-v0.8.0.tar.gz#ecafca018b5109a28537633d0433d513f68b1bae7191a1821e8eaa84ccf128ee"
+install_package "node-v0.8.0" "https://nodejs.org/dist/v0.8.0/node-v0.8.0.tar.gz#ecafca018b5109a28537633d0433d513f68b1bae7191a1821e8eaa84ccf128ee" warn_eol

--- a/share/node-build/0.8.1
+++ b/share/node-build/0.8.1
@@ -1,1 +1,1 @@
-install_package "node-v0.8.1" "https://nodejs.org/dist/v0.8.1/node-v0.8.1.tar.gz#0cda1325a010ce18f68501ae68e0ce97f0094e7a282c34a451f552621643a884"
+install_package "node-v0.8.1" "https://nodejs.org/dist/v0.8.1/node-v0.8.1.tar.gz#0cda1325a010ce18f68501ae68e0ce97f0094e7a282c34a451f552621643a884" warn_eol

--- a/share/node-build/0.8.10
+++ b/share/node-build/0.8.10
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.10/node-v0.8.10-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.10/node-v0.8.10-sunos-x64.tar.gz#15d6adf4d457a820ef62d07e52a00b42d8ce23a59cc55a54a3cc564e86f5c56a"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.10/node-v0.8.10-sunos-x86.tar.gz#1efe7482197330c59067a9646d67c0af3fa638ccec32cd3d3c71ecc6729511f2"
 
-install_package "node-v0.8.10" "https://nodejs.org/dist/v0.8.10/node-v0.8.10.tar.gz#ce495ab8fee58b4df49d46be2b08fabdd2fcb3880982aedda8e88751e2a2011b"
+install_package "node-v0.8.10" "https://nodejs.org/dist/v0.8.10/node-v0.8.10.tar.gz#ce495ab8fee58b4df49d46be2b08fabdd2fcb3880982aedda8e88751e2a2011b" warn_eol

--- a/share/node-build/0.8.11
+++ b/share/node-build/0.8.11
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.11/node-v0.8.11-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.11/node-v0.8.11-sunos-x64.tar.gz#9633b53df777c6b5a41dc3e6c106c51f20fbe151c793d82c80c93ca17ccc6975"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.11/node-v0.8.11-sunos-x86.tar.gz#038d1b1774bdd9c260c5967380bd89df3145a7aeb190effd681ae2091f9e1676"
 
-install_package "node-v0.8.11" "https://nodejs.org/dist/v0.8.11/node-v0.8.11.tar.gz#e9594460f992b5862e21fb4d8ef27907839254c646b4ed5e8ab1ec25b4ccd29d"
+install_package "node-v0.8.11" "https://nodejs.org/dist/v0.8.11/node-v0.8.11.tar.gz#e9594460f992b5862e21fb4d8ef27907839254c646b4ed5e8ab1ec25b4ccd29d" warn_eol

--- a/share/node-build/0.8.12
+++ b/share/node-build/0.8.12
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.12/node-v0.8.12-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.12/node-v0.8.12-sunos-x64.tar.gz#94f9cc5425094f2103f1324e3dbe6d277bdc0dab1171a4be4f90466958df324e"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.12/node-v0.8.12-sunos-x86.tar.gz#f2b5e658fbcd5df94d36b75b9b8fb8c1929adb4a79015ebcdab7e1e494da7264"
 
-install_package "node-v0.8.12" "https://nodejs.org/dist/v0.8.12/node-v0.8.12.tar.gz#d64a7f2ab8f4419a11bde5379d6065666fd1cc4593ec828cb5ac57385efafa45"
+install_package "node-v0.8.12" "https://nodejs.org/dist/v0.8.12/node-v0.8.12.tar.gz#d64a7f2ab8f4419a11bde5379d6065666fd1cc4593ec828cb5ac57385efafa45" warn_eol

--- a/share/node-build/0.8.13
+++ b/share/node-build/0.8.13
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.13/node-v0.8.13-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.13/node-v0.8.13-sunos-x64.tar.gz#e0563da18e7b127e040e2f356a51db38816e3b3a71d50f6735946d2c4646ad7b"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.13/node-v0.8.13-sunos-x86.tar.gz#b070262e2ce8d0f2eedcae8632e512f2fafca31f5eb51a8994a8b58ef65e8083"
 
-install_package "node-v0.8.13" "https://nodejs.org/dist/v0.8.13/node-v0.8.13.tar.gz#4d85486079aed1749b8bd77899cb728820325384881c874cf78480696f3d8c8c"
+install_package "node-v0.8.13" "https://nodejs.org/dist/v0.8.13/node-v0.8.13.tar.gz#4d85486079aed1749b8bd77899cb728820325384881c874cf78480696f3d8c8c" warn_eol

--- a/share/node-build/0.8.14
+++ b/share/node-build/0.8.14
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.14/node-v0.8.14-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.14/node-v0.8.14-sunos-x64.tar.gz#bd24375f0064abb29a48b7f0975bd719c4175cc4ae8fb47cace2d26db352f35d"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.14/node-v0.8.14-sunos-x86.tar.gz#76b110657c0bdc9b75d85efc259f0df390c854e885a093213674fdca8d92edc5"
 
-install_package "node-v0.8.14" "https://nodejs.org/dist/v0.8.14/node-v0.8.14.tar.gz#e5ce2aadb4df3ea4ca7a021106ffe09d286474476454038e9ed0135eac18e6d0"
+install_package "node-v0.8.14" "https://nodejs.org/dist/v0.8.14/node-v0.8.14.tar.gz#e5ce2aadb4df3ea4ca7a021106ffe09d286474476454038e9ed0135eac18e6d0" warn_eol

--- a/share/node-build/0.8.15
+++ b/share/node-build/0.8.15
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.15/node-v0.8.15-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.15/node-v0.8.15-sunos-x64.tar.gz#fa0e1bf5cbd46c5ff476e88d1fbee571ab96b038cee9eb38f703da5b45c60a6a"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.15/node-v0.8.15-sunos-x86.tar.gz#bb51410611a8c97998c4e587e75aa6ef6746236ef45454fa3b9c42a05fa8a649"
 
-install_package "node-v0.8.15" "https://nodejs.org/dist/v0.8.15/node-v0.8.15.tar.gz#1758639c6df3e081fe26585472d0f1961c5703b44ba6c57ecdf66a4c015792b1"
+install_package "node-v0.8.15" "https://nodejs.org/dist/v0.8.15/node-v0.8.15.tar.gz#1758639c6df3e081fe26585472d0f1961c5703b44ba6c57ecdf66a4c015792b1" warn_eol

--- a/share/node-build/0.8.16
+++ b/share/node-build/0.8.16
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.16/node-v0.8.16-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.16/node-v0.8.16-sunos-x64.tar.gz#832a394c1cfbbd67be7f397a229561c17bec28df65d00716d767e835ba9cae28"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.16/node-v0.8.16-sunos-x86.tar.gz#37a3e1f9b9e2f77eb23681792be1ac65b80455f4a5dbf710a7722ac2efb804d0"
 
-install_package "node-v0.8.16" "https://nodejs.org/dist/v0.8.16/node-v0.8.16.tar.gz#2cd09d4227c787d6886be45dc54dad5aed779d7bd4b1e15ba930101d9d1ed2a4"
+install_package "node-v0.8.16" "https://nodejs.org/dist/v0.8.16/node-v0.8.16.tar.gz#2cd09d4227c787d6886be45dc54dad5aed779d7bd4b1e15ba930101d9d1ed2a4" warn_eol

--- a/share/node-build/0.8.17
+++ b/share/node-build/0.8.17
@@ -6,4 +6,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.17/node-v0.8.17-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.17/node-v0.8.17-sunos-x64.tar.gz#9bf6565ffbcf47b1e2f328b73bac0748659e5ed0b94b07dd8462c232af2cc91b"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.17/node-v0.8.17-sunos-x86.tar.gz#ddf05292902728bec9494fe0ce460cbb182e0638aebf5bc9d28d929e7c78d87d"
 
-install_package "node-v0.8.17" "https://nodejs.org/dist/v0.8.17/node-v0.8.17.tar.gz#8f070b42ffb84fde9d3ed2f802b08664b94dda327a36bf08a80c8b7efcf8b29e"
+install_package "node-v0.8.17" "https://nodejs.org/dist/v0.8.17/node-v0.8.17.tar.gz#8f070b42ffb84fde9d3ed2f802b08664b94dda327a36bf08a80c8b7efcf8b29e" warn_eol

--- a/share/node-build/0.8.18
+++ b/share/node-build/0.8.18
@@ -6,4 +6,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.18/node-v0.8.18-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.18/node-v0.8.18-sunos-x64.tar.gz#7c36db277ce3f7dd59dc9cc792f16f02266d9dfdcd22b3658370e425ebe95080"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.18/node-v0.8.18-sunos-x86.tar.gz#306263031eeff00ded073b08f5344831b572034ab0d3a98af01a5f46c614411b"
 
-install_package "node-v0.8.18" "https://nodejs.org/dist/v0.8.18/node-v0.8.18.tar.gz#1d63dd42f9bd22f087585ddf80a881c6acbe1664891b1dda3b71306fe9ae00f9"
+install_package "node-v0.8.18" "https://nodejs.org/dist/v0.8.18/node-v0.8.18.tar.gz#1d63dd42f9bd22f087585ddf80a881c6acbe1664891b1dda3b71306fe9ae00f9" warn_eol

--- a/share/node-build/0.8.19
+++ b/share/node-build/0.8.19
@@ -6,4 +6,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.19/node-v0.8.19-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.19/node-v0.8.19-sunos-x64.tar.gz#fb32343c8bafbd7698db5db2f2b103769e2ef2eccc20586000d8c3ccb8a9fdbc"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.19/node-v0.8.19-sunos-x86.tar.gz#d296d478ad60114d6f26848c63881d98e24a5c499695805d17e70368d8678f6e"
 
-install_package "node-v0.8.19" "https://nodejs.org/dist/v0.8.19/node-v0.8.19.tar.gz#703207d7b394bd3d4035dc3c94b417ee441fd3ea66aa90cd3d7c9bb28e5f9df4"
+install_package "node-v0.8.19" "https://nodejs.org/dist/v0.8.19/node-v0.8.19.tar.gz#703207d7b394bd3d4035dc3c94b417ee441fd3ea66aa90cd3d7c9bb28e5f9df4" warn_eol

--- a/share/node-build/0.8.2
+++ b/share/node-build/0.8.2
@@ -1,1 +1,1 @@
-install_package "node-v0.8.2" "https://nodejs.org/dist/v0.8.2/node-v0.8.2.tar.gz#6830ed4eaf6c191243fb3afbe3ca3283d7e3a537c8f3ce508fa2af1328fe4baf"
+install_package "node-v0.8.2" "https://nodejs.org/dist/v0.8.2/node-v0.8.2.tar.gz#6830ed4eaf6c191243fb3afbe3ca3283d7e3a537c8f3ce508fa2af1328fe4baf" warn_eol

--- a/share/node-build/0.8.20
+++ b/share/node-build/0.8.20
@@ -6,4 +6,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.20/node-v0.8.20-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.20/node-v0.8.20-sunos-x64.tar.gz#73e8c9951ab6cc4641eadf2bdfffa5f8c8b2efe21fef2ac915f41e4e4915c8af"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.20/node-v0.8.20-sunos-x86.tar.gz#3595c38edcd478d9d728fa152022511420d3864a89234b79a5b64d7ec3924598"
 
-install_package "node-v0.8.20" "https://nodejs.org/dist/v0.8.20/node-v0.8.20.tar.gz#e4461bfded531f4880839829ab3bce5b824905d6e181876e3d0309a366bf57ee"
+install_package "node-v0.8.20" "https://nodejs.org/dist/v0.8.20/node-v0.8.20.tar.gz#e4461bfded531f4880839829ab3bce5b824905d6e181876e3d0309a366bf57ee" warn_eol

--- a/share/node-build/0.8.21
+++ b/share/node-build/0.8.21
@@ -6,4 +6,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.21/node-v0.8.21-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.21/node-v0.8.21-sunos-x64.tar.gz#51ca34ac742efb321720144110c9df1672f3aa53521f73591c11cbf0a5a8754c"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.21/node-v0.8.21-sunos-x86.tar.gz#f34358c23e9145db8a28f41a9269f3a75c0066b32ff0f19d05bacb04eb2192c6"
 
-install_package "node-v0.8.21" "https://nodejs.org/dist/v0.8.21/node-v0.8.21.tar.gz#e526f56d22bb2ebee5a607bd1e7a16dcc8530b916e3a372192e6cd5fa97d08e6"
+install_package "node-v0.8.21" "https://nodejs.org/dist/v0.8.21/node-v0.8.21.tar.gz#e526f56d22bb2ebee5a607bd1e7a16dcc8530b916e3a372192e6cd5fa97d08e6" warn_eol

--- a/share/node-build/0.8.22
+++ b/share/node-build/0.8.22
@@ -6,4 +6,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.22/node-v0.8.22-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.22/node-v0.8.22-sunos-x64.tar.gz#8807dcc3192d3a8c0aae407b620e7ccea62ea3c8ba00a9c99118684cc9c43b77"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.22/node-v0.8.22-sunos-x86.tar.gz#1eb0aa09ba0c5e99e81dd267ee63586f40ea6c3c4ea0b1134a659cb3a86472c4"
 
-install_package "node-v0.8.22" "https://nodejs.org/dist/v0.8.22/node-v0.8.22.tar.gz#3f61152cf5cd8fc1ab5c6c18101819841b947da79e1e44b51418c0ad2e6db8e8"
+install_package "node-v0.8.22" "https://nodejs.org/dist/v0.8.22/node-v0.8.22.tar.gz#3f61152cf5cd8fc1ab5c6c18101819841b947da79e1e44b51418c0ad2e6db8e8" warn_eol

--- a/share/node-build/0.8.23
+++ b/share/node-build/0.8.23
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.23/node-v0.8.23-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.23/node-v0.8.23-sunos-x64.tar.gz#8bd2f6ab2ed42416dd93e63dae996c5cf4b6ac1f1f5809b31d2c1d6302f55288"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.23/node-v0.8.23-sunos-x86.tar.gz#5784b479f6430abe8f8c58f1f6a1f457fe7f841bd390bb7e6c2cdd2abf02025c"
 
-install_package "node-v0.8.23" "https://nodejs.org/dist/v0.8.23/node-v0.8.23.tar.gz#382432638aedc25495e655dda338adcf41c6fa1d35f355936d659784c1deed9d"
+install_package "node-v0.8.23" "https://nodejs.org/dist/v0.8.23/node-v0.8.23.tar.gz#382432638aedc25495e655dda338adcf41c6fa1d35f355936d659784c1deed9d" warn_eol

--- a/share/node-build/0.8.24
+++ b/share/node-build/0.8.24
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.24/node-v0.8.24-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.24/node-v0.8.24-sunos-x64.tar.gz#71578fd0ae413bdd41e336959889db70f1268084da92c37ba8467701b60ac995"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.24/node-v0.8.24-sunos-x86.tar.gz#ce340c74abff8c6d462ce373ed8c6882c522a1032d327474ef17541403448b82"
 
-install_package "node-v0.8.24" "https://nodejs.org/dist/v0.8.24/node-v0.8.24.tar.gz#a0836e210da50106329e573532d5c590594ff1fcb9564fe8b55a04f04ff77705"
+install_package "node-v0.8.24" "https://nodejs.org/dist/v0.8.24/node-v0.8.24.tar.gz#a0836e210da50106329e573532d5c590594ff1fcb9564fe8b55a04f04ff77705" warn_eol

--- a/share/node-build/0.8.25
+++ b/share/node-build/0.8.25
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.25/node-v0.8.25-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.25/node-v0.8.25-sunos-x64.tar.gz#371ba8792e979ad0b2b1e780436e3ed4201ed2c1ffb916c01bc5de94178cd0d8"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.25/node-v0.8.25-sunos-x86.tar.gz#0ad7c35c45e929edc13ab1ed699ed02b9bfc4155a643db979baa0ee121c5b8d6"
 
-install_package "node-v0.8.25" "https://nodejs.org/dist/v0.8.25/node-v0.8.25.tar.gz#3dad0149020102e9b5604edae3cecd5842221c6657f26d35717bffaaf376caec"
+install_package "node-v0.8.25" "https://nodejs.org/dist/v0.8.25/node-v0.8.25.tar.gz#3dad0149020102e9b5604edae3cecd5842221c6657f26d35717bffaaf376caec" warn_eol

--- a/share/node-build/0.8.26
+++ b/share/node-build/0.8.26
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.26/node-v0.8.26-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.26/node-v0.8.26-sunos-x64.tar.gz#c216e547c7f84e397c71241b99a1565de78a22bbcc3f9c39005a4b28dd741896"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.26/node-v0.8.26-sunos-x86.tar.gz#faaaab76ca39712a17af2928ad71a0ce94bd6af599b7d3472912e5e4724e7aab"
 
-install_package "node-v0.8.26" "https://nodejs.org/dist/v0.8.26/node-v0.8.26.tar.gz#d873216685774b96139af534ce015077d2c93ddfc4e3596e128853f3c08a5413"
+install_package "node-v0.8.26" "https://nodejs.org/dist/v0.8.26/node-v0.8.26.tar.gz#d873216685774b96139af534ce015077d2c93ddfc4e3596e128853f3c08a5413" warn_eol

--- a/share/node-build/0.8.27
+++ b/share/node-build/0.8.27
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.27/node-v0.8.27-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.27/node-v0.8.27-sunos-x64.tar.gz#6340f05c2b56160fcfb796723d6702f28d0100595b7180acf715d7304a03d1bd"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.27/node-v0.8.27-sunos-x86.tar.gz#5e41e9e31fdd849483ef2b81c5dae7cf9487e70780bda2d216447b34c2707265"
 
-install_package "node-v0.8.27" "https://nodejs.org/dist/v0.8.27/node-v0.8.27.tar.gz#30608f9dcd9ad122f7e8e6212f95969979e3dc35309d0c422a56486334a9369e"
+install_package "node-v0.8.27" "https://nodejs.org/dist/v0.8.27/node-v0.8.27.tar.gz#30608f9dcd9ad122f7e8e6212f95969979e3dc35309d0c422a56486334a9369e" warn_eol

--- a/share/node-build/0.8.28
+++ b/share/node-build/0.8.28
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.28/node-v0.8.28-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.28/node-v0.8.28-sunos-x64.tar.gz#5966bb3ca9ed4a30a9391b0329c41a1075e01410b38d5d8245271f7d2bfa0db2"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.28/node-v0.8.28-sunos-x86.tar.gz#784c45b07e1e9b664cbe1cefa5d0ddaf6de5397a70cd3b529f8953182a2b5b4e"
 
-install_package "node-v0.8.28" "https://nodejs.org/dist/v0.8.28/node-v0.8.28.tar.gz#50e9a4282a741c923bd41c3ebb76698edbd7b1324024fe70cedc1e34b782d44f"
+install_package "node-v0.8.28" "https://nodejs.org/dist/v0.8.28/node-v0.8.28.tar.gz#50e9a4282a741c923bd41c3ebb76698edbd7b1324024fe70cedc1e34b782d44f" warn_eol

--- a/share/node-build/0.8.3
+++ b/share/node-build/0.8.3
@@ -1,1 +1,1 @@
-install_package "node-v0.8.3" "https://nodejs.org/dist/v0.8.3/node-v0.8.3.tar.gz#600a1d88744937dbad048f65f60d1259b814c59777d7b9d8665def77b1e1ec35"
+install_package "node-v0.8.3" "https://nodejs.org/dist/v0.8.3/node-v0.8.3.tar.gz#600a1d88744937dbad048f65f60d1259b814c59777d7b9d8665def77b1e1ec35" warn_eol

--- a/share/node-build/0.8.4
+++ b/share/node-build/0.8.4
@@ -1,1 +1,1 @@
-install_package "node-v0.8.4" "https://nodejs.org/dist/v0.8.4/node-v0.8.4.tar.gz#d0a3b0d2028ddd6bbaab5d3fe38dd6f80d7e810fe9e55efab3230a7c90d31174"
+install_package "node-v0.8.4" "https://nodejs.org/dist/v0.8.4/node-v0.8.4.tar.gz#d0a3b0d2028ddd6bbaab5d3fe38dd6f80d7e810fe9e55efab3230a7c90d31174" warn_eol

--- a/share/node-build/0.8.5
+++ b/share/node-build/0.8.5
@@ -1,1 +1,1 @@
-install_package "node-v0.8.5" "https://nodejs.org/dist/v0.8.5/node-v0.8.5.tar.gz#022a924973b15291f98b57437b53c59eaabee02348a2534259836e837f9ea6c0"
+install_package "node-v0.8.5" "https://nodejs.org/dist/v0.8.5/node-v0.8.5.tar.gz#022a924973b15291f98b57437b53c59eaabee02348a2534259836e837f9ea6c0" warn_eol

--- a/share/node-build/0.8.6
+++ b/share/node-build/0.8.6
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.6/node-v0.8.6-linux-x86.tar.gz#d5
 binary sunos-x64 "https://nodejs.org/dist/v0.8.6/node-v0.8.6-sunos-x64.tar.gz#41b42ceec543c8087a5bc3f66ad7788003409d58daf16b9ee872bea29a9ee98d"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.6/node-v0.8.6-sunos-x86.tar.gz#94fa004e74f2e176022c03c07fd3cabb84de3bfc25c801e741be38a152a46341"
 
-install_package "node-v0.8.6" "https://nodejs.org/dist/v0.8.6/node-v0.8.6.tar.gz#dbd42800e69644beff5c2cf11a9d4cf6dfbd644a9a36ffdd5e8c6b8db9240854"
+install_package "node-v0.8.6" "https://nodejs.org/dist/v0.8.6/node-v0.8.6.tar.gz#dbd42800e69644beff5c2cf11a9d4cf6dfbd644a9a36ffdd5e8c6b8db9240854" warn_eol

--- a/share/node-build/0.8.7
+++ b/share/node-build/0.8.7
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.7/node-v0.8.7-linux-x86.tar.gz#60
 binary sunos-x64 "https://nodejs.org/dist/v0.8.7/node-v0.8.7-sunos-x64.tar.gz#de4b5134884eec075c5e00eda81086cd92187e81c2e910462aca36a848e008a7"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.7/node-v0.8.7-sunos-x86.tar.gz#3219c5efd7bf1f069d424c34fd75332b094f7870e24f33eb46916f4d509a1ecb"
 
-install_package "node-v0.8.7" "https://nodejs.org/dist/v0.8.7/node-v0.8.7.tar.gz#fa979488347ad08ea6e36d3fe9c543807cd6f84cad31b22bfc6179b54b1e9d04"
+install_package "node-v0.8.7" "https://nodejs.org/dist/v0.8.7/node-v0.8.7.tar.gz#fa979488347ad08ea6e36d3fe9c543807cd6f84cad31b22bfc6179b54b1e9d04" warn_eol

--- a/share/node-build/0.8.8
+++ b/share/node-build/0.8.8
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.8/node-v0.8.8-linux-x86.tar.gz#b2
 binary sunos-x64 "https://nodejs.org/dist/v0.8.8/node-v0.8.8-sunos-x64.tar.gz#b94b63c97bdaa963ce5945a75d9bc73f694eca29df7be3a0070713e03acea295"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.8/node-v0.8.8-sunos-x86.tar.gz#e5fe9ecbc4dbbe65558cfb8d01678515ce3bb98573fff7a43810f99e404cd33e"
 
-install_package "node-v0.8.8" "https://nodejs.org/dist/v0.8.8/node-v0.8.8.tar.gz#092b7045b8e956f838a2a3da36cdcf7954e9e0d16fb88b14e2b7d090422e3133"
+install_package "node-v0.8.8" "https://nodejs.org/dist/v0.8.8/node-v0.8.8.tar.gz#092b7045b8e956f838a2a3da36cdcf7954e9e0d16fb88b14e2b7d090422e3133" warn_eol

--- a/share/node-build/0.8.9
+++ b/share/node-build/0.8.9
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.9/node-v0.8.9-linux-x86.tar.gz#ed
 binary sunos-x64 "https://nodejs.org/dist/v0.8.9/node-v0.8.9-sunos-x64.tar.gz#dbc20cfc4d665497d772d8c1a7f4140f63617cfeab83ac73649d1914fabf9c90"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.9/node-v0.8.9-sunos-x86.tar.gz#e93a229d09e5032aa7add4a2c255b9aea53ff634419956d732e0f6e154fcd896"
 
-install_package "node-v0.8.9" "https://nodejs.org/dist/v0.8.9/node-v0.8.9.tar.gz#320f06877c5e4b4dcc407c76c4d6dcf24384211c2ee22f8bc794a8ec898136ba"
+install_package "node-v0.8.9" "https://nodejs.org/dist/v0.8.9/node-v0.8.9.tar.gz#320f06877c5e4b4dcc407c76c4d6dcf24384211c2ee22f8bc794a8ec898136ba" warn_eol

--- a/share/node-build/0.9.0
+++ b/share/node-build/0.9.0
@@ -1,1 +1,1 @@
-install_package "node-v0.9.0" "https://nodejs.org/dist/v0.9.0/node-v0.9.0.tar.gz#4d2e5d7c8b345f6e401eed7d06b4bbc6cb012aefc34b46e7c3aedb4a0fccd258"
+install_package "node-v0.9.0" "https://nodejs.org/dist/v0.9.0/node-v0.9.0.tar.gz#4d2e5d7c8b345f6e401eed7d06b4bbc6cb012aefc34b46e7c3aedb4a0fccd258" warn_eol

--- a/share/node-build/0.9.1
+++ b/share/node-build/0.9.1
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.1/node-v0.9.1-linux-x86.tar.gz#31
 binary sunos-x64 "https://nodejs.org/dist/v0.9.1/node-v0.9.1-sunos-x64.tar.gz#971283d3b205dd624d750ecf66f45faf8738cae2e05cab24edcf68188bab5d0b"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.1/node-v0.9.1-sunos-x86.tar.gz#3b7cd36578e3703bd3c4141e3af389598c954e180985aac5d33035c698fd1e53"
 
-install_package "node-v0.9.1" "https://nodejs.org/dist/v0.9.1/node-v0.9.1.tar.gz#12bc0deb1a0c3fdcd5c54ffd241c1e291d372620944c3f97388d38f460f222b9"
+install_package "node-v0.9.1" "https://nodejs.org/dist/v0.9.1/node-v0.9.1.tar.gz#12bc0deb1a0c3fdcd5c54ffd241c1e291d372620944c3f97388d38f460f222b9" warn_eol

--- a/share/node-build/0.9.10
+++ b/share/node-build/0.9.10
@@ -6,4 +6,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.10/node-v0.9.10-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.9.10/node-v0.9.10-sunos-x64.tar.gz#99ae3de4362861a0eec4c181fb42d585e72fd4ad30e61ff894702fd2eb0d46d0"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.10/node-v0.9.10-sunos-x86.tar.gz#3623fbe87783fff3508ddd042b9dd23a2ea76ea0e711463dea0a085cda847a0d"
 
-install_package "node-v0.9.10" "https://nodejs.org/dist/v0.9.10/node-v0.9.10.tar.gz#efdb49fc4ce2b4876c2fac00f5a2d8458f6aba42fa85001b0cb01f7a4b234ec9"
+install_package "node-v0.9.10" "https://nodejs.org/dist/v0.9.10/node-v0.9.10.tar.gz#efdb49fc4ce2b4876c2fac00f5a2d8458f6aba42fa85001b0cb01f7a4b234ec9" warn_eol

--- a/share/node-build/0.9.11
+++ b/share/node-build/0.9.11
@@ -6,4 +6,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.11/node-v0.9.11-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.9.11/node-v0.9.11-sunos-x64.tar.gz#c84a2db0e0839400c4ef4ee7de1b9a3cbc44d7bc66beda324497227019d9f44d"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.11/node-v0.9.11-sunos-x86.tar.gz#eb793e5c212571a434b63afd92618fcd6da1b41e325bf6153550dce5a2871389"
 
-install_package "node-v0.9.11" "https://nodejs.org/dist/v0.9.11/node-v0.9.11.tar.gz#2e22a9ecd838527f69d31e35fa5781d4b8099e3b33891b5f7d7e46f2291d6988"
+install_package "node-v0.9.11" "https://nodejs.org/dist/v0.9.11/node-v0.9.11.tar.gz#2e22a9ecd838527f69d31e35fa5781d4b8099e3b33891b5f7d7e46f2291d6988" warn_eol

--- a/share/node-build/0.9.12
+++ b/share/node-build/0.9.12
@@ -6,4 +6,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.12/node-v0.9.12-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.9.12/node-v0.9.12-sunos-x64.tar.gz#b2dcc56ca896e9f0297ea3e41bb521e81cdea801dd6cb3ea1a4fe6b82be358f4"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.12/node-v0.9.12-sunos-x86.tar.gz#cf3f8db68ae33e1b07a7a0e8eb84cec116765347814188c04528903803a97bdc"
 
-install_package "node-v0.9.12" "https://nodejs.org/dist/v0.9.12/node-v0.9.12.tar.gz#d1dbf425eb72b7c6d931f5fabf79b1e67ce1b2808c19c4b06a9aafe313ac2474"
+install_package "node-v0.9.12" "https://nodejs.org/dist/v0.9.12/node-v0.9.12.tar.gz#d1dbf425eb72b7c6d931f5fabf79b1e67ce1b2808c19c4b06a9aafe313ac2474" warn_eol

--- a/share/node-build/0.9.2
+++ b/share/node-build/0.9.2
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.2/node-v0.9.2-linux-x86.tar.gz#fa
 binary sunos-x64 "https://nodejs.org/dist/v0.9.2/node-v0.9.2-sunos-x64.tar.gz#0d87e660f1cc57cfcb1a9c1cc85b4ed305f08f6d3463d6d6cdcfd537ca79138a"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.2/node-v0.9.2-sunos-x86.tar.gz#7d47f6c89e9036247f754a80b47eb36ae1973f1f200b9a70cabc413933e17684"
 
-install_package "node-v0.9.2" "https://nodejs.org/dist/v0.9.2/node-v0.9.2.tar.gz#84dc31888a5d53a0188ebc04ef4b84488b2f0361dd4696b7ae047af7372102c1"
+install_package "node-v0.9.2" "https://nodejs.org/dist/v0.9.2/node-v0.9.2.tar.gz#84dc31888a5d53a0188ebc04ef4b84488b2f0361dd4696b7ae047af7372102c1" warn_eol

--- a/share/node-build/0.9.3
+++ b/share/node-build/0.9.3
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.3/node-v0.9.3-linux-x86.tar.gz#8d
 binary sunos-x64 "https://nodejs.org/dist/v0.9.3/node-v0.9.3-sunos-x64.tar.gz#fc34d3614624f27b3801f4c2f3019f6cd2c7ad5b05d97d8dd28524d9ff4c4ebe"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.3/node-v0.9.3-sunos-x86.tar.gz#df4cb58d17cb545dd8a91e49b1f270fa1dd4f1b2cd81d6afd8ec24f0ce1c6049"
 
-install_package "node-v0.9.3" "https://nodejs.org/dist/v0.9.3/node-v0.9.3.tar.gz#7e1750cd47d7b8c13c7cf12457b6a528fa2abf8a10b7c9a35c13ed47cebaab41"
+install_package "node-v0.9.3" "https://nodejs.org/dist/v0.9.3/node-v0.9.3.tar.gz#7e1750cd47d7b8c13c7cf12457b6a528fa2abf8a10b7c9a35c13ed47cebaab41" warn_eol

--- a/share/node-build/0.9.4
+++ b/share/node-build/0.9.4
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.4/node-v0.9.4-linux-x86.tar.gz#f7
 binary sunos-x64 "https://nodejs.org/dist/v0.9.4/node-v0.9.4-sunos-x64.tar.gz#fd52e94f51f78b8d55d450cf8c389ee5e2e283d4a0deb602c3bb10964181539d"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.4/node-v0.9.4-sunos-x86.tar.gz#1cac9ed70d26d3465efb45c4ca2ff4d99af786407fe44dbfef135a0ce80ea64a"
 
-install_package "node-v0.9.4" "https://nodejs.org/dist/v0.9.4/node-v0.9.4.tar.gz#6978981caceff7b83a23a6e3c89dba5734d27a623d2c3d26ecd77e41f2bd39f7"
+install_package "node-v0.9.4" "https://nodejs.org/dist/v0.9.4/node-v0.9.4.tar.gz#6978981caceff7b83a23a6e3c89dba5734d27a623d2c3d26ecd77e41f2bd39f7" warn_eol

--- a/share/node-build/0.9.5
+++ b/share/node-build/0.9.5
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.5/node-v0.9.5-linux-x86.tar.gz#62
 binary sunos-x64 "https://nodejs.org/dist/v0.9.5/node-v0.9.5-sunos-x64.tar.gz#c4cf7cedcf151b263a9adca424deba0d21312dc61ac654ec5b77ff277dca1844"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.5/node-v0.9.5-sunos-x86.tar.gz#1750c8713ac29814a09d470156029e1841b3bc6d210a5d3bdfebf06b6104ae4b"
 
-install_package "node-v0.9.5" "https://nodejs.org/dist/v0.9.5/node-v0.9.5.tar.gz#0235bffe94b6e1fca312436e6b8cf62e6d35fe02c752d0c57e4af9ae63e021d1"
+install_package "node-v0.9.5" "https://nodejs.org/dist/v0.9.5/node-v0.9.5.tar.gz#0235bffe94b6e1fca312436e6b8cf62e6d35fe02c752d0c57e4af9ae63e021d1" warn_eol

--- a/share/node-build/0.9.6
+++ b/share/node-build/0.9.6
@@ -5,4 +5,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.6/node-v0.9.6-linux-x86.tar.gz#cc
 binary sunos-x64 "https://nodejs.org/dist/v0.9.6/node-v0.9.6-sunos-x64.tar.gz#d9bf25de31b127535f98b109a0481f1c1fcae97aca783b2f3b457205784adbd3"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.6/node-v0.9.6-sunos-x86.tar.gz#2d36b537597f0c20ab95a14b244c9093e8949c71c522f361bd48f6e97f2d1a0a"
 
-install_package "node-v0.9.6" "https://nodejs.org/dist/v0.9.6/node-v0.9.6.tar.gz#e314c69555a53241eb809132b8d76b6843d44b7f8afb68cf2f60fcf86e05c916"
+install_package "node-v0.9.6" "https://nodejs.org/dist/v0.9.6/node-v0.9.6.tar.gz#e314c69555a53241eb809132b8d76b6843d44b7f8afb68cf2f60fcf86e05c916" warn_eol

--- a/share/node-build/0.9.7
+++ b/share/node-build/0.9.7
@@ -6,4 +6,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.7/node-v0.9.7-linux-x86.tar.gz#bf
 binary sunos-x64 "https://nodejs.org/dist/v0.9.7/node-v0.9.7-sunos-x64.tar.gz#a5eb8ccf2dae8cc5d532f244ee28621f52535891e321313a9b0afd8f4d6cc737"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.7/node-v0.9.7-sunos-x86.tar.gz#7533414da857d30e3cd9747b0dfc769fb34c393af80b0935f0877a4bcc6e29ad"
 
-install_package "node-v0.9.7" "https://nodejs.org/dist/v0.9.7/node-v0.9.7.tar.gz#c05fe0a304d3a7edc2ace4a9ce8e4c37d29332d908d8b578b075d2ac2c2b71b8"
+install_package "node-v0.9.7" "https://nodejs.org/dist/v0.9.7/node-v0.9.7.tar.gz#c05fe0a304d3a7edc2ace4a9ce8e4c37d29332d908d8b578b075d2ac2c2b71b8" warn_eol

--- a/share/node-build/0.9.8
+++ b/share/node-build/0.9.8
@@ -6,4 +6,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.8/node-v0.9.8-linux-x86.tar.gz#c2
 binary sunos-x64 "https://nodejs.org/dist/v0.9.8/node-v0.9.8-sunos-x64.tar.gz#654dd17df28a6ac7704c7b977cf906580153830553dd8a2ed684b3b70cbcf732"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.8/node-v0.9.8-sunos-x86.tar.gz#2d767fa5502e4b24ba85feb32f6918833a4654b7b2d0236cbf9e039dc2c5a145"
 
-install_package "node-v0.9.8" "https://nodejs.org/dist/v0.9.8/node-v0.9.8.tar.gz#b7ad7d9f02d5eaca73a288a261578965c67d3847c2392ee09527acf72549b2e5"
+install_package "node-v0.9.8" "https://nodejs.org/dist/v0.9.8/node-v0.9.8.tar.gz#b7ad7d9f02d5eaca73a288a261578965c67d3847c2392ee09527acf72549b2e5" warn_eol

--- a/share/node-build/0.9.9
+++ b/share/node-build/0.9.9
@@ -6,4 +6,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.9/node-v0.9.9-linux-x86.tar.gz#aa
 binary sunos-x64 "https://nodejs.org/dist/v0.9.9/node-v0.9.9-sunos-x64.tar.gz#5c74ea6c3c07cb8e7b447c8a6f03b32dff81139d34610bffe651cbd38f8c60fc"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.9/node-v0.9.9-sunos-x86.tar.gz#492feecab9ed2062ce645027229a8fb05de29a71382afa6ac4fb792342fb234b"
 
-install_package "node-v0.9.9" "https://nodejs.org/dist/v0.9.9/node-v0.9.9.tar.gz#d285559044db3e340ab6403d7508943fbec4cc166f1ad96a00ac441794ce8a88"
+install_package "node-v0.9.9" "https://nodejs.org/dist/v0.9.9/node-v0.9.9.tar.gz#d285559044db3e340ab6403d7508943fbec4cc166f1ad96a00ac441794ce8a88" warn_eol

--- a/share/node-build/iojs-0.12.0-dev
+++ b/share/node-build/iojs-0.12.0-dev
@@ -1,1 +1,1 @@
-install_git "iojs-0.12.0-dev" "https://github.com/iojs/io.js.git" "v0.12" standard
+install_git "iojs-0.12.0-dev" "https://github.com/iojs/io.js.git" "v0.12" standard warn_eol

--- a/share/node-build/iojs-1.0.0
+++ b/share/node-build/iojs-1.0.0
@@ -3,4 +3,4 @@ binary linux-armv7l "https://iojs.org/dist/v1.0.0/iojs-v1.0.0-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v1.0.0/iojs-v1.0.0-linux-x64.tar.gz#df5f5e68e820aac9366ade18db5eae947b8a6c9cc66bc0b461b32e99f66ce960"
 binary linux-x86 "https://iojs.org/dist/v1.0.0/iojs-v1.0.0-linux-x86.tar.gz#b1e9d197a1719a596c810b818f512b6ebbaf35f00f0f04f6c433e660bf511202"
 
-install_package "iojs-v1.0.0" "https://iojs.org/dist/v1.0.0/iojs-v1.0.0.tar.gz#dcc6ccd99fffa20ebe59b35acca51150cfd68171cbf36fee210b3f5480964d05"
+install_package "iojs-v1.0.0" "https://iojs.org/dist/v1.0.0/iojs-v1.0.0.tar.gz#dcc6ccd99fffa20ebe59b35acca51150cfd68171cbf36fee210b3f5480964d05" warn_eol

--- a/share/node-build/iojs-1.0.1
+++ b/share/node-build/iojs-1.0.1
@@ -3,4 +3,4 @@ binary linux-armv7l "https://iojs.org/dist/v1.0.1/iojs-v1.0.1-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v1.0.1/iojs-v1.0.1-linux-x64.tar.gz#77ba1aacc2bb79fac32abe5e348fb701ba4446e5ec5583842d59a415faeb1daa"
 binary linux-x86 "https://iojs.org/dist/v1.0.1/iojs-v1.0.1-linux-x86.tar.gz#6dae2ad4b00f6432ea0f24f93087db39e49fed3a9853b7e1c8a02f310c412436"
 
-install_package "iojs-v1.0.1" "https://iojs.org/dist/v1.0.1/iojs-v1.0.1.tar.gz#c26052dad5d9ccd8a7b9134806994ebf2d217a57d6efd5633e01c5cc1dcdedc5"
+install_package "iojs-v1.0.1" "https://iojs.org/dist/v1.0.1/iojs-v1.0.1.tar.gz#c26052dad5d9ccd8a7b9134806994ebf2d217a57d6efd5633e01c5cc1dcdedc5" warn_eol

--- a/share/node-build/iojs-1.0.2
+++ b/share/node-build/iojs-1.0.2
@@ -3,4 +3,4 @@ binary linux-armv7l "https://iojs.org/dist/v1.0.2/iojs-v1.0.2-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v1.0.2/iojs-v1.0.2-linux-x64.tar.gz#e379bbbc385dd63f07a14f6d025a9dd45181081b2b4eec59524e3591493d6b57"
 binary linux-x86 "https://iojs.org/dist/v1.0.2/iojs-v1.0.2-linux-x86.tar.gz#5cf3f1cd6e87201594ac89e4feddca10a8349a91a054eedec68380e3a74c5d46"
 
-install_package "iojs-v1.0.2" "https://iojs.org/dist/v1.0.2/iojs-v1.0.2.tar.gz#39fa602bf8dda874682d9c0380311de3295997c0b674b5e8aec0b988912cd9d1"
+install_package "iojs-v1.0.2" "https://iojs.org/dist/v1.0.2/iojs-v1.0.2.tar.gz#39fa602bf8dda874682d9c0380311de3295997c0b674b5e8aec0b988912cd9d1" warn_eol

--- a/share/node-build/iojs-1.0.3
+++ b/share/node-build/iojs-1.0.3
@@ -3,4 +3,4 @@ binary linux-armv7l "https://iojs.org/dist/v1.0.3/iojs-v1.0.3-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v1.0.3/iojs-v1.0.3-linux-x64.tar.gz#047b75b518767f0983c8159c9bb9a2939a214964ee127890e590af63f9082839"
 binary linux-x86 "https://iojs.org/dist/v1.0.3/iojs-v1.0.3-linux-x86.tar.gz#7c2d64056b430ebfc46a4f14039d21c1f7fb3fc0c8932eb9da94820e1fee4d1b"
 
-install_package "iojs-v1.0.3" "https://iojs.org/dist/v1.0.3/iojs-v1.0.3.tar.gz#c7fe7f71d9920f4cfd930f9022c7dddca7e11a0377fed1ee23e3241c2952db42"
+install_package "iojs-v1.0.3" "https://iojs.org/dist/v1.0.3/iojs-v1.0.3.tar.gz#c7fe7f71d9920f4cfd930f9022c7dddca7e11a0377fed1ee23e3241c2952db42" warn_eol

--- a/share/node-build/iojs-1.0.4
+++ b/share/node-build/iojs-1.0.4
@@ -3,4 +3,4 @@ binary linux-armv7l "https://iojs.org/dist/v1.0.4/iojs-v1.0.4-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v1.0.4/iojs-v1.0.4-linux-x64.tar.gz#9b147d4c1d8ff2c89bb1182bd145334b469ee3c71d845b99cf3b35c9c0c5652f"
 binary linux-x86 "https://iojs.org/dist/v1.0.4/iojs-v1.0.4-linux-x86.tar.gz#a532f61d882fed334662186c4d2d017c82de10b6558673823b093daca406624c"
 
-install_package "iojs-v1.0.4" "https://iojs.org/dist/v1.0.4/iojs-v1.0.4.tar.gz#59f4d34eafe70b1e96efba7491556db9ec449e5774352885a73ff41bad7c2965"
+install_package "iojs-v1.0.4" "https://iojs.org/dist/v1.0.4/iojs-v1.0.4.tar.gz#59f4d34eafe70b1e96efba7491556db9ec449e5774352885a73ff41bad7c2965" warn_eol

--- a/share/node-build/iojs-1.1.0
+++ b/share/node-build/iojs-1.1.0
@@ -3,4 +3,4 @@ binary linux-armv7l "https://iojs.org/dist/v1.1.0/iojs-v1.1.0-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v1.1.0/iojs-v1.1.0-linux-x64.tar.gz#a80baa514c0758fc5ccfa59d5b734de5cb52b15b09a2c1e38c8dabb860ad3420"
 binary linux-x86 "https://iojs.org/dist/v1.1.0/iojs-v1.1.0-linux-x86.tar.gz#e150da87d109095a0217627beac572388941c412723796ac5839c784a285d733"
 
-install_package "iojs-v1.1.0" "https://iojs.org/dist/v1.1.0/iojs-v1.1.0.tar.gz#f0b8a8db1bf434eaebf4d6a7fcfd6adeaf85ab22f410f202b37a9c76781e7f7b"
+install_package "iojs-v1.1.0" "https://iojs.org/dist/v1.1.0/iojs-v1.1.0.tar.gz#f0b8a8db1bf434eaebf4d6a7fcfd6adeaf85ab22f410f202b37a9c76781e7f7b" warn_eol

--- a/share/node-build/iojs-1.2.0
+++ b/share/node-build/iojs-1.2.0
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v1.2.0/iojs-v1.2.0-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v1.2.0/iojs-v1.2.0-linux-x64.tar.gz#bf475addb9e549f7005d61c13acdbefcf1e8e0fc60c73448c9baedc9795910fa"
 binary linux-x86 "https://iojs.org/dist/v1.2.0/iojs-v1.2.0-linux-x86.tar.gz#4d2d9a158fb4aff30dd3b7c354d084d95b7ba43fc3bb7dfd77284934e390ef85"
 
-install_package "iojs-v1.2.0" "https://iojs.org/dist/v1.2.0/iojs-v1.2.0.tar.gz#33666fce914ca57ef60e2e29d7b02cd64c99a8609287a9227da2087ab9c65d9d"
+install_package "iojs-v1.2.0" "https://iojs.org/dist/v1.2.0/iojs-v1.2.0.tar.gz#33666fce914ca57ef60e2e29d7b02cd64c99a8609287a9227da2087ab9c65d9d" warn_eol

--- a/share/node-build/iojs-1.3.0
+++ b/share/node-build/iojs-1.3.0
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v1.3.0/iojs-v1.3.0-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v1.3.0/iojs-v1.3.0-linux-x64.tar.gz#3fa309fce40a9ad94a612c91443034456d6e109e4e63a039f72e3ea5fc31e592"
 binary linux-x86 "https://iojs.org/dist/v1.3.0/iojs-v1.3.0-linux-x86.tar.gz#3c747f9af20824a085967042055032838acf100e35d4a90a68e67bb478aff2e7"
 
-install_package "iojs-v1.3.0" "https://iojs.org/dist/v1.3.0/iojs-v1.3.0.tar.gz#eb652fb854274e04b4a309b1b8cd4d5bb3eb45882e9442bacb129d247e9de021"
+install_package "iojs-v1.3.0" "https://iojs.org/dist/v1.3.0/iojs-v1.3.0.tar.gz#eb652fb854274e04b4a309b1b8cd4d5bb3eb45882e9442bacb129d247e9de021" warn_eol

--- a/share/node-build/iojs-1.4.1
+++ b/share/node-build/iojs-1.4.1
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v1.4.1/iojs-v1.4.1-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v1.4.1/iojs-v1.4.1-linux-x64.tar.gz#846ca8ed78d63926a5f75e46653d173f1773241a43b65c0148eb492248a5efd2"
 binary linux-x86 "https://iojs.org/dist/v1.4.1/iojs-v1.4.1-linux-x86.tar.gz#5029ebe7eb1b446ff234d1d7f414a2479ce0b50ec421d2800aa67b7f22132a3c"
 
-install_package "iojs-v1.4.1" "https://iojs.org/dist/v1.4.1/iojs-v1.4.1.tar.gz#da7bbb2ec8d0980ddbfca9d6de2ba5e9d5b57b41f6ef50140da746577fc98c34"
+install_package "iojs-v1.4.1" "https://iojs.org/dist/v1.4.1/iojs-v1.4.1.tar.gz#da7bbb2ec8d0980ddbfca9d6de2ba5e9d5b57b41f6ef50140da746577fc98c34" warn_eol

--- a/share/node-build/iojs-1.4.2
+++ b/share/node-build/iojs-1.4.2
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.gz#99e6ea760fea597caab3c198d4990ead8d7efb319ebea300f5b780bf53c72b9e"
 binary linux-x86 "https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x86.tar.gz#19a257b7a1490ebe1080bf24fa391113f0db1bee56e7c2bb6a9956e7e2f007c4"
 
-install_package "iojs-v1.4.2" "https://iojs.org/dist/v1.4.2/iojs-v1.4.2.tar.gz#943ea794e045ec47c8a1514c58f70be660a7a5c351601c557a86126f6827fa37"
+install_package "iojs-v1.4.2" "https://iojs.org/dist/v1.4.2/iojs-v1.4.2.tar.gz#943ea794e045ec47c8a1514c58f70be660a7a5c351601c557a86126f6827fa37" warn_eol

--- a/share/node-build/iojs-1.4.3
+++ b/share/node-build/iojs-1.4.3
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.gz#b66b09d58dd58c1382de842e74e951dbd75ccf3475425ef147e7b13db644704e"
 binary linux-x86 "https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x86.tar.gz#37b81e75b04efcf3fe56cd22dcbff9f7513234be645d7f4af5ff4c2ed58a418f"
 
-install_package "iojs-v1.4.3" "https://iojs.org/dist/v1.4.3/iojs-v1.4.3.tar.gz#86f89147606311a159dcb3d110f5e3b55fc614d1577b7cbe25d27df16b4e33b0"
+install_package "iojs-v1.4.3" "https://iojs.org/dist/v1.4.3/iojs-v1.4.3.tar.gz#86f89147606311a159dcb3d110f5e3b55fc614d1577b7cbe25d27df16b4e33b0" warn_eol

--- a/share/node-build/iojs-1.5.0
+++ b/share/node-build/iojs-1.5.0
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v1.5.0/iojs-v1.5.0-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v1.5.0/iojs-v1.5.0-linux-x64.tar.gz#3f88989f5613adcc7451bf3ce7467063a6d81c94ed88221ca081c37f12ee183d"
 binary linux-x86 "https://iojs.org/dist/v1.5.0/iojs-v1.5.0-linux-x86.tar.gz#2ce1d22367bc9d3918e6ddd70aa5e3e8bc9148b3d47f3c21628a8b2e9f3071fb"
 
-install_package "iojs-v1.5.0" "https://iojs.org/dist/v1.5.0/iojs-v1.5.0.tar.gz#83fc43cff80ebbbcb670110037fb2999202b00398ad5c63c7e76a8080b6a3b8a"
+install_package "iojs-v1.5.0" "https://iojs.org/dist/v1.5.0/iojs-v1.5.0.tar.gz#83fc43cff80ebbbcb670110037fb2999202b00398ad5c63c7e76a8080b6a3b8a" warn_eol

--- a/share/node-build/iojs-1.5.1
+++ b/share/node-build/iojs-1.5.1
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v1.5.1/iojs-v1.5.1-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v1.5.1/iojs-v1.5.1-linux-x64.tar.gz#1ec0b9ce05efacda642bc3e3d6c56dbe030b43e5e97ee1569b04d6a31d9f9bea"
 binary linux-x86 "https://iojs.org/dist/v1.5.1/iojs-v1.5.1-linux-x86.tar.gz#f52b56fdcf7b0c8d092a150d4aade96ffe5655941404d9f626e062b75c0d477b"
 
-install_package "iojs-v1.5.1" "https://iojs.org/dist/v1.5.1/iojs-v1.5.1.tar.gz#46e8a405392e6557b833f43229d19fc7d9bc8f9a6b7423cd6d667a60d36abd7d"
+install_package "iojs-v1.5.1" "https://iojs.org/dist/v1.5.1/iojs-v1.5.1.tar.gz#46e8a405392e6557b833f43229d19fc7d9bc8f9a6b7423cd6d667a60d36abd7d" warn_eol

--- a/share/node-build/iojs-1.6.0
+++ b/share/node-build/iojs-1.6.0
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v1.6.0/iojs-v1.6.0-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v1.6.0/iojs-v1.6.0-linux-x64.tar.gz#775b50ae89ea78e5225fb19be834b01db7109b964567140b09dc90a395d9d40e"
 binary linux-x86 "https://iojs.org/dist/v1.6.0/iojs-v1.6.0-linux-x86.tar.gz#843efa08130cdba711eaf351be05ff473d0a0bc5189a8c32bf61a1ddb41d6f1a"
 
-install_package "iojs-v1.6.0" "https://iojs.org/dist/v1.6.0/iojs-v1.6.0.tar.gz#da337d5fc915a54cc9def2eec9c97d2eefc0b50da45f553c4b15b9b5e24579df"
+install_package "iojs-v1.6.0" "https://iojs.org/dist/v1.6.0/iojs-v1.6.0.tar.gz#da337d5fc915a54cc9def2eec9c97d2eefc0b50da45f553c4b15b9b5e24579df" warn_eol

--- a/share/node-build/iojs-1.6.1
+++ b/share/node-build/iojs-1.6.1
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v1.6.1/iojs-v1.6.1-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v1.6.1/iojs-v1.6.1-linux-x64.tar.gz#6cf8f9cd065dc1d0fee5f1c77c5cd8bc71fc4a0b0854d06d7a97fe557aa71384"
 binary linux-x86 "https://iojs.org/dist/v1.6.1/iojs-v1.6.1-linux-x86.tar.gz#744d93fc17ab493ca05ba3b242e8e1ce1c4738e0f7828115979873b8840916d9"
 
-install_package "iojs-v1.6.1" "https://iojs.org/dist/v1.6.1/iojs-v1.6.1.tar.gz#1cd70dc07b9b38c27539b0202536caee31a8d63f45dd7945d9293cac5da30df2"
+install_package "iojs-v1.6.1" "https://iojs.org/dist/v1.6.1/iojs-v1.6.1.tar.gz#1cd70dc07b9b38c27539b0202536caee31a8d63f45dd7945d9293cac5da30df2" warn_eol

--- a/share/node-build/iojs-1.6.2
+++ b/share/node-build/iojs-1.6.2
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v1.6.2/iojs-v1.6.2-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v1.6.2/iojs-v1.6.2-linux-x64.tar.gz#1598b95cb6e1a4b664ea0a8fc69d0cf53e597bbd1164a94966fc3e34f63a7447"
 binary linux-x86 "https://iojs.org/dist/v1.6.2/iojs-v1.6.2-linux-x86.tar.gz#fc82c32221c48d1021b1bee5867bf8c54ae2d5914c7d1f8281be587ad4307576"
 
-install_package "iojs-v1.6.2" "https://iojs.org/dist/v1.6.2/iojs-v1.6.2.tar.gz#ea537c47a46a15fdae0eab884a7c8f947905bd0cadc3b0d3ca4dbc51fe4afb5f"
+install_package "iojs-v1.6.2" "https://iojs.org/dist/v1.6.2/iojs-v1.6.2.tar.gz#ea537c47a46a15fdae0eab884a7c8f947905bd0cadc3b0d3ca4dbc51fe4afb5f" warn_eol

--- a/share/node-build/iojs-1.6.3
+++ b/share/node-build/iojs-1.6.3
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v1.6.3/iojs-v1.6.3-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v1.6.3/iojs-v1.6.3-linux-x64.tar.gz#cf0b5308dc27118c607bc36478f99ab0be0cc5b13e80e4696fda0189810f00af"
 binary linux-x86 "https://iojs.org/dist/v1.6.3/iojs-v1.6.3-linux-x86.tar.gz#ff370875a5fc2c9ab03581c6f06b800f284377d0056f1ce2f4ba7e9d70774594"
 
-install_package "iojs-v1.6.3" "https://iojs.org/dist/v1.6.3/iojs-v1.6.3.tar.gz#7ab455fc96af90512325848e8c508c19a622a52b1371d233f1c8fa9c41e64660"
+install_package "iojs-v1.6.3" "https://iojs.org/dist/v1.6.3/iojs-v1.6.3.tar.gz#7ab455fc96af90512325848e8c508c19a622a52b1371d233f1c8fa9c41e64660" warn_eol

--- a/share/node-build/iojs-1.6.4
+++ b/share/node-build/iojs-1.6.4
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v1.6.4/iojs-v1.6.4-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v1.6.4/iojs-v1.6.4-linux-x64.tar.gz#932a577e53a014f5c1017da437db59a30f3283ae780ab4167374979d46854660"
 binary linux-x86 "https://iojs.org/dist/v1.6.4/iojs-v1.6.4-linux-x86.tar.gz#aef972d0e0fe4113fd0c39455159dfd50688818d571566792c274e854752c4c6"
 
-install_package "iojs-v1.6.4" "https://iojs.org/dist/v1.6.4/iojs-v1.6.4.tar.gz#875db123a05b3e0ebf2e7f6bb88c0d70275099bc970f61fbbfb79d42de71fbe3"
+install_package "iojs-v1.6.4" "https://iojs.org/dist/v1.6.4/iojs-v1.6.4.tar.gz#875db123a05b3e0ebf2e7f6bb88c0d70275099bc970f61fbbfb79d42de71fbe3" warn_eol

--- a/share/node-build/iojs-1.7.1
+++ b/share/node-build/iojs-1.7.1
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v1.7.1/iojs-v1.7.1-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v1.7.1/iojs-v1.7.1-linux-x64.tar.gz#e6eca168d3735f164a2e79c8cb5d8b2bf3a8b42c86f43853b5028a210d62e77b"
 binary linux-x86 "https://iojs.org/dist/v1.7.1/iojs-v1.7.1-linux-x86.tar.gz#7b9460df57e093d411f47dacce2dc73a7eca7c37d72f36348e7d6265bdb568f7"
 
-install_package "iojs-v1.7.1" "https://iojs.org/dist/v1.7.1/iojs-v1.7.1.tar.gz#8f7c6927bbded5912d9bd3903e779b534ddc742ea3aa669859369263b179eff9"
+install_package "iojs-v1.7.1" "https://iojs.org/dist/v1.7.1/iojs-v1.7.1.tar.gz#8f7c6927bbded5912d9bd3903e779b534ddc742ea3aa669859369263b179eff9" warn_eol

--- a/share/node-build/iojs-1.8.1
+++ b/share/node-build/iojs-1.8.1
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v1.8.1/iojs-v1.8.1-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v1.8.1/iojs-v1.8.1-linux-x64.tar.gz#bc0d239487d08aefb0126cbdadce835fcf4f4efddbde8d122de89c0eeadc7e07"
 binary linux-x86 "https://iojs.org/dist/v1.8.1/iojs-v1.8.1-linux-x86.tar.gz#05968739ab978c7078cb7a209ad3f40647c5d1158f7dbe9957176ac4426d881d"
 
-install_package "iojs-v1.8.1" "https://iojs.org/dist/v1.8.1/iojs-v1.8.1.tar.gz#07d407b600cf1e7446d694338a595f1f265625b9f0b51c4366434a63bb70e11b"
+install_package "iojs-v1.8.1" "https://iojs.org/dist/v1.8.1/iojs-v1.8.1.tar.gz#07d407b600cf1e7446d694338a595f1f265625b9f0b51c4366434a63bb70e11b" warn_eol

--- a/share/node-build/iojs-1.8.2
+++ b/share/node-build/iojs-1.8.2
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v1.8.2/iojs-v1.8.2-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v1.8.2/iojs-v1.8.2-linux-x64.tar.gz#57343b5fc2879c5dcaadad4f59d9ca64d058a98e65e3b5e678e5879ac52a2eb9"
 binary linux-x86 "https://iojs.org/dist/v1.8.2/iojs-v1.8.2-linux-x86.tar.gz#11e1182c5a847ae9e02544f84d19ca5405cfcca89f3cf2935d51790f85f8a91a"
 
-install_package "iojs-v1.8.2" "https://iojs.org/dist/v1.8.2/iojs-v1.8.2.tar.gz#ea36c96061aa2b74275dc2c71ea2ff0efca0358ef628efe76ea324afeeb0e4f7"
+install_package "iojs-v1.8.2" "https://iojs.org/dist/v1.8.2/iojs-v1.8.2.tar.gz#ea36c96061aa2b74275dc2c71ea2ff0efca0358ef628efe76ea324afeeb0e4f7" warn_eol

--- a/share/node-build/iojs-1.8.3
+++ b/share/node-build/iojs-1.8.3
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v1.8.3/iojs-v1.8.3-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v1.8.3/iojs-v1.8.3-linux-x64.tar.gz#86502cfcb255fe60fd19807df64a1dbaeb5f0c1258188e1246f893a41a9e0c73"
 binary linux-x86 "https://iojs.org/dist/v1.8.3/iojs-v1.8.3-linux-x86.tar.gz#c1b425c56a6ade3d4204d6834b041aac5daf028f8ba6f0d183fb537a8479d613"
 
-install_package "iojs-v1.8.3" "https://iojs.org/dist/v1.8.3/iojs-v1.8.3.tar.gz#9613618c8675323801cf1fa9fe3778149e6e42ae2753ddb16a663140fdc9cd56"
+install_package "iojs-v1.8.3" "https://iojs.org/dist/v1.8.3/iojs-v1.8.3.tar.gz#9613618c8675323801cf1fa9fe3778149e6e42ae2753ddb16a663140fdc9cd56" warn_eol

--- a/share/node-build/iojs-1.8.4
+++ b/share/node-build/iojs-1.8.4
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v1.8.4/iojs-v1.8.4-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v1.8.4/iojs-v1.8.4-linux-x64.tar.gz#9d58ea690732bcf1bffe40d95d0e456869f1ed19d33a7f0a2150cd6ac112abbe"
 binary linux-x86 "https://iojs.org/dist/v1.8.4/iojs-v1.8.4-linux-x86.tar.gz#49ef83f3dd3fe3ee4e36e2f83fe2c9d397b222549667da1b4558a2a7c060c913"
 
-install_package "iojs-v1.8.4" "https://iojs.org/dist/v1.8.4/iojs-v1.8.4.tar.gz#861f4128b8ab0e292d73460b1344593d943d52925c84e9bb58ced188204a7e25"
+install_package "iojs-v1.8.4" "https://iojs.org/dist/v1.8.4/iojs-v1.8.4.tar.gz#861f4128b8ab0e292d73460b1344593d943d52925c84e9bb58ced188204a7e25" warn_eol

--- a/share/node-build/iojs-1.x-dev
+++ b/share/node-build/iojs-1.x-dev
@@ -1,1 +1,1 @@
-install_git "iojs-1.x-dev" "https://github.com/iojs/io.js.git" "v1.x" standard
+install_git "iojs-1.x-dev" "https://github.com/iojs/io.js.git" "v1.x" standard warn_eol

--- a/share/node-build/iojs-2.0.0
+++ b/share/node-build/iojs-2.0.0
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v2.0.0/iojs-v2.0.0-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v2.0.0/iojs-v2.0.0-linux-x64.tar.gz#edf44e185b49ed01b390097ff5104f0457b59a1a37b99d0983f73ca018c58e3a"
 binary linux-x86 "https://iojs.org/dist/v2.0.0/iojs-v2.0.0-linux-x86.tar.gz#a593b44ea4729e440e8dc63549b22a00a1bdc2c6c5a1208e7549f338713a13d5"
 
-install_package "iojs-v2.0.0" "https://iojs.org/dist/v2.0.0/iojs-v2.0.0.tar.gz#e4dd47b19fd41c9fa6f59c6d76f723ae79e76c3db5474e4d9dacc873dd47767a"
+install_package "iojs-v2.0.0" "https://iojs.org/dist/v2.0.0/iojs-v2.0.0.tar.gz#e4dd47b19fd41c9fa6f59c6d76f723ae79e76c3db5474e4d9dacc873dd47767a" warn_eol

--- a/share/node-build/iojs-2.0.1
+++ b/share/node-build/iojs-2.0.1
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v2.0.1/iojs-v2.0.1-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v2.0.1/iojs-v2.0.1-linux-x64.tar.gz#ae9a1bcd870774198b5ff3bc9534f7c8cc3790af2c16bca5b07e6f4a6b4a065c"
 binary linux-x86 "https://iojs.org/dist/v2.0.1/iojs-v2.0.1-linux-x86.tar.gz#ab5bf0fa89f59ba27eb5e02d70fab724ff50ba6a3e6b0419b1720a9d0fcbd87b"
 
-install_package "iojs-v2.0.1" "https://iojs.org/dist/v2.0.1/iojs-v2.0.1.tar.gz#6d27e6f632a6835b944a60eec1162d35cb6c8c3d0a2caf3e9737bf1ab8b74f47"
+install_package "iojs-v2.0.1" "https://iojs.org/dist/v2.0.1/iojs-v2.0.1.tar.gz#6d27e6f632a6835b944a60eec1162d35cb6c8c3d0a2caf3e9737bf1ab8b74f47" warn_eol

--- a/share/node-build/iojs-2.0.2
+++ b/share/node-build/iojs-2.0.2
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v2.0.2/iojs-v2.0.2-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v2.0.2/iojs-v2.0.2-linux-x64.tar.gz#53bd4c6c56614fe28d988ffec7e6b54cfdded57a3ffbf502a8768f94aa3f1681"
 binary linux-x86 "https://iojs.org/dist/v2.0.2/iojs-v2.0.2-linux-x86.tar.gz#48f4086f22f8801df14726e8ada0dfbc41032bf827415477abfd4888c58e8899"
 
-install_package "iojs-v2.0.2" "https://iojs.org/dist/v2.0.2/iojs-v2.0.2.tar.gz#31cc88739c368ddc1c0d259ab8dc3f2040649f5e4e91456f6fdb3be8815e3ae3"
+install_package "iojs-v2.0.2" "https://iojs.org/dist/v2.0.2/iojs-v2.0.2.tar.gz#31cc88739c368ddc1c0d259ab8dc3f2040649f5e4e91456f6fdb3be8815e3ae3" warn_eol

--- a/share/node-build/iojs-2.1.0
+++ b/share/node-build/iojs-2.1.0
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v2.1.0/iojs-v2.1.0-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v2.1.0/iojs-v2.1.0-linux-x64.tar.gz#b6774e268360f0ff878caa351b18815a1e4a66d12e5a01cd3479f2e34b784973"
 binary linux-x86 "https://iojs.org/dist/v2.1.0/iojs-v2.1.0-linux-x86.tar.gz#1c81a729a311f377f037787090e37b6c6a56df85314a5d149c1a1566c49b7e56"
 
-install_package "iojs-v2.1.0" "https://iojs.org/dist/v2.1.0/iojs-v2.1.0.tar.gz#f10473944dc0e4a7bd2d57efc65d7c2a1d1991852c2d7b3cb6a0fa81b3fed26c"
+install_package "iojs-v2.1.0" "https://iojs.org/dist/v2.1.0/iojs-v2.1.0.tar.gz#f10473944dc0e4a7bd2d57efc65d7c2a1d1991852c2d7b3cb6a0fa81b3fed26c" warn_eol

--- a/share/node-build/iojs-2.2.0
+++ b/share/node-build/iojs-2.2.0
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v2.2.0/iojs-v2.2.0-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v2.2.0/iojs-v2.2.0-linux-x64.tar.gz#217502ffe322b238afbbc863be626ae5097551449d806c5c5315c78fee39e186"
 binary linux-x86 "https://iojs.org/dist/v2.2.0/iojs-v2.2.0-linux-x86.tar.gz#beec38a199fa01c81bb8f1a55a392d3372226d9a3da45da96ef141cf758070a0"
 
-install_package "iojs-v2.2.0" "https://iojs.org/dist/v2.2.0/iojs-v2.2.0.tar.gz#b816b793ff474e6502b096845165884b5871a9e021ae532182ca363c1bb8ec52"
+install_package "iojs-v2.2.0" "https://iojs.org/dist/v2.2.0/iojs-v2.2.0.tar.gz#b816b793ff474e6502b096845165884b5871a9e021ae532182ca363c1bb8ec52" warn_eol

--- a/share/node-build/iojs-2.2.1
+++ b/share/node-build/iojs-2.2.1
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v2.2.1/iojs-v2.2.1-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v2.2.1/iojs-v2.2.1-linux-x64.tar.gz#4e44b6194f189e66505739d200536edf09f26161ad50602921dde86623c3dd7d"
 binary linux-x86 "https://iojs.org/dist/v2.2.1/iojs-v2.2.1-linux-x86.tar.gz#7c1aa41127c965c754eca41ddf17686c43a49e8744041073767ad2a88e335fa1"
 
-install_package "iojs-v2.2.1" "https://iojs.org/dist/v2.2.1/iojs-v2.2.1.tar.gz#55e79cc4f4cde41f03c1e204d2af5ee4b6e4edcf14defc82e518436e939195fa"
+install_package "iojs-v2.2.1" "https://iojs.org/dist/v2.2.1/iojs-v2.2.1.tar.gz#55e79cc4f4cde41f03c1e204d2af5ee4b6e4edcf14defc82e518436e939195fa" warn_eol

--- a/share/node-build/iojs-2.3.0
+++ b/share/node-build/iojs-2.3.0
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v2.3.0/iojs-v2.3.0-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v2.3.0/iojs-v2.3.0-linux-x64.tar.gz#d1cee3cd8e1373ad376bed14f771c4f29a210d6d38397c28a2bd74f8fc749a78"
 binary linux-x86 "https://iojs.org/dist/v2.3.0/iojs-v2.3.0-linux-x86.tar.gz#0154fcfdc26143d9b43ad2e46de2d0e5ccec8e4eae06930899fb1127a5be0f2e"
 
-install_package "iojs-v2.3.0" "https://iojs.org/dist/v2.3.0/iojs-v2.3.0.tar.gz#556e1a2f58c993fcb7a89c55bc2a4da6fba74cd4d444777a8b64b19d57c4cc3c"
+install_package "iojs-v2.3.0" "https://iojs.org/dist/v2.3.0/iojs-v2.3.0.tar.gz#556e1a2f58c993fcb7a89c55bc2a4da6fba74cd4d444777a8b64b19d57c4cc3c" warn_eol

--- a/share/node-build/iojs-2.3.1
+++ b/share/node-build/iojs-2.3.1
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v2.3.1/iojs-v2.3.1-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v2.3.1/iojs-v2.3.1-linux-x64.tar.gz#26c2021becadd14b46a44c6657aafe85c5703d77ba94ce9f1f9ea5f054ad6ccd"
 binary linux-x86 "https://iojs.org/dist/v2.3.1/iojs-v2.3.1-linux-x86.tar.gz#f63e168d31642caa2cecdfa0ff1178a07992fbfc5d259725d518553932e463e7"
 
-install_package "iojs-v2.3.1" "https://iojs.org/dist/v2.3.1/iojs-v2.3.1.tar.gz#c2198e3a63fc204a4bcb11568ce9925a4985b87048222a0a7da1143f8f866aee"
+install_package "iojs-v2.3.1" "https://iojs.org/dist/v2.3.1/iojs-v2.3.1.tar.gz#c2198e3a63fc204a4bcb11568ce9925a4985b87048222a0a7da1143f8f866aee" warn_eol

--- a/share/node-build/iojs-2.3.2
+++ b/share/node-build/iojs-2.3.2
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v2.3.2/iojs-v2.3.2-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v2.3.2/iojs-v2.3.2-linux-x64.tar.gz#55d9622f2f3eb5ed3976431224206735d4c696975ae9f92d50284f89a29a80fb"
 binary linux-x86 "https://iojs.org/dist/v2.3.2/iojs-v2.3.2-linux-x86.tar.gz#aabd7d4e8ea770d3b378b8bfda7ff68037f9d18395545271de9d73465a6af7c5"
 
-install_package "iojs-v2.3.2" "https://iojs.org/dist/v2.3.2/iojs-v2.3.2.tar.gz#87722b5fd2ac5e79b1ac7bb802e23613011af6095ef7a49c0b46c4fc98ecfb7b"
+install_package "iojs-v2.3.2" "https://iojs.org/dist/v2.3.2/iojs-v2.3.2.tar.gz#87722b5fd2ac5e79b1ac7bb802e23613011af6095ef7a49c0b46c4fc98ecfb7b" warn_eol

--- a/share/node-build/iojs-2.3.3
+++ b/share/node-build/iojs-2.3.3
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v2.3.3/iojs-v2.3.3-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v2.3.3/iojs-v2.3.3-linux-x64.tar.gz#ff910d12c522514329e1fa21c6d24e96aefc4a361e5ef0386c676ad63d3c18e1"
 binary linux-x86 "https://iojs.org/dist/v2.3.3/iojs-v2.3.3-linux-x86.tar.gz#03188ee3e472e140b1ee8c7a8d8c7698aafb75314012a043ca6a517bf1ccd47a"
 
-install_package "iojs-v2.3.3" "https://iojs.org/dist/v2.3.3/iojs-v2.3.3.tar.gz#0384ea20739124c27dc9b47b8079f0c75efb33c7011c45f02243e9a015f8cd89"
+install_package "iojs-v2.3.3" "https://iojs.org/dist/v2.3.3/iojs-v2.3.3.tar.gz#0384ea20739124c27dc9b47b8079f0c75efb33c7011c45f02243e9a015f8cd89" warn_eol

--- a/share/node-build/iojs-2.3.4
+++ b/share/node-build/iojs-2.3.4
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v2.3.4/iojs-v2.3.4-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v2.3.4/iojs-v2.3.4-linux-x64.tar.gz#655e33e62a6bad494a7feefdc8e332e00f8fe480e55ab723b50aa3008d8152d4"
 binary linux-x86 "https://iojs.org/dist/v2.3.4/iojs-v2.3.4-linux-x86.tar.gz#a9a209df1f2f26765f1ea05ea51de7c58fc2ea65efa98533ccf5bd9f9be06bbb"
 
-install_package "iojs-v2.3.4" "https://iojs.org/dist/v2.3.4/iojs-v2.3.4.tar.gz#18aeb8ad79b549f45caf6e4baa421046a0cd8f60102ac0986f19b19174962cc1"
+install_package "iojs-v2.3.4" "https://iojs.org/dist/v2.3.4/iojs-v2.3.4.tar.gz#18aeb8ad79b549f45caf6e4baa421046a0cd8f60102ac0986f19b19174962cc1" warn_eol

--- a/share/node-build/iojs-2.4.0
+++ b/share/node-build/iojs-2.4.0
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v2.4.0/iojs-v2.4.0-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v2.4.0/iojs-v2.4.0-linux-x64.tar.gz#b7110e8323e2ba8a6f330e2de8d98ce7003294a8cf7e3ade36022cc4cbd6266f"
 binary linux-x86 "https://iojs.org/dist/v2.4.0/iojs-v2.4.0-linux-x86.tar.gz#3289ea9bdc83d177c7e17ef0b5075ef7f8363aa2d94ab03eaa789fbdb796c683"
 
-install_package "iojs-v2.4.0" "https://iojs.org/dist/v2.4.0/iojs-v2.4.0.tar.gz#1e2546fef303f7bb99c29297459e8debda2684e27ff535a746f57d82915d013d"
+install_package "iojs-v2.4.0" "https://iojs.org/dist/v2.4.0/iojs-v2.4.0.tar.gz#1e2546fef303f7bb99c29297459e8debda2684e27ff535a746f57d82915d013d" warn_eol

--- a/share/node-build/iojs-2.5.0
+++ b/share/node-build/iojs-2.5.0
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v2.5.0/iojs-v2.5.0-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v2.5.0/iojs-v2.5.0-linux-x64.tar.gz#efb56b7294a5e8844c5f4a0e57e4a6cde491002d1841e784058da38e6c35e129"
 binary linux-x86 "https://iojs.org/dist/v2.5.0/iojs-v2.5.0-linux-x86.tar.gz#83da9de19605e754d2b5dcb202f718cb980f211dc23a31bf35b5ad66bf689df4"
 
-install_package "iojs-v2.5.0" "https://iojs.org/dist/v2.5.0/iojs-v2.5.0.tar.gz#8d0b5f6a28655045d04cdc6fd2d4eb76fa2e02ad0610cdfc2a441f7c39ee404a"
+install_package "iojs-v2.5.0" "https://iojs.org/dist/v2.5.0/iojs-v2.5.0.tar.gz#8d0b5f6a28655045d04cdc6fd2d4eb76fa2e02ad0610cdfc2a441f7c39ee404a" warn_eol

--- a/share/node-build/iojs-3.0.0
+++ b/share/node-build/iojs-3.0.0
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v3.0.0/iojs-v3.0.0-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v3.0.0/iojs-v3.0.0-linux-x64.tar.gz#bbf8d9479bbb1eb5fb374d8e7aa26974bef67f2d451d085687160b0c5d9d73e2"
 binary linux-x86 "https://iojs.org/dist/v3.0.0/iojs-v3.0.0-linux-x86.tar.gz#10da1f422f639112a0a651fa7daa32d444c1fbc5a0aa70e774ade8c82f85ba3c"
 
-install_package "iojs-v3.0.0" "https://iojs.org/dist/v3.0.0/iojs-v3.0.0.tar.gz#0e7f6bda7f500bb80c42dfdb896ed170ed5bbfb30c5a84f2f0e31f6f72ed5d55"
+install_package "iojs-v3.0.0" "https://iojs.org/dist/v3.0.0/iojs-v3.0.0.tar.gz#0e7f6bda7f500bb80c42dfdb896ed170ed5bbfb30c5a84f2f0e31f6f72ed5d55" warn_eol

--- a/share/node-build/iojs-3.1.0
+++ b/share/node-build/iojs-3.1.0
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v3.1.0/iojs-v3.1.0-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v3.1.0/iojs-v3.1.0-linux-x64.tar.gz#c2bb4a848f6f7505bb7973d9b1ef9cddc5d533056f623fcd911348a06c950fe9"
 binary linux-x86 "https://iojs.org/dist/v3.1.0/iojs-v3.1.0-linux-x86.tar.gz#252391d427dc325112f8434ba6f91cba87c7ee91945c28de44e352b3e7c007f4"
 
-install_package "iojs-v3.1.0" "https://iojs.org/dist/v3.1.0/iojs-v3.1.0.tar.gz#471c6faa28d53c0290ecbf9358f6416fca4786aad079e23c44a88cc7f42d1097"
+install_package "iojs-v3.1.0" "https://iojs.org/dist/v3.1.0/iojs-v3.1.0.tar.gz#471c6faa28d53c0290ecbf9358f6416fca4786aad079e23c44a88cc7f42d1097" warn_eol

--- a/share/node-build/iojs-3.2.0
+++ b/share/node-build/iojs-3.2.0
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v3.2.0/iojs-v3.2.0-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v3.2.0/iojs-v3.2.0-linux-x64.tar.gz#05b4b27b1e964c9d93f21520e02e4e15c88cbe6c933bb44834c17287a305844f"
 binary linux-x86 "https://iojs.org/dist/v3.2.0/iojs-v3.2.0-linux-x86.tar.gz#9f54b33806d563cf2a32bda00963f204d7a67019b8071e79df5d50ff3612e165"
 
-install_package "iojs-v3.2.0" "https://iojs.org/dist/v3.2.0/iojs-v3.2.0.tar.gz#c31ffbbc8ba1e2aa3834efb2441b967bb309f1beeda6c7a7c9ce0cc9fa3a89ee"
+install_package "iojs-v3.2.0" "https://iojs.org/dist/v3.2.0/iojs-v3.2.0.tar.gz#c31ffbbc8ba1e2aa3834efb2441b967bb309f1beeda6c7a7c9ce0cc9fa3a89ee" warn_eol

--- a/share/node-build/iojs-3.3.0
+++ b/share/node-build/iojs-3.3.0
@@ -4,4 +4,4 @@ binary linux-armv7l "https://iojs.org/dist/v3.3.0/iojs-v3.3.0-linux-armv7l.tar.g
 binary linux-x64 "https://iojs.org/dist/v3.3.0/iojs-v3.3.0-linux-x64.tar.gz#c9b1c51b7cc780c19df504e29e26b27ee89f7bf6f8d601da597f52e7e39767fd"
 binary linux-x86 "https://iojs.org/dist/v3.3.0/iojs-v3.3.0-linux-x86.tar.gz#197716f55592c85e04f644f9e2ef0d276cf90fecba3cf0e01bad6d3d628446dd"
 
-install_package "iojs-v3.3.0" "https://iojs.org/dist/v3.3.0/iojs-v3.3.0.tar.gz#e84a649858e6f5c1458c0d5d7bf1952f78e93a26ea6bc519222e92e43e2fadde"
+install_package "iojs-v3.3.0" "https://iojs.org/dist/v3.3.0/iojs-v3.3.0.tar.gz#e84a649858e6f5c1458c0d5d7bf1952f78e93a26ea6bc519222e92e43e2fadde" warn_eol

--- a/share/node-build/iojs-3.3.1
+++ b/share/node-build/iojs-3.3.1
@@ -7,4 +7,4 @@ binary linux-x86 "https://iojs.org/dist/v3.3.1/iojs-v3.3.1-linux-x86.tar.gz#88e4
 binary sunos-x64 "https://iojs.org/dist/v3.3.1/iojs-v3.3.1-sunos-x64.tar.gz#a2e2a2c22b9ef3a5459204888d7d9d9e7d1991782bda46b8b8e7dabfcb958c28"
 binary sunos-x86 "https://iojs.org/dist/v3.3.1/iojs-v3.3.1-sunos-x86.tar.gz#b85b49b9b09a100b3e5fca3c4f87591df49e832f38d0ad59ad99a3140f41a48c"
 
-install_package "iojs-v3.3.1" "https://iojs.org/dist/v3.3.1/iojs-v3.3.1.tar.gz#b1ce0bb2ddb5d012bd9f22c787a4c74ce5d1546553086e40785be91489fee1d1"
+install_package "iojs-v3.3.1" "https://iojs.org/dist/v3.3.1/iojs-v3.3.1.tar.gz#b1ce0bb2ddb5d012bd9f22c787a4c74ce5d1546553086e40785be91489fee1d1" warn_eol

--- a/share/node-build/jxcore+sm-0.3.0.0
+++ b/share/node-build/jxcore+sm-0.3.0.0
@@ -13,5 +13,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0300/jx_suse64sm.zip#5a6cc2f616
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0300/jx_ub32sm.zip#63965f2165154af1e6c9d9e343ac9b7a586459138ed6656313958ff3ab838e83"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0300/jx_ub64sm.zip#9c30cd5dbf5afb166d06e0118536af2a49fae14f49d67adee06459934a75c934"
 
-install_package jxcore-0.3.0.0 "https://github.com/jxcore/jxcore/archive/v0.3.0.tar.gz#1e76648ecd012a2370354369f6161666763b4bc028544e9dc0cb27c035a90f24" jxcore_spidermonkey standard
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm
+install_package jxcore-0.3.0.0 "https://github.com/jxcore/jxcore/archive/v0.3.0.tar.gz#1e76648ecd012a2370354369f6161666763b4bc028544e9dc0cb27c035a90f24" jxcore_spidermonkey standard warn_eol
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm warn_eol

--- a/share/node-build/jxcore+sm-0.3.0.1
+++ b/share/node-build/jxcore+sm-0.3.0.1
@@ -15,5 +15,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0301/jx_suse64sm.zip#f30284f909
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0301/jx_ub32sm.zip#c7f76539280d5131f9d01657c6c62e6b759703e720ff51aa0aa3550265a3fec4"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0301/jx_ub64sm.zip#14add2a2f0ac6909dfbcdf39301e0f779866ca2fd5cfc0c97866834f2b6a8c45"
 
-install_package jxcore-0.3.0.1 "https://github.com/jxcore/jxcore/archive/v0.3.0.1.tar.gz#fd25b575b4dd42be87f9681dbcf9812836bc6389f6d90073913092085e902a44" jxcore_spidermonkey standard
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm
+install_package jxcore-0.3.0.1 "https://github.com/jxcore/jxcore/archive/v0.3.0.1.tar.gz#fd25b575b4dd42be87f9681dbcf9812836bc6389f6d90073913092085e902a44" jxcore_spidermonkey standard warn_eol
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm warn_eol

--- a/share/node-build/jxcore+sm-0.3.0.2
+++ b/share/node-build/jxcore+sm-0.3.0.2
@@ -15,5 +15,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0302/jx_suse64sm.zip#0943b465a1
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0302/jx_ub32sm.zip#2d25443d6895dfd9f62eb9e281081eba6d5ba6fd239eeabd02a65137ef61dada"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0302/jx_ub64sm.zip#433ac458be0ac02e1ffb6f6e1db1034f35ac746286d48a40b8b65875e211e689"
 
-install_package jxcore-0.3.0.2 "https://github.com/jxcore/jxcore/archive/v0.3.0.2.tar.gz#79baa480676ef44a93d2cf6081b4d001ecf09cb746b73143cf264e8ba8601b96" jxcore_spidermonkey standard
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm
+install_package jxcore-0.3.0.2 "https://github.com/jxcore/jxcore/archive/v0.3.0.2.tar.gz#79baa480676ef44a93d2cf6081b4d001ecf09cb746b73143cf264e8ba8601b96" jxcore_spidermonkey standard warn_eol
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm warn_eol

--- a/share/node-build/jxcore+sm-0.3.0.3
+++ b/share/node-build/jxcore+sm-0.3.0.3
@@ -15,5 +15,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0303/jx_suse64sm.zip#90b970b82e
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0303/jx_ub32sm.zip#ade168bbeb6d16879b0284579d8fb77f78f0c6f983a2b9f18a8df324026a2f28"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0303/jx_ub64sm.zip#759e82a993592e91d858feb3b0a5df70fadcf42f91a393f6e8dfec5f8fb95bfd"
 
-install_package jxcore-0.3.0.3 "https://github.com/jxcore/jxcore/archive/v0.3.0.3.tar.gz#b8e4f5c791f130fb0dd51fc0489bdadf5b4dfd2ed56e050943d3269631e1ccdc" jxcore_spidermonkey standard
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx303.tar.gz#f3479e698f7d9288256b944cfb14842349364575a2819bd4d635ec79924c6368" jxcore_npm
+install_package jxcore-0.3.0.3 "https://github.com/jxcore/jxcore/archive/v0.3.0.3.tar.gz#b8e4f5c791f130fb0dd51fc0489bdadf5b4dfd2ed56e050943d3269631e1ccdc" jxcore_spidermonkey standard warn_eol
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx303.tar.gz#f3479e698f7d9288256b944cfb14842349364575a2819bd4d635ec79924c6368" jxcore_npm warn_eol

--- a/share/node-build/jxcore+sm-0.3.0.4
+++ b/share/node-build/jxcore+sm-0.3.0.4
@@ -15,5 +15,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0304/jx_suse64sm.zip#ff724ecdce
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0304/jx_ub32sm.zip#0d44fc932924e4b5e27feae5e0f795a8075627e8e418d8f5ad2c5a533defc0f2"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0304/jx_ub64sm.zip#cec1b83501ebc39bc2109941bc7edb8826edda66282de6929ac3127978bd4d94"
 
-install_package jxcore-0.3.0.4 "https://github.com/jxcore/jxcore/archive/v0.3.0.4.tar.gz#84e67ee008abb6794940806ab2992536144d9e831643181ea0230f4e8f1aade7" jxcore_spidermonkey standard
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx304.tar.gz#e12617fe36c58c59ee5d06e99f421f21b8a3215d5d780597e5218e2c6b63f17a" jxcore_npm
+install_package jxcore-0.3.0.4 "https://github.com/jxcore/jxcore/archive/v0.3.0.4.tar.gz#84e67ee008abb6794940806ab2992536144d9e831643181ea0230f4e8f1aade7" jxcore_spidermonkey standard warn_eol
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx304.tar.gz#e12617fe36c58c59ee5d06e99f421f21b8a3215d5d780597e5218e2c6b63f17a" jxcore_npm warn_eol

--- a/share/node-build/jxcore+sm-0.3.0.5
+++ b/share/node-build/jxcore+sm-0.3.0.5
@@ -15,5 +15,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0305/jx_suse64sm.zip#04c98d4da5
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0305/jx_ub32sm.zip#a1b4166cf948e27120c9e3c85c5940716e7f649654343955e4ae659a58f29518"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0305/jx_ub64sm.zip#d254d665b42d2b4f632c73ce6afef25d8da19846cf5a9fa4eb73be9a0f9aaaa0"
 
-install_package jxcore-0.3.0.5 "https://github.com/jxcore/jxcore/archive/v0.3.0.5.tar.gz#a7c7759f66609f32bc2aed5f3674e251d66710bb742417faf5c0059319cc00b5" jxcore_spidermonkey standard
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx305.tar.gz#fdefdb122e6ca0ea23a11730c7e032742a86b2c7e9e46421304bc6b7ce99a7fa" jxcore_npm
+install_package jxcore-0.3.0.5 "https://github.com/jxcore/jxcore/archive/v0.3.0.5.tar.gz#a7c7759f66609f32bc2aed5f3674e251d66710bb742417faf5c0059319cc00b5" jxcore_spidermonkey standard warn_eol
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx305.tar.gz#fdefdb122e6ca0ea23a11730c7e032742a86b2c7e9e46421304bc6b7ce99a7fa" jxcore_npm warn_eol

--- a/share/node-build/jxcore+sm-0.3.0.6
+++ b/share/node-build/jxcore+sm-0.3.0.6
@@ -15,5 +15,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0306/jx_suse64sm.zip#1f6a6e519f
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0306/jx_ub32sm.zip#c09a3e2442126c349a802c48e2a58b8e391f0355a1ad8131b492b7e2434031ae"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0306/jx_ub64sm.zip#edc80a72aec681bfe2501be2fb89ae9deb7faf265cc208e3a82921a8dedcfb2a"
 
-install_package jxcore-0.3.0.6 "https://github.com/jxcore/jxcore/archive/v0.3.0.6.tar.gz#8e978743f126c27ba6478873013d71575af23082c1804f3cbaa911d720ef0f19" jxcore_spidermonkey standard
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx305.tar.gz#fdefdb122e6ca0ea23a11730c7e032742a86b2c7e9e46421304bc6b7ce99a7fa" jxcore_npm
+install_package jxcore-0.3.0.6 "https://github.com/jxcore/jxcore/archive/v0.3.0.6.tar.gz#8e978743f126c27ba6478873013d71575af23082c1804f3cbaa911d720ef0f19" jxcore_spidermonkey standard warn_eol
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx305.tar.gz#fdefdb122e6ca0ea23a11730c7e032742a86b2c7e9e46421304bc6b7ce99a7fa" jxcore_npm warn_eol

--- a/share/node-build/jxcore+sm-0.3.0.7
+++ b/share/node-build/jxcore+sm-0.3.0.7
@@ -15,5 +15,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0307/jx_suse64sm.zip#b412e9cd7d
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0307/jx_ub32sm.zip#21926feed8baf44c00fb002829191b55399809192f72b44f9170e7830c24fba9"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0307/jx_ub64sm.zip#35ff53927e40105bed20fa41fb00c0dfb99ff69430362874db36ba7f72feae9b"
 
-install_package jxcore-0.3.0.7 "https://github.com/jxcore/jxcore/archive/v0.3.0.7.tar.gz#a5d3daeb736981cafc41eee70c62994bdc9001a88a6a15771624c018c74463c3" jxcore_spidermonkey standard
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx307.tar.gz#7b99397f17f5fdb592842ccd62e25806b2a05ae9997c4508b47412f194e8ba6e" jxcore_npm
+install_package jxcore-0.3.0.7 "https://github.com/jxcore/jxcore/archive/v0.3.0.7.tar.gz#a5d3daeb736981cafc41eee70c62994bdc9001a88a6a15771624c018c74463c3" jxcore_spidermonkey standard warn_eol
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx307.tar.gz#7b99397f17f5fdb592842ccd62e25806b2a05ae9997c4508b47412f194e8ba6e" jxcore_npm warn_eol

--- a/share/node-build/jxcore+sm-0.3.1.0
+++ b/share/node-build/jxcore+sm-0.3.1.0
@@ -15,5 +15,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0310/jx_suse64sm.zip#c40e1a128d
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0310/jx_ub32sm.zip#ac85fe3ac35149aeb4449d6899e82a98ac5e6ebc8fc43fa6c16bdcf666979ab8"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0310/jx_ub64sm.zip#e299ee14fae34f19bb8f838b188aca36266a305950625e909e615923dd15c4be"
 
-install_package jxcore-0.3.1.0 "https://github.com/jxcore/jxcore/archive/v0.3.1.0.tar.gz#cae9dac0602667b5b5dedf2ac23445e2875c2bfb91cbdfd7b370790f8a0c96df" jxcore_spidermonkey standard
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx310.tar.gz#3c8e1b1fed9be44c4ec6fd09e6978a29c3e466f684e2812f6762c0a6d28fb85c" jxcore_npm
+install_package jxcore-0.3.1.0 "https://github.com/jxcore/jxcore/archive/v0.3.1.0.tar.gz#cae9dac0602667b5b5dedf2ac23445e2875c2bfb91cbdfd7b370790f8a0c96df" jxcore_spidermonkey standard warn_eol
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx310.tar.gz#3c8e1b1fed9be44c4ec6fd09e6978a29c3e466f684e2812f6762c0a6d28fb85c" jxcore_npm warn_eol

--- a/share/node-build/jxcore+sm-0.3.1.1
+++ b/share/node-build/jxcore+sm-0.3.1.1
@@ -15,5 +15,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0311/jx_suse64sm.zip#c10c85b6eb
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0311/jx_ub32sm.zip#cd8713e85838a59f421cba51ce488d63fe4ad50046b5d595759797360526aa61"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0311/jx_ub64sm.zip#9f8df5354fc3d7c7148a53bf307183e36f104eb66b0bfb46bfa7e276f2b927d0"
 
-install_package jxcore-0.3.1.1 "https://github.com/jxcore/jxcore/archive/v0.3.1.1.tar.gz#a1a44e0a06158245320a2aca20a7381469a453f3c5e2bc1ce36fdb470801c1f5" jxcore_spidermonkey standard
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx311.tar.gz#b0a696e01db4af87c2b6978453a01e4294951dd915d4770b559cab918a20c127" jxcore_npm
+install_package jxcore-0.3.1.1 "https://github.com/jxcore/jxcore/archive/v0.3.1.1.tar.gz#a1a44e0a06158245320a2aca20a7381469a453f3c5e2bc1ce36fdb470801c1f5" jxcore_spidermonkey standard warn_eol
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx311.tar.gz#b0a696e01db4af87c2b6978453a01e4294951dd915d4770b559cab918a20c127" jxcore_npm warn_eol

--- a/share/node-build/jxcore+sm-dev
+++ b/share/node-build/jxcore+sm-dev
@@ -2,5 +2,5 @@ after_install_package() {
   fix_jxcore_directory_structure
 }
 
-install_git jxcore-dev "https://github.com/jxcore/jxcore.git" "master" jxcore_spidermonkey standard
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx310.tar.gz#3c8e1b1fed9be44c4ec6fd09e6978a29c3e466f684e2812f6762c0a6d28fb85c" jxcore_npm
+install_git jxcore-dev "https://github.com/jxcore/jxcore.git" "master" jxcore_spidermonkey standard warn_eol
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx310.tar.gz#3c8e1b1fed9be44c4ec6fd09e6978a29c3e466f684e2812f6762c0a6d28fb85c" jxcore_npm warn_eol

--- a/share/node-build/jxcore+v8-0.3.0.0
+++ b/share/node-build/jxcore+v8-0.3.0.0
@@ -13,5 +13,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0300/jx_suse64v8.zip#ce7a7ca9db
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0300/jx_ub32v8.zip#d54228a58ae658fb50e866c4236801faf1f13a26b429a8a4de9ec7c325948024"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0300/jx_ub64v8.zip#02ddb8b7fd41714927ef292c1362ca36d14afa9f04d2cc79d31e1925fc2ad6c2"
 
-install_package jxcore-0.3.0.0 "https://github.com/jxcore/jxcore/archive/v0.3.0.tar.gz#1e76648ecd012a2370354369f6161666763b4bc028544e9dc0cb27c035a90f24"
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm
+install_package jxcore-0.3.0.0 "https://github.com/jxcore/jxcore/archive/v0.3.0.tar.gz#1e76648ecd012a2370354369f6161666763b4bc028544e9dc0cb27c035a90f24" warn_eol
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm warn_eol

--- a/share/node-build/jxcore+v8-0.3.0.1
+++ b/share/node-build/jxcore+v8-0.3.0.1
@@ -15,5 +15,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0301/jx_suse64v8.zip#b454a40bb3
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0301/jx_ub32v8.zip#59bc363ab28d044a098ef42927582f87b3a9c8cad894bed0d73caae3a7539dbd"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0301/jx_ub64v8.zip#36ac32276d9fdfee9778718cbb0571ec4bc61680e91c5042a6cd8870d0308a9b"
 
-install_package jxcore-0.3.0.1 "https://github.com/jxcore/jxcore/archive/v0.3.0.1.tar.gz#fd25b575b4dd42be87f9681dbcf9812836bc6389f6d90073913092085e902a44"
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm
+install_package jxcore-0.3.0.1 "https://github.com/jxcore/jxcore/archive/v0.3.0.1.tar.gz#fd25b575b4dd42be87f9681dbcf9812836bc6389f6d90073913092085e902a44" warn_eol
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm warn_eol

--- a/share/node-build/jxcore+v8-0.3.0.2
+++ b/share/node-build/jxcore+v8-0.3.0.2
@@ -15,5 +15,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0302/jx_suse64v8.zip#12098decaf
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0302/jx_ub32v8.zip#f680e0d7f3310acbfc25929f115b24bee77e7eee3276bb0d5e3dcdce2108d0e0"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0302/jx_ub64v8.zip#c87fb4a92ae193009e646d851c89178291374a0e41f83a75bdb4ed48e129474f"
 
-install_package jxcore-0.3.0.2 "https://github.com/jxcore/jxcore/archive/v0.3.0.2.tar.gz#79baa480676ef44a93d2cf6081b4d001ecf09cb746b73143cf264e8ba8601b96"
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm
+install_package jxcore-0.3.0.2 "https://github.com/jxcore/jxcore/archive/v0.3.0.2.tar.gz#79baa480676ef44a93d2cf6081b4d001ecf09cb746b73143cf264e8ba8601b96" warn_eol
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm warn_eol

--- a/share/node-build/jxcore+v8-0.3.0.3
+++ b/share/node-build/jxcore+v8-0.3.0.3
@@ -15,5 +15,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0303/jx_suse64v8.zip#80f3ab32b6
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0303/jx_ub32v8.zip#d5f481f10aad3802ce8368b6a5a381a5557839e19da6d541d17898dcb2fd7099"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0303/jx_ub64v8.zip#257d484f2e563984b6104a3fdb4cf99e7b01bb77a289a0ade045f1e998ec584c"
 
-install_package jxcore-0.3.0.3 "https://github.com/jxcore/jxcore/archive/v0.3.0.3.tar.gz#b8e4f5c791f130fb0dd51fc0489bdadf5b4dfd2ed56e050943d3269631e1ccdc"
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx303.tar.gz#f3479e698f7d9288256b944cfb14842349364575a2819bd4d635ec79924c6368" jxcore_npm
+install_package jxcore-0.3.0.3 "https://github.com/jxcore/jxcore/archive/v0.3.0.3.tar.gz#b8e4f5c791f130fb0dd51fc0489bdadf5b4dfd2ed56e050943d3269631e1ccdc" warn_eol
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx303.tar.gz#f3479e698f7d9288256b944cfb14842349364575a2819bd4d635ec79924c6368" jxcore_npm warn_eol

--- a/share/node-build/jxcore+v8-0.3.0.4
+++ b/share/node-build/jxcore+v8-0.3.0.4
@@ -15,5 +15,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0304/jx_suse64v8.zip#0f368cb1ee
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0304/jx_ub32v8.zip#d8f33ca1544ff89213d65d733511cec6a41e9f384352a4b5310babd0b22baac4"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0304/jx_ub64v8.zip#8a268aa4a6128d214abdfec88c5a636c8ccdffa90f42a038dfb75f87493bb81e"
 
-install_package jxcore-0.3.0.4 "https://github.com/jxcore/jxcore/archive/v0.3.0.4.tar.gz#84e67ee008abb6794940806ab2992536144d9e831643181ea0230f4e8f1aade7"
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx304.tar.gz#e12617fe36c58c59ee5d06e99f421f21b8a3215d5d780597e5218e2c6b63f17a" jxcore_npm
+install_package jxcore-0.3.0.4 "https://github.com/jxcore/jxcore/archive/v0.3.0.4.tar.gz#84e67ee008abb6794940806ab2992536144d9e831643181ea0230f4e8f1aade7" warn_eol
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx304.tar.gz#e12617fe36c58c59ee5d06e99f421f21b8a3215d5d780597e5218e2c6b63f17a" jxcore_npm warn_eol

--- a/share/node-build/jxcore+v8-0.3.0.5
+++ b/share/node-build/jxcore+v8-0.3.0.5
@@ -15,5 +15,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0305/jx_suse64v8.zip#4afad1d2c1
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0305/jx_ub32v8.zip#fc893263bf8252bef52e8ba4ebab1c195fb18437db941c20168755e5e3a02685"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0305/jx_ub64v8.zip#44ffa659f01c3ea4d886a4a4bab17afaff87c5f6f447fe1ebedaa63ec4fd4990"
 
-install_package jxcore-0.3.0.5 "https://github.com/jxcore/jxcore/archive/v0.3.0.5.tar.gz#a7c7759f66609f32bc2aed5f3674e251d66710bb742417faf5c0059319cc00b5"
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx305.tar.gz#fdefdb122e6ca0ea23a11730c7e032742a86b2c7e9e46421304bc6b7ce99a7fa" jxcore_npm
+install_package jxcore-0.3.0.5 "https://github.com/jxcore/jxcore/archive/v0.3.0.5.tar.gz#a7c7759f66609f32bc2aed5f3674e251d66710bb742417faf5c0059319cc00b5" warn_eol
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx305.tar.gz#fdefdb122e6ca0ea23a11730c7e032742a86b2c7e9e46421304bc6b7ce99a7fa" jxcore_npm warn_eol

--- a/share/node-build/jxcore+v8-0.3.0.6
+++ b/share/node-build/jxcore+v8-0.3.0.6
@@ -15,5 +15,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0306/jx_suse64v8.zip#a3c1fffb47
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0306/jx_ub32v8.zip#fcdeaf029f293437ed3e2811006cb96f27ce52178abe4004a0fe48d42be71a57"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0306/jx_ub64v8.zip#675766946cc2baf8727f96cbd57223ce0f6add0fb9342445bd6a8ebcf25a3112"
 
-install_package jxcore-0.3.0.6 "https://github.com/jxcore/jxcore/archive/v0.3.0.6.tar.gz#8e978743f126c27ba6478873013d71575af23082c1804f3cbaa911d720ef0f19"
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx305.tar.gz#fdefdb122e6ca0ea23a11730c7e032742a86b2c7e9e46421304bc6b7ce99a7fa" jxcore_npm
+install_package jxcore-0.3.0.6 "https://github.com/jxcore/jxcore/archive/v0.3.0.6.tar.gz#8e978743f126c27ba6478873013d71575af23082c1804f3cbaa911d720ef0f19" warn_eol
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx305.tar.gz#fdefdb122e6ca0ea23a11730c7e032742a86b2c7e9e46421304bc6b7ce99a7fa" jxcore_npm warn_eol

--- a/share/node-build/jxcore+v8-0.3.0.7
+++ b/share/node-build/jxcore+v8-0.3.0.7
@@ -15,5 +15,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0307/jx_suse64v8.zip#139eab46f5
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0307/jx_ub32v8.zip#3b33c65c7196c1621612cb4f047abf26f81184eb172550363146a3c7e7724d37"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0307/jx_ub64v8.zip#60368d54f71d6a66bbeebabb8cabcdd81c20bf1a6daa7bdca0d98062e1087330"
 
-install_package jxcore-0.3.0.7 "https://github.com/jxcore/jxcore/archive/v0.3.0.7.tar.gz#a5d3daeb736981cafc41eee70c62994bdc9001a88a6a15771624c018c74463c3"
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx307.tar.gz#7b99397f17f5fdb592842ccd62e25806b2a05ae9997c4508b47412f194e8ba6e" jxcore_npm
+install_package jxcore-0.3.0.7 "https://github.com/jxcore/jxcore/archive/v0.3.0.7.tar.gz#a5d3daeb736981cafc41eee70c62994bdc9001a88a6a15771624c018c74463c3" warn_eol
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx307.tar.gz#7b99397f17f5fdb592842ccd62e25806b2a05ae9997c4508b47412f194e8ba6e" jxcore_npm warn_eol

--- a/share/node-build/jxcore+v8-0.3.1.0
+++ b/share/node-build/jxcore+v8-0.3.1.0
@@ -15,5 +15,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0310/jx_suse64v8.zip#a9f1303861
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0310/jx_ub32v8.zip#d533f8fe93000b3ef595cded488ae52b7817fb6cf3860d1d28e7067694ec5e85"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0310/jx_ub64v8.zip#e21abde7d6c5f7d8366c530e09de66a8fec617710988ae24b301a2dd4ea9dbcb"
 
-install_package jxcore-0.3.1.0 "https://github.com/jxcore/jxcore/archive/v0.3.1.0.tar.gz#cae9dac0602667b5b5dedf2ac23445e2875c2bfb91cbdfd7b370790f8a0c96df"
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx310.tar.gz#3c8e1b1fed9be44c4ec6fd09e6978a29c3e466f684e2812f6762c0a6d28fb85c" jxcore_npm
+install_package jxcore-0.3.1.0 "https://github.com/jxcore/jxcore/archive/v0.3.1.0.tar.gz#cae9dac0602667b5b5dedf2ac23445e2875c2bfb91cbdfd7b370790f8a0c96df" warn_eol
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx310.tar.gz#3c8e1b1fed9be44c4ec6fd09e6978a29c3e466f684e2812f6762c0a6d28fb85c" jxcore_npm warn_eol

--- a/share/node-build/jxcore+v8-0.3.1.1
+++ b/share/node-build/jxcore+v8-0.3.1.1
@@ -15,5 +15,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0311/jx_suse64v8.zip#1797be220b
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0311/jx_ub32v8.zip#392bfa35add03ede1b6d18c596d586e0551141ea88d60094241e05ab9b660db1"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0311/jx_ub64v8.zip#f3bd4d58f8af6e03ad1a48c95727ed1c050c2d24f12c7974797ce7d63b3dd8f0"
 
-install_package jxcore-0.3.1.1 "https://github.com/jxcore/jxcore/archive/v0.3.1.1.tar.gz#a1a44e0a06158245320a2aca20a7381469a453f3c5e2bc1ce36fdb470801c1f5"
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx311.tar.gz#b0a696e01db4af87c2b6978453a01e4294951dd915d4770b559cab918a20c127" jxcore_npm
+install_package jxcore-0.3.1.1 "https://github.com/jxcore/jxcore/archive/v0.3.1.1.tar.gz#a1a44e0a06158245320a2aca20a7381469a453f3c5e2bc1ce36fdb470801c1f5" warn_eol
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx311.tar.gz#b0a696e01db4af87c2b6978453a01e4294951dd915d4770b559cab918a20c127" jxcore_npm warn_eol

--- a/share/node-build/jxcore+v8-dev
+++ b/share/node-build/jxcore+v8-dev
@@ -2,5 +2,5 @@ after_install_package() {
   fix_jxcore_directory_structure
 }
 
-install_git jxcore-dev "https://github.com/jxcore/jxcore.git" "master"
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx310.tar.gz#3c8e1b1fed9be44c4ec6fd09e6978a29c3e466f684e2812f6762c0a6d28fb85c" jxcore_npm
+install_git jxcore-dev "https://github.com/jxcore/jxcore.git" "master" warn_eol
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx310.tar.gz#3c8e1b1fed9be44c4ec6fd09e6978a29c3e466f684e2812f6762c0a6d28fb85c" jxcore_npm warn_eol


### PR DESCRIPTION
This is a carry-over from https://github.com/rbenv/ruby-build/pull/942.

So far, this pr cherry-picks the `build_package_warn_eol` and `build_package_warn_unsupported ` functions from https://github.com/rbenv/ruby-build/pull/942.

Because of the way we've added binary support, this feature is a little weird.

The `binary` commands save any matching binary into a variable. Then when `install_package` is invoked in the definition, a binary install is attempted _if_ a matching binary was saved from the previous `binary` invocations. However, the binary installation itself is implemented as a call to `install_package` using the `copy` mechanism.

This means that, presently, (before this pr) any extra build commands that trail the `install_package` line in the build definition are *not* invoked if a binary install is successful. This is usually the desired behavior. Most of these extra commands are for autoconf or make. However, there are the occasional command that make sense for binaries, too. Which, until now, have been accomplished using `after_install` hooks.

So a couple options.

1. We could pass the extra commands along to the binary installs. This could potentially be safe because any commands that *aren't* intended to also apply to binary installs are likely just setting env vars for autoconf/make. However, there is a risk that some future command is not safe for binary installs.
2. We could pass the extra commands along to the binary installs, but filter for `warn_*` commands. Much more safe than above, but super hacky.
3. We could require these types of commands (that apply to both binary and standard installs) be invoked only through `before_install` or `after_install` hooks. This is what's used for jxcore-related build commands.
4. Duplicate the commands to the `binary` commands. This is rather brute force and is redundant (since the same `warn_eol` command would need added to every `binary` command in the definition). But it's very safe and explicit. However, it's rather ugly to force the `binary` function to be responsible for platform matching as well as handling build commands.
5. Refactor the binary install mechanism to be less brittle/hacky. Lots of work, but would be better in the long run.
6. Other options?