### PR TITLE
Only match nightlies that include the source

### DIFF
--- a/share/node-build/nightly
+++ b/share/node-build/nightly
@@ -6,7 +6,7 @@ after_install_package() {
 
 nightlies="https://nodejs.org/download/nightly"
 
-read -ra manifest < <(http get "${nightlies}/index.tab" | tail -n +2 | sort -rn -t $'\t' -k2,2 -k1,1 | head -1)
+read -ra manifest < <(http get "${nightlies}/index.tab" | grep src | sort -rn -t $'\t' -k2,2 -k1,1 | head -1)
 
 version="${manifest[0]}"
 date="${manifest[1]}"


### PR DESCRIPTION
Some nodejs nightlies dropped without the source tarball. Without the
src tarball, there is no fallback for when a binary doesn't match, thus
completely failing the install.

This change now only grabs nightlies that include the source tarball.
(And due to the grep, no longer needs to omit the header row)

A side effect of this change is that it may now skip more recent
nightlies that have potentially matching binaries for the given
platform. However, it is more important to be able to ensure that a
from-source install is possible for a given nightly, than to have the
latest possible nightly that fails completely if no binary matches
current platform.

This could still be improved to check the current platform first and
allow non-source nightlies IFF a matching binary exists AND a compile
wasn't requested.

fixes #180