### PR TITLE
Add 'nightly' definition

### DIFF
--- a/share/node-build/nightly
+++ b/share/node-build/nightly
@@ -1,0 +1,18 @@
+nightlies="https://nodejs.org/download/nightly"
+
+read -ra manifest < <(http get "${nightlies}/index.tab" | tail -n +2 | sort -r -k 2 | head -1)
+
+version="${manifest[0]}"
+date="${manifest[1]}"
+
+IFS=',' read -ra files <<< "${manifest[2]}"
+for file in "${files[@]}"; do
+  case "$file" in
+    headers | src | osx-*-pkg | win-* ) continue;;
+    osx-x64-tar ) file="darwin-x64";;
+  esac
+
+  binary "$file" "${nightlies}/${version}/node-${version}-${file}.tar.gz"
+done
+
+install_package "$version" "${nightlies}/${version}/node-${version}.tar.gz"

--- a/share/node-build/nightly
+++ b/share/node-build/nightly
@@ -1,19 +1,21 @@
 nightlies="https://nodejs.org/download/nightly"
 
-read -ra manifest < <(http get "${nightlies}/index.tab" | tail -n +2 | sort -r -k 2 | head -1)
+read -ra manifest < <(http get "${nightlies}/index.tab" | tail -n +2 | sort -rn -t $'\t' -k2,2 -k1,1 | head -1)
 
 version="${manifest[0]}"
 date="${manifest[1]}"
 
-latest="$(http get "${nightlies}/index.tab" | grep "$date")"
+# warn message if more than one release for recent date
 
+latest="$(http get "${nightlies}/index.tab" | grep "$date")"
 if [ $(wc -l <<<"$latest") -gt 1 ]; then
   {
-    echo "More than one nightly release:"
+    echo "More than one nightly release; installing first of:"
     echo "$latest"
   } >&2
-  exit 1
 fi
+
+# do platform matching of binaries
 
 IFS=',' read -ra files <<< "${manifest[2]}"
 for file in "${files[@]}"; do

--- a/share/node-build/nightly
+++ b/share/node-build/nightly
@@ -5,6 +5,16 @@ read -ra manifest < <(http get "${nightlies}/index.tab" | tail -n +2 | sort -r -
 version="${manifest[0]}"
 date="${manifest[1]}"
 
+latest="$(http get "${nightlies}/index.tab" | grep "$date")"
+
+if [ $(wc -l <<<"$latest") -gt 1 ]; then
+  {
+    echo "More than one nightly release:"
+    echo "$latest"
+  } >&2
+  exit 1
+fi
+
 IFS=',' read -ra files <<< "${manifest[2]}"
 for file in "${files[@]}"; do
   case "$file" in


### PR DESCRIPTION
This definition parses https://nodejs.org/download/nightly/index.tab for the most recently nightly and installs it. Unfortunately, I don't know of a way for the definition file to alter or force the version-name. Thus, nodes installed with this definition file will be named 'nightly'. But I suppose that has its own benefit (being able to force-reinstall the nightly to overwrite and frequently get the latest nightly).

Thoughts?