### PR TITLE
Name nightly builds after their proper build version

### DIFF
--- a/share/node-build/nightly
+++ b/share/node-build/nightly
@@ -1,3 +1,9 @@
+after_install_package() {
+  local v="$("${PREFIX_PATH}/bin/node" -v)"
+  local prefix="$(dirname "$PREFIX_PATH")"
+  mv "$PREFIX_PATH" "${prefix}/${v#v}"
+}
+
 nightlies="https://nodejs.org/download/nightly"
 
 read -ra manifest < <(http get "${nightlies}/index.tab" | tail -n +2 | sort -rn -t $'\t' -k2,2 -k1,1 | head -1)


### PR DESCRIPTION
Using the after_install_package hook, we have a chance to rename a node such that it need not exactly match the build definition.

Thus the `nightly` build definition can be run, and still result in `7.0.0-nightly2016xxxxxx`

Pros:
- the name accurately reflects the node version
- running `nodenv install nightly` on different days will not (assuming new nightlies are released) simply replace the `nightly` version. (this is also a con)

Cons:
- running `nodenv install nightly` on different days will result in different nodes being installed. (though they will each be uniquely identified with unique names)
- running `nodenv install nightly` frequently will result in a clutter of nightly nodes

I would like to have the desired approach decided before the next node-build release. That way the `nightly` build definition that gets released won't change much in behavior after release.

So: should `nightly` (and likewise `latest` or `latest-4.x`, etc) build definitions result in a node version named `nightly` (etc)?

Or does it make since for these build definitions to result in literal node builds with version-based names? 
- `nightly` -> `7.0.0-nightly20160501abcdefg`
- `latest-4.x` -> `4.4.4`
- `lts` -> `4.4.4`
- etc

/ @jawshooah 