### PR TITLE
warn EOL

### DIFF
--- a/bin/node-build
+++ b/bin/node-build
@@ -605,7 +605,7 @@ build_package_warn_eol() {
 
   { echo
     echo "WARNING: $package_name is past its end of life and is now unsupported."
-    echo "It no longer receives bug fixes or critical security updates."
+    echo "It no longer receives bug fixes or security updates."
     echo
   } >&3
 }
@@ -614,8 +614,8 @@ build_package_warn_unsupported() {
   local package_name="$1"
 
   { echo
-    echo "WARNING: $package_name is nearing its end of life."
-    echo "It only receives critical security updates, no bug fixes."
+    echo "WARNING: $package_name is in LTS Maintenance mode and nearing its end of life."
+    echo "It only receives *critical* security updates, *critical* bug fixes and documentation updates."
     echo
   } >&3
 }

--- a/bin/node-build
+++ b/bin/node-build
@@ -610,7 +610,7 @@ build_package_warn_eol() {
   } >&3
 }
 
-build_package_warn_unsupported() {
+build_package_warn_lts_maintenance() {
   local package_name="$1"
 
   { echo

--- a/share/node-build/0.1.100
+++ b/share/node-build/0.1.100
@@ -1,1 +1,5 @@
-install_package "node-v0.1.100" "https://nodejs.org/dist/v0.1.100/node-v0.1.100.tar.gz#623d9157017ca3805cbbca653724f8e25a52be689f821d0c608f94717342e1e2" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.100" "https://nodejs.org/dist/v0.1.100/node-v0.1.100.tar.gz#623d9157017ca3805cbbca653724f8e25a52be689f821d0c608f94717342e1e2"

--- a/share/node-build/0.1.101
+++ b/share/node-build/0.1.101
@@ -1,1 +1,5 @@
-install_package "node-v0.1.101" "https://nodejs.org/dist/v0.1.101/node-v0.1.101.tar.gz#44b08c5c9bd0c23d79d447bc67e1767ec1350a02cec0da6e5ce4c7f790b4e773" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.101" "https://nodejs.org/dist/v0.1.101/node-v0.1.101.tar.gz#44b08c5c9bd0c23d79d447bc67e1767ec1350a02cec0da6e5ce4c7f790b4e773"

--- a/share/node-build/0.1.102
+++ b/share/node-build/0.1.102
@@ -1,1 +1,5 @@
-install_package "node-v0.1.102" "https://nodejs.org/dist/v0.1.102/node-v0.1.102.tar.gz#bd9b1d09ad40ceaef4bdd46019960c5c2fe87026c9598a6fb23c66457510a22d" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.102" "https://nodejs.org/dist/v0.1.102/node-v0.1.102.tar.gz#bd9b1d09ad40ceaef4bdd46019960c5c2fe87026c9598a6fb23c66457510a22d"

--- a/share/node-build/0.1.103
+++ b/share/node-build/0.1.103
@@ -1,1 +1,5 @@
-install_package "node-v0.1.103" "https://nodejs.org/dist/v0.1.103/node-v0.1.103.tar.gz#7482b898a0f9514c74137b490c3ad0810ee5ce1586e8886c5182f6446e56711e" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.103" "https://nodejs.org/dist/v0.1.103/node-v0.1.103.tar.gz#7482b898a0f9514c74137b490c3ad0810ee5ce1586e8886c5182f6446e56711e"

--- a/share/node-build/0.1.104
+++ b/share/node-build/0.1.104
@@ -1,1 +1,5 @@
-install_package "node-v0.1.104" "https://nodejs.org/dist/v0.1.104/node-v0.1.104.tar.gz#a1c776f44bc07305dc0e56df17cc3260eaafa0394c3b06c27448ad85bec272df" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.104" "https://nodejs.org/dist/v0.1.104/node-v0.1.104.tar.gz#a1c776f44bc07305dc0e56df17cc3260eaafa0394c3b06c27448ad85bec272df"

--- a/share/node-build/0.1.14
+++ b/share/node-build/0.1.14
@@ -1,1 +1,5 @@
-install_package "node-v0.1.14" "https://nodejs.org/dist/v0.1.14/node-v0.1.14.tar.gz#ff74848a9d444923e378e45ec46d6d0867889e78a045c43fa33080fe47c85004" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.14" "https://nodejs.org/dist/v0.1.14/node-v0.1.14.tar.gz#ff74848a9d444923e378e45ec46d6d0867889e78a045c43fa33080fe47c85004"

--- a/share/node-build/0.1.15
+++ b/share/node-build/0.1.15
@@ -1,1 +1,5 @@
-install_package "node-v0.1.15" "https://nodejs.org/dist/v0.1.15/node-v0.1.15.tar.gz#aaf90fb73ba9246adce7ea066ecbf954cb8fa1868246b73871adbe1dd3fcc8e0" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.15" "https://nodejs.org/dist/v0.1.15/node-v0.1.15.tar.gz#aaf90fb73ba9246adce7ea066ecbf954cb8fa1868246b73871adbe1dd3fcc8e0"

--- a/share/node-build/0.1.16
+++ b/share/node-build/0.1.16
@@ -1,1 +1,5 @@
-install_package "node-v0.1.16" "https://nodejs.org/dist/v0.1.16/node-v0.1.16.tar.gz#3e2088120bbd45881778d105ec53241bd15b0a90f4061d0e3bec2d7faa2955c2" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.16" "https://nodejs.org/dist/v0.1.16/node-v0.1.16.tar.gz#3e2088120bbd45881778d105ec53241bd15b0a90f4061d0e3bec2d7faa2955c2"

--- a/share/node-build/0.1.17
+++ b/share/node-build/0.1.17
@@ -1,1 +1,5 @@
-install_package "node-v0.1.17" "https://nodejs.org/dist/v0.1.17/node-v0.1.17.tar.gz#86765206da369900663976b215ff6aa38a6b7518474f60c382b3926a0186528a" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.17" "https://nodejs.org/dist/v0.1.17/node-v0.1.17.tar.gz#86765206da369900663976b215ff6aa38a6b7518474f60c382b3926a0186528a"

--- a/share/node-build/0.1.18
+++ b/share/node-build/0.1.18
@@ -1,1 +1,5 @@
-install_package "node-v0.1.18" "https://nodejs.org/dist/v0.1.18/node-v0.1.18.tar.gz#08b2db2dc4f0bb97fc51d79675803e1e4756209531b3c4a9b0f9850802155587" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.18" "https://nodejs.org/dist/v0.1.18/node-v0.1.18.tar.gz#08b2db2dc4f0bb97fc51d79675803e1e4756209531b3c4a9b0f9850802155587"

--- a/share/node-build/0.1.19
+++ b/share/node-build/0.1.19
@@ -1,1 +1,5 @@
-install_package "node-v0.1.19" "https://nodejs.org/dist/v0.1.19/node-v0.1.19.tar.gz#5eff91296a705f72bed6dd493e20af49fd56987e16928f45005605bc6736480a" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.19" "https://nodejs.org/dist/v0.1.19/node-v0.1.19.tar.gz#5eff91296a705f72bed6dd493e20af49fd56987e16928f45005605bc6736480a"

--- a/share/node-build/0.1.20
+++ b/share/node-build/0.1.20
@@ -1,1 +1,5 @@
-install_package "node-v0.1.20" "https://nodejs.org/dist/v0.1.20/node-v0.1.20.tar.gz#4f6684d831554508b2ec4ab3ebe3c417a5f55174a3a00cb5ad67b90d473942fc" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.20" "https://nodejs.org/dist/v0.1.20/node-v0.1.20.tar.gz#4f6684d831554508b2ec4ab3ebe3c417a5f55174a3a00cb5ad67b90d473942fc"

--- a/share/node-build/0.1.21
+++ b/share/node-build/0.1.21
@@ -1,1 +1,5 @@
-install_package "node-v0.1.21" "https://nodejs.org/dist/v0.1.21/node-v0.1.21.tar.gz#f7a7cc74c7b3eff74056bfa4710ae0bde65bf2d86ed9f9fdbc0406e14c0a5100" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.21" "https://nodejs.org/dist/v0.1.21/node-v0.1.21.tar.gz#f7a7cc74c7b3eff74056bfa4710ae0bde65bf2d86ed9f9fdbc0406e14c0a5100"

--- a/share/node-build/0.1.22
+++ b/share/node-build/0.1.22
@@ -1,1 +1,5 @@
-install_package "node-v0.1.22" "https://nodejs.org/dist/v0.1.22/node-v0.1.22.tar.gz#7884d315b318cdd4e45abe76d42cc44aabb792cce1d2974ff7b4669561fb28ba" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.22" "https://nodejs.org/dist/v0.1.22/node-v0.1.22.tar.gz#7884d315b318cdd4e45abe76d42cc44aabb792cce1d2974ff7b4669561fb28ba"

--- a/share/node-build/0.1.23
+++ b/share/node-build/0.1.23
@@ -1,1 +1,5 @@
-install_package "node-v0.1.23" "https://nodejs.org/dist/v0.1.23/node-v0.1.23.tar.gz#69b416d60f288389d25d04797a030b4db6a1ca0cafbd545ca2b8824afaba3035" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.23" "https://nodejs.org/dist/v0.1.23/node-v0.1.23.tar.gz#69b416d60f288389d25d04797a030b4db6a1ca0cafbd545ca2b8824afaba3035"

--- a/share/node-build/0.1.24
+++ b/share/node-build/0.1.24
@@ -1,1 +1,5 @@
-install_package "node-v0.1.24" "https://nodejs.org/dist/v0.1.24/node-v0.1.24.tar.gz#a1bb4bda5c43142485ea4b0f725bae6319132daf90a243635f626f2d191374f4" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.24" "https://nodejs.org/dist/v0.1.24/node-v0.1.24.tar.gz#a1bb4bda5c43142485ea4b0f725bae6319132daf90a243635f626f2d191374f4"

--- a/share/node-build/0.1.25
+++ b/share/node-build/0.1.25
@@ -1,1 +1,5 @@
-install_package "node-v0.1.25" "https://nodejs.org/dist/v0.1.25/node-v0.1.25.tar.gz#48cb603bd55182c22a0030db78be146e137bcf396ff78dc1b7fe748adc9d59a6" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.25" "https://nodejs.org/dist/v0.1.25/node-v0.1.25.tar.gz#48cb603bd55182c22a0030db78be146e137bcf396ff78dc1b7fe748adc9d59a6"

--- a/share/node-build/0.1.26
+++ b/share/node-build/0.1.26
@@ -1,1 +1,5 @@
-install_package "node-v0.1.26" "https://nodejs.org/dist/v0.1.26/node-v0.1.26.tar.gz#8c6e5858bcf1e401af50a7f71d6cbffb3af2f4e41813c46a138edb489bbd84f0" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.26" "https://nodejs.org/dist/v0.1.26/node-v0.1.26.tar.gz#8c6e5858bcf1e401af50a7f71d6cbffb3af2f4e41813c46a138edb489bbd84f0"

--- a/share/node-build/0.1.27
+++ b/share/node-build/0.1.27
@@ -1,1 +1,5 @@
-install_package "node-v0.1.27" "https://nodejs.org/dist/v0.1.27/node-v0.1.27.tar.gz#1f83401b9ede7558350e183fc4386234a803d1253e7fe99bce0aba7138270806" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.27" "https://nodejs.org/dist/v0.1.27/node-v0.1.27.tar.gz#1f83401b9ede7558350e183fc4386234a803d1253e7fe99bce0aba7138270806"

--- a/share/node-build/0.1.28
+++ b/share/node-build/0.1.28
@@ -1,1 +1,5 @@
-install_package "node-v0.1.28" "https://nodejs.org/dist/v0.1.28/node-v0.1.28.tar.gz#06f8a8d5246d34629b1355497c2f0f9f779c7dd9830e3ec51c67cbdae46c9069" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.28" "https://nodejs.org/dist/v0.1.28/node-v0.1.28.tar.gz#06f8a8d5246d34629b1355497c2f0f9f779c7dd9830e3ec51c67cbdae46c9069"

--- a/share/node-build/0.1.29
+++ b/share/node-build/0.1.29
@@ -1,1 +1,5 @@
-install_package "node-v0.1.29" "https://nodejs.org/dist/v0.1.29/node-v0.1.29.tar.gz#b56ddee6fbd89f674df7d38295563f4124e728dbf2dc4e7fb359fd1f6fe9bb06" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.29" "https://nodejs.org/dist/v0.1.29/node-v0.1.29.tar.gz#b56ddee6fbd89f674df7d38295563f4124e728dbf2dc4e7fb359fd1f6fe9bb06"

--- a/share/node-build/0.1.30
+++ b/share/node-build/0.1.30
@@ -1,1 +1,5 @@
-install_package "node-v0.1.30" "https://nodejs.org/dist/v0.1.30/node-v0.1.30.tar.gz#37ee475b43609b9052300472ea33cf027f6777975bc90611837e54ecdad3f22c" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.30" "https://nodejs.org/dist/v0.1.30/node-v0.1.30.tar.gz#37ee475b43609b9052300472ea33cf027f6777975bc90611837e54ecdad3f22c"

--- a/share/node-build/0.1.31
+++ b/share/node-build/0.1.31
@@ -1,1 +1,5 @@
-install_package "node-v0.1.31" "https://nodejs.org/dist/v0.1.31/node-v0.1.31.tar.gz#260972bedf789580b56433ca27a1e3717b131a531a4b3688980a16e65d79abbd" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.31" "https://nodejs.org/dist/v0.1.31/node-v0.1.31.tar.gz#260972bedf789580b56433ca27a1e3717b131a531a4b3688980a16e65d79abbd"

--- a/share/node-build/0.1.32
+++ b/share/node-build/0.1.32
@@ -1,1 +1,5 @@
-install_package "node-v0.1.32" "https://nodejs.org/dist/v0.1.32/node-v0.1.32.tar.gz#1fda75df1f2c15df3d24c59b8cb3f0c649b6476a59354b9ddad25287cb57f73e" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.32" "https://nodejs.org/dist/v0.1.32/node-v0.1.32.tar.gz#1fda75df1f2c15df3d24c59b8cb3f0c649b6476a59354b9ddad25287cb57f73e"

--- a/share/node-build/0.1.33
+++ b/share/node-build/0.1.33
@@ -1,1 +1,5 @@
-install_package "node-v0.1.33" "https://nodejs.org/dist/v0.1.33/node-v0.1.33.tar.gz#4a5db1dbacb22baf3a43a77a9c089bd3eb6b903ccc83e874541c48984310c5a7" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.33" "https://nodejs.org/dist/v0.1.33/node-v0.1.33.tar.gz#4a5db1dbacb22baf3a43a77a9c089bd3eb6b903ccc83e874541c48984310c5a7"

--- a/share/node-build/0.1.90
+++ b/share/node-build/0.1.90
@@ -1,1 +1,5 @@
-install_package "node-v0.1.90" "https://nodejs.org/dist/v0.1.90/node-v0.1.90.tar.gz#0dbd47f6be45049a54de6ff268b25a8ccf8cac38bd75788e713dab35a14695c3" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.90" "https://nodejs.org/dist/v0.1.90/node-v0.1.90.tar.gz#0dbd47f6be45049a54de6ff268b25a8ccf8cac38bd75788e713dab35a14695c3"

--- a/share/node-build/0.1.91
+++ b/share/node-build/0.1.91
@@ -1,1 +1,5 @@
-install_package "node-v0.1.91" "https://nodejs.org/dist/v0.1.91/node-v0.1.91.tar.gz#dcdbd47c9bbe508c86f2dad4f751e5caaf1247a013cb55b8d5e75f47e800f38a" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.91" "https://nodejs.org/dist/v0.1.91/node-v0.1.91.tar.gz#dcdbd47c9bbe508c86f2dad4f751e5caaf1247a013cb55b8d5e75f47e800f38a"

--- a/share/node-build/0.1.92
+++ b/share/node-build/0.1.92
@@ -1,1 +1,5 @@
-install_package "node-v0.1.92" "https://nodejs.org/dist/v0.1.92/node-v0.1.92.tar.gz#f23ba3e4596fa22dabe2f5d5718a55e3100badeb2de2ef623440d9288ce88e04" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.92" "https://nodejs.org/dist/v0.1.92/node-v0.1.92.tar.gz#f23ba3e4596fa22dabe2f5d5718a55e3100badeb2de2ef623440d9288ce88e04"

--- a/share/node-build/0.1.93
+++ b/share/node-build/0.1.93
@@ -1,1 +1,5 @@
-install_package "node-v0.1.93" "https://nodejs.org/dist/v0.1.93/node-v0.1.93.tar.gz#7f0574212b2addb53adb47422b7343ac0872e0fd9618b8e8877f61579686a95a" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.93" "https://nodejs.org/dist/v0.1.93/node-v0.1.93.tar.gz#7f0574212b2addb53adb47422b7343ac0872e0fd9618b8e8877f61579686a95a"

--- a/share/node-build/0.1.94
+++ b/share/node-build/0.1.94
@@ -1,1 +1,5 @@
-install_package "node-v0.1.94" "https://nodejs.org/dist/v0.1.94/node-v0.1.94.tar.gz#93d19477e069171307f66dffc665c900d80382bca021536451c785f78dba1b3d" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.94" "https://nodejs.org/dist/v0.1.94/node-v0.1.94.tar.gz#93d19477e069171307f66dffc665c900d80382bca021536451c785f78dba1b3d"

--- a/share/node-build/0.1.95
+++ b/share/node-build/0.1.95
@@ -1,1 +1,5 @@
-install_package "node-v0.1.95" "https://nodejs.org/dist/v0.1.95/node-v0.1.95.tar.gz#d215477805fc7f48522f97813f0757dcc85b5b9423db1b3e6a16ea78afa375b8" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.95" "https://nodejs.org/dist/v0.1.95/node-v0.1.95.tar.gz#d215477805fc7f48522f97813f0757dcc85b5b9423db1b3e6a16ea78afa375b8"

--- a/share/node-build/0.1.96
+++ b/share/node-build/0.1.96
@@ -1,1 +1,5 @@
-install_package "node-v0.1.96" "https://nodejs.org/dist/v0.1.96/node-v0.1.96.tar.gz#b58c607a3f2549722acc9c7cf1f3ccd57c3c15ca7a8ca4a9e6fe3567e8a0b500" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.96" "https://nodejs.org/dist/v0.1.96/node-v0.1.96.tar.gz#b58c607a3f2549722acc9c7cf1f3ccd57c3c15ca7a8ca4a9e6fe3567e8a0b500"

--- a/share/node-build/0.1.97
+++ b/share/node-build/0.1.97
@@ -1,1 +1,5 @@
-install_package "node-v0.1.97" "https://nodejs.org/dist/v0.1.97/node-v0.1.97.tar.gz#8ad00afa4d43c479a5025293ef83fd69e94ddef5ee2795263ca46222d1c2a954" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.97" "https://nodejs.org/dist/v0.1.97/node-v0.1.97.tar.gz#8ad00afa4d43c479a5025293ef83fd69e94ddef5ee2795263ca46222d1c2a954"

--- a/share/node-build/0.1.98
+++ b/share/node-build/0.1.98
@@ -1,1 +1,5 @@
-install_package "node-v0.1.98" "https://nodejs.org/dist/v0.1.98/node-v0.1.98.tar.gz#6ce54b2e81ba1f4085d165bf3e853111a77e2a20de9493a0d7092665a5c9fda8" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.98" "https://nodejs.org/dist/v0.1.98/node-v0.1.98.tar.gz#6ce54b2e81ba1f4085d165bf3e853111a77e2a20de9493a0d7092665a5c9fda8"

--- a/share/node-build/0.1.99
+++ b/share/node-build/0.1.99
@@ -1,1 +1,5 @@
-install_package "node-v0.1.99" "https://nodejs.org/dist/v0.1.99/node-v0.1.99.tar.gz#fcd771a873609096c33e297869c52799bbcd4038b68112a9185785ca73a235d0" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.1.99" "https://nodejs.org/dist/v0.1.99/node-v0.1.99.tar.gz#fcd771a873609096c33e297869c52799bbcd4038b68112a9185785ca73a235d0"

--- a/share/node-build/0.10-dev
+++ b/share/node-build/0.10-dev
@@ -1,1 +1,5 @@
-install_git "0.10-dev" "https://github.com/nodejs/node.git" "v0.10-staging" standard warn_unsupported
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_git "0.10-dev" "https://github.com/nodejs/node.git" "v0.10-staging" standard

--- a/share/node-build/0.10-next
+++ b/share/node-build/0.10-next
@@ -1,1 +1,5 @@
-install_git "0.10-next" "https://github.com/nodejs/node.git" "v0.10" standard warn_unsupported
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_git "0.10-next" "https://github.com/nodejs/node.git" "v0.10" standard

--- a/share/node-build/0.10.0
+++ b/share/node-build/0.10.0
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.0/node-v0.10.0-darwin-x64.tar.gz#6499e4fc0abe82446ffccc0dac6c29e9744577bb76886d0a92cfc74f799794f4"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.0/node-v0.10.0-darwin-x86.tar.gz#488067bc7ecc96d6bb3df0130304c1f1cd01b5138b85427032c15f83fbf1dd27"
 binary linux-x64 "https://nodejs.org/dist/v0.10.0/node-v0.10.0-linux-x64.tar.gz#a91c84f993c1674be7548deb81486bf34ade4aa9154f7932d294ed945228a5be"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.0/node-v0.10.0-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.10.0/node-v0.10.0-sunos-x64.tar.gz#6fe0569bdc90d3d2a4cf49fe03ab4213085cfc60bc1714d3bbe058543e8c95be"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.0/node-v0.10.0-sunos-x86.tar.gz#bc4dd51c9daba761b2eac5af8ce31184f9ecc2036e8e0a2ca1d03a800c275582"
 
-install_package "node-v0.10.0" "https://nodejs.org/dist/v0.10.0/node-v0.10.0.tar.gz#1624dc37866ebfb5431e3393e6b049cf238cac8ad4d20c6d567263b1259177ab" warn_unsupported
+install_package "node-v0.10.0" "https://nodejs.org/dist/v0.10.0/node-v0.10.0.tar.gz#1624dc37866ebfb5431e3393e6b049cf238cac8ad4d20c6d567263b1259177ab"

--- a/share/node-build/0.10.1
+++ b/share/node-build/0.10.1
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.1/node-v0.10.1-darwin-x64.tar.gz#eb5cc271f39a680b1280a422e7e9da48c0033edf779616656bdc90d4c372c000"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.1/node-v0.10.1-darwin-x86.tar.gz#303151e500ddfe94c04bdfaec825d953414f599b470b04a8346c914c23918460"
 binary linux-x64 "https://nodejs.org/dist/v0.10.1/node-v0.10.1-linux-x64.tar.gz#90c555a55ab5d343148511623fdb7c37a6888952db5340734d1c2b8f0f01dd11"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.1/node-v0.10.1-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.10.1/node-v0.10.1-sunos-x64.tar.gz#0908f81bb72c986e5b80b6a6f4c7848d37a46b360f83f2bdddc090e810196a5b"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.1/node-v0.10.1-sunos-x86.tar.gz#e90bb06af4262bf770bb0e2cbaa5689e1b6bf0ff7c8cfae069d27739f3ba0680"
 
-install_package "node-v0.10.1" "https://nodejs.org/dist/v0.10.1/node-v0.10.1.tar.gz#2628dbf42fb3ec3927e595dc66f2f96e3c23455990dea690e300296d92afe4d3" warn_unsupported
+install_package "node-v0.10.1" "https://nodejs.org/dist/v0.10.1/node-v0.10.1.tar.gz#2628dbf42fb3ec3927e595dc66f2f96e3c23455990dea690e300296d92afe4d3"

--- a/share/node-build/0.10.10
+++ b/share/node-build/0.10.10
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.10/node-v0.10.10-darwin-x64.tar.gz#ecec87637784f98318efa5f076a25985609387782b3e371b7596e939775d7cb6"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.10/node-v0.10.10-darwin-x86.tar.gz#a1555490bae2e7bafb96fe0d12a4fb97949c54e6c083b70d6aef672d77f15b26"
 binary linux-x64 "https://nodejs.org/dist/v0.10.10/node-v0.10.10-linux-x64.tar.gz#ab42335b0e6e45bac62823d995d8062e9ba0344bc416c76a263a5e45773b2e7d"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.10/node-v0.10.10-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.10/node-v0.10.10-sunos-x64.tar.gz#7dafccd4548b4829f31c77cd9261f3cd64d7799422d03d9903a6fe7b402f7b2b"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.10/node-v0.10.10-sunos-x86.tar.gz#2f38f3229d1efbd13326e9ed7ec0b00ce82fbe6699c3f76f7d90dbee2a7a9b69"
 
-install_package "node-v0.10.10" "https://nodejs.org/dist/v0.10.10/node-v0.10.10.tar.gz#a54de71d2c3ac7ae864ab9640b6eecb27d7d49c190ac1ca6526243fd7a8ad15c" warn_unsupported
+install_package "node-v0.10.10" "https://nodejs.org/dist/v0.10.10/node-v0.10.10.tar.gz#a54de71d2c3ac7ae864ab9640b6eecb27d7d49c190ac1ca6526243fd7a8ad15c"

--- a/share/node-build/0.10.11
+++ b/share/node-build/0.10.11
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.11/node-v0.10.11-darwin-x64.tar.gz#0c3e0ba53f3878aa5b3dac9b87cc1eff0dc8110b75d7b3b004a61ebdda734ece"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.11/node-v0.10.11-darwin-x86.tar.gz#6c957697248db3a4ba202dbd3d3c01c3051f9a6c6f13075c4c1e2b2f31b071a0"
 binary linux-x64 "https://nodejs.org/dist/v0.10.11/node-v0.10.11-linux-x64.tar.gz#0fa2be9b44d6acd4bd43908bade00053de35e6e27f72a2dc41d072c86263b52a"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.11/node-v0.10.11-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.11/node-v0.10.11-sunos-x64.tar.gz#2ef86b94f0abc16ffb49cff6444fc4f6eb32b476cc06938e1aeb64f705001c91"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.11/node-v0.10.11-sunos-x86.tar.gz#60237169d3b698c09d4a8ad5260065f338296e592bbce9ee768ea455c33f65f8"
 
-install_package "node-v0.10.11" "https://nodejs.org/dist/v0.10.11/node-v0.10.11.tar.gz#ee4b398efde1fa7a334435910447422dae58e93da8711602c2228485f2b58cb1" warn_unsupported
+install_package "node-v0.10.11" "https://nodejs.org/dist/v0.10.11/node-v0.10.11.tar.gz#ee4b398efde1fa7a334435910447422dae58e93da8711602c2228485f2b58cb1"

--- a/share/node-build/0.10.12
+++ b/share/node-build/0.10.12
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.12/node-v0.10.12-darwin-x64.tar.gz#e41d873b0444937ac1f2816ea8c6c4abb3f0af260c2fc1419e83fb7ea5a23090"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.12/node-v0.10.12-darwin-x86.tar.gz#650c0c2e90fa386cbea97a0e0c963fa14c2f2203856c5282722ebbce72717753"
 binary linux-x64 "https://nodejs.org/dist/v0.10.12/node-v0.10.12-linux-x64.tar.gz#d35f3ddb0e8f2de42f9da225a56c19a7aa5c62276d4278242f31087c0397adb8"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.12/node-v0.10.12-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.12/node-v0.10.12-sunos-x64.tar.gz#eb50e180f02f4fa8157527d7d906b28c3ae9ccc7c081b72d28159c90f2f5a861"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.12/node-v0.10.12-sunos-x86.tar.gz#8d0c36f5a15464ede5c8fe487c81c245def3a772fa014380d506d6bec7f268c5"
 
-install_package "node-v0.10.12" "https://nodejs.org/dist/v0.10.12/node-v0.10.12.tar.gz#7339a7c333454a567a41c900b6ef2f6c89e8c778062c173beb029611b29496b6" warn_unsupported
+install_package "node-v0.10.12" "https://nodejs.org/dist/v0.10.12/node-v0.10.12.tar.gz#7339a7c333454a567a41c900b6ef2f6c89e8c778062c173beb029611b29496b6"

--- a/share/node-build/0.10.13
+++ b/share/node-build/0.10.13
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.13/node-v0.10.13-darwin-x64.tar.gz#45f014d08120cb2a3f03616338e2931d673190a52692336cde386e1a91310115"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.13/node-v0.10.13-darwin-x86.tar.gz#f41b547f80f3aaca7540f9d51ccde5f07f1b3185bd2574f445da1a52eb82a3f6"
 binary linux-x64 "https://nodejs.org/dist/v0.10.13/node-v0.10.13-linux-x64.tar.gz#dcbad86b863faf4a1e10fec9ecd7864cebbbb6783805f1808f563797ce5db2b8"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.13/node-v0.10.13-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.13/node-v0.10.13-sunos-x64.tar.gz#04ec26f8b20606781a08d6afefc17e83f377e59d188b5e491fdacefd1cfb73fa"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.13/node-v0.10.13-sunos-x86.tar.gz#8a86ef4770aada5d21dd9848c43c036dfd7e13a8423861844a165df0c2b72870"
 
-install_package "node-v0.10.13" "https://nodejs.org/dist/v0.10.13/node-v0.10.13.tar.gz#a102fad260d216b95611ddd57aeb6531c92ad1038508390654423feb1b51c059" warn_unsupported
+install_package "node-v0.10.13" "https://nodejs.org/dist/v0.10.13/node-v0.10.13.tar.gz#a102fad260d216b95611ddd57aeb6531c92ad1038508390654423feb1b51c059"

--- a/share/node-build/0.10.14
+++ b/share/node-build/0.10.14
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.14/node-v0.10.14-darwin-x64.tar.gz#1a2f35f53be472de27bef88e6e2efc69b4d563b384ab33eba39a6035570bcc67"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.14/node-v0.10.14-darwin-x86.tar.gz#e867defaa3c7e332f13f92a89263089e6fa70bb1d868a7981d708f227b2575d9"
 binary linux-x64 "https://nodejs.org/dist/v0.10.14/node-v0.10.14-linux-x64.tar.gz#fbed54f3d87febc679823d5309aae52f19f104b8ac6927849b9b852a6fb7d060"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.14/node-v0.10.14-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.14/node-v0.10.14-sunos-x64.tar.gz#5e2796a91441eb7a5326eb35b35e1bd404b45fc125f7a3b0f7efa812957c5040"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.14/node-v0.10.14-sunos-x86.tar.gz#ff49a2b8ab36b041889adbebb9e9b72cf79f73264810f057e00500780bb89497"
 
-install_package "node-v0.10.14" "https://nodejs.org/dist/v0.10.14/node-v0.10.14.tar.gz#5b022575b9f6e5c3c704dfa9ecaf511e1b14eaca196edb3eaf89d246efeb70d9" warn_unsupported
+install_package "node-v0.10.14" "https://nodejs.org/dist/v0.10.14/node-v0.10.14.tar.gz#5b022575b9f6e5c3c704dfa9ecaf511e1b14eaca196edb3eaf89d246efeb70d9"

--- a/share/node-build/0.10.15
+++ b/share/node-build/0.10.15
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.15/node-v0.10.15-darwin-x64.tar.gz#f4ea534e6ca6326a8bf823b6c44ae50f5d968c105a18c6372a8bde2d50518489"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.15/node-v0.10.15-darwin-x86.tar.gz#31f26458689948eaa0a1747cc550a205b8a70b4a8b59737ccfc0fca5b1ce43be"
 binary linux-x64 "https://nodejs.org/dist/v0.10.15/node-v0.10.15-linux-x64.tar.gz#0b5191748a91b1c49947fef6b143f3e5e5633c9381a31aaa467e7c80efafb6e9"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.15/node-v0.10.15-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.15/node-v0.10.15-sunos-x64.tar.gz#bcfff390eb599536114d2697272c6f1b19daa88677428cef5ff9535d6cc24551"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.15/node-v0.10.15-sunos-x86.tar.gz#766eefedc60f7fbd0b96f71738710021570f52ae2c68e936d165312084da84ed"
 
-install_package "node-v0.10.15" "https://nodejs.org/dist/v0.10.15/node-v0.10.15.tar.gz#87345ab3b96aa02c5250d7b5ae1d80e620e8ae2a7f509f7fa18c4aaa340953e8" warn_unsupported
+install_package "node-v0.10.15" "https://nodejs.org/dist/v0.10.15/node-v0.10.15.tar.gz#87345ab3b96aa02c5250d7b5ae1d80e620e8ae2a7f509f7fa18c4aaa340953e8"

--- a/share/node-build/0.10.16
+++ b/share/node-build/0.10.16
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.16/node-v0.10.16-darwin-x64.tar.gz#ca2cfb44f4b592840643f50b11b06aef56328a647afc73db7dc37d7cc61bf393"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.16/node-v0.10.16-darwin-x86.tar.gz#8a7dc94a4661ff0674c0e5000526cf1a1c614ca46f48e5a17917e65867c1641c"
 binary linux-arm-pi "https://nodejs.org/dist/v0.10.16/node-v0.10.16-linux-arm-pi.tar.gz#fcf96d7d1ed743adfd84903ad374acb4ff885f51ee895619501449cf227d15d1"
@@ -6,4 +10,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.16/node-v0.10.16-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.16/node-v0.10.16-sunos-x64.tar.gz#2e00695ee36a90c52aa63233827128faf76f93c2d9128220198a344ab3c79a13"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.16/node-v0.10.16-sunos-x86.tar.gz#9fe6130a62de0c8d9c58a5e7eaa274a413176fce8c8128a3435f5839d629fcdc"
 
-install_package "node-v0.10.16" "https://nodejs.org/dist/v0.10.16/node-v0.10.16.tar.gz#62db6ec83f34733bffdae2f8ee50d7273d568bba8814be29e78a042c1d64f31a" warn_unsupported
+install_package "node-v0.10.16" "https://nodejs.org/dist/v0.10.16/node-v0.10.16.tar.gz#62db6ec83f34733bffdae2f8ee50d7273d568bba8814be29e78a042c1d64f31a"

--- a/share/node-build/0.10.17
+++ b/share/node-build/0.10.17
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.17/node-v0.10.17-darwin-x64.tar.gz#4c2df96d444704aba89ac69952f9cfade9b7651f736c9ccd09e0b40200b56832"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.17/node-v0.10.17-darwin-x86.tar.gz#430c50fbcf4253eb703ab8d0a9992fbb1141bf51076487fcbdb0dab1a63c5003"
 binary linux-x64 "https://nodejs.org/dist/v0.10.17/node-v0.10.17-linux-x64.tar.gz#a4cf2690394cdb2468482816be22365544475777c2e9cf4058ef3015e33b7993"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.17/node-v0.10.17-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.17/node-v0.10.17-sunos-x64.tar.gz#b7b57bb51f0439c2df72a001e2dc6ed5ce2172c2417bac1df4c87d531508128f"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.17/node-v0.10.17-sunos-x86.tar.gz#8a7a2f43a28260bbcc02b0cb3d8a1689f5fdda847c35cce09fb98a47ae62157a"
 
-install_package "node-v0.10.17" "https://nodejs.org/dist/v0.10.17/node-v0.10.17.tar.gz#1f9de40dd2d98bc984a4970ef399ed3ad67f040feaafc711e549f3265bcce61c" warn_unsupported
+install_package "node-v0.10.17" "https://nodejs.org/dist/v0.10.17/node-v0.10.17.tar.gz#1f9de40dd2d98bc984a4970ef399ed3ad67f040feaafc711e549f3265bcce61c"

--- a/share/node-build/0.10.18
+++ b/share/node-build/0.10.18
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.18/node-v0.10.18-darwin-x64.tar.gz#9a0fafc8142a47ae1517c8df2b53188d181f13022d9560202fc906f35575cef0"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.18/node-v0.10.18-darwin-x86.tar.gz#60432fbf590b0e88028fc9f969284d051ae045cf8f40f7f6ddb1bb40705f70c2"
 binary linux-x64 "https://nodejs.org/dist/v0.10.18/node-v0.10.18-linux-x64.tar.gz#480aed8ec0a2acf6c7cc168650045cea559c5b69c9b8538a181af830662c1262"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.18/node-v0.10.18-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.18/node-v0.10.18-sunos-x64.tar.gz#a70735329c07c3cc462011721fc81302e2a4cd7b3c71b5e8586b82dd05df253e"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.18/node-v0.10.18-sunos-x86.tar.gz#d8b0a69fed8d2181dda3c730e4b00d070b23552da2bc939f3dd0ebbaa4ff418d"
 
-install_package "node-v0.10.18" "https://nodejs.org/dist/v0.10.18/node-v0.10.18.tar.gz#3ee4436473869d4d84bb5cad4352b09ace00656467eca7d6db7cd7da5b8c5495" warn_unsupported
+install_package "node-v0.10.18" "https://nodejs.org/dist/v0.10.18/node-v0.10.18.tar.gz#3ee4436473869d4d84bb5cad4352b09ace00656467eca7d6db7cd7da5b8c5495"

--- a/share/node-build/0.10.19
+++ b/share/node-build/0.10.19
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.19/node-v0.10.19-darwin-x64.tar.gz#4a51a73b03184dacd10abb12bfc461db1c35c9167f4348ed851f51ed56806af8"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.19/node-v0.10.19-darwin-x86.tar.gz#79e225bc267a389558ab4a06b6838c2bc288d2088787afff49b6984e495bf0dc"
 binary linux-x64 "https://nodejs.org/dist/v0.10.19/node-v0.10.19-linux-x64.tar.gz#d9ff0bbc075149a91ac97dba8dabdf4473506527bc3c9461fe2cce92d3da1191"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.19/node-v0.10.19-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.19/node-v0.10.19-sunos-x64.tar.gz#aed9156f656d692e6cc6a40e600df0021e846c58fa0e0b023debe9fc542c0496"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.19/node-v0.10.19-sunos-x86.tar.gz#92a7627d6faefa8474610ba53c9065f841cde5620528f1b0b73d0750d08dd0e6"
 
-install_package "node-v0.10.19" "https://nodejs.org/dist/v0.10.19/node-v0.10.19.tar.gz#e50787672cdf6afa6caeef9345ca40c4a69f96a31829a0884ea6ed63dfdde21e" warn_unsupported
+install_package "node-v0.10.19" "https://nodejs.org/dist/v0.10.19/node-v0.10.19.tar.gz#e50787672cdf6afa6caeef9345ca40c4a69f96a31829a0884ea6ed63dfdde21e"

--- a/share/node-build/0.10.2
+++ b/share/node-build/0.10.2
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.2/node-v0.10.2-darwin-x64.tar.gz#cef798ba85522f1e82076cf60cb27ea7d85406ecea461e9dd1b5503d48a23c3b"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.2/node-v0.10.2-darwin-x86.tar.gz#30ec4d0bf99ea44f760f7bf3f4ddbaea305560635991aa96ea2d8ef7590005b2"
 binary linux-x64 "https://nodejs.org/dist/v0.10.2/node-v0.10.2-linux-x64.tar.gz#44ff658b1c3ae027b75310e0173b7d069ae70f6adaed23d22f2e087f5048c428"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.2/node-v0.10.2-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.10.2/node-v0.10.2-sunos-x64.tar.gz#d5f211013177b65115364419bbdc95b68aabb293e115ae127a9c3f31404feeaa"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.2/node-v0.10.2-sunos-x86.tar.gz#8689f820535a84e7b488abb9d83c153f1c591b87a7b89a0e6b88e024a1b3d445"
 
-install_package "node-v0.10.2" "https://nodejs.org/dist/v0.10.2/node-v0.10.2.tar.gz#4eb642897fdb945b49720f2604afc493587aec7a9ff1537e882df659e4dd8aa2" warn_unsupported
+install_package "node-v0.10.2" "https://nodejs.org/dist/v0.10.2/node-v0.10.2.tar.gz#4eb642897fdb945b49720f2604afc493587aec7a9ff1537e882df659e4dd8aa2"

--- a/share/node-build/0.10.20
+++ b/share/node-build/0.10.20
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.20/node-v0.10.20-darwin-x64.tar.gz#f059b3d9dfd42fa9d7d8542e51aea6c92d87aff1b9023fc1c7c12acb7f3d28e5"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.20/node-v0.10.20-darwin-x86.tar.gz#69a921ab23ae6e3aecf03ae8c289d33bf9f24a6b29d36b8493b759856a113e7c"
 binary linux-x64 "https://nodejs.org/dist/v0.10.20/node-v0.10.20-linux-x64.tar.gz#eaebfc66d031f3b5071b72c84dd74f326a9a3c018e14d5de7d107c4f3a36dc96"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.20/node-v0.10.20-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.20/node-v0.10.20-sunos-x64.tar.gz#0cb7827eb73165a22e9c770d4b27aaa47ec13eeb8e49ddd8b5d7111f099bab21"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.20/node-v0.10.20-sunos-x86.tar.gz#0bc199ab554e28536eba659b931471d69048f3d5c01f5d14cc9cb88dc1f0e0f7"
 
-install_package "node-v0.10.20" "https://nodejs.org/dist/v0.10.20/node-v0.10.20.tar.gz#b5af00d4d43644f37caa2dad5fa81e6f898ebb7b238f02a1cddfcff11c81e649" warn_unsupported
+install_package "node-v0.10.20" "https://nodejs.org/dist/v0.10.20/node-v0.10.20.tar.gz#b5af00d4d43644f37caa2dad5fa81e6f898ebb7b238f02a1cddfcff11c81e649"

--- a/share/node-build/0.10.21
+++ b/share/node-build/0.10.21
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.21/node-v0.10.21-darwin-x64.tar.gz#26a2c00b3b61d34a1558b70e093230ead737f43de2be2954deeeef2edd54e7bb"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.21/node-v0.10.21-darwin-x86.tar.gz#88601fa705729002c828d53ac7e8ed716ec860a13985a7c48fcbb5efb8f7f23a"
 binary linux-x64 "https://nodejs.org/dist/v0.10.21/node-v0.10.21-linux-x64.tar.gz#2791efef0a1e9a9231b937e55e5b783146e23291bca59a65092f8340eb7c87c8"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.21/node-v0.10.21-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.21/node-v0.10.21-sunos-x64.tar.gz#1f6eb3674fbd370f1d5db2d00af39c6805dfa725a2f727adfcdea757f51155e4"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.21/node-v0.10.21-sunos-x86.tar.gz#11bfafb20045589dddff2bb12e23f2ae98e877a4a4dcc82a76bf2ad4a28ad93f"
 
-install_package "node-v0.10.21" "https://nodejs.org/dist/v0.10.21/node-v0.10.21.tar.gz#7c125bf22c1756064f2a68310d4822f77c8134ce178b2faa6155671a8124140d" warn_unsupported
+install_package "node-v0.10.21" "https://nodejs.org/dist/v0.10.21/node-v0.10.21.tar.gz#7c125bf22c1756064f2a68310d4822f77c8134ce178b2faa6155671a8124140d"

--- a/share/node-build/0.10.22
+++ b/share/node-build/0.10.22
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.22/node-v0.10.22-darwin-x64.tar.gz#2e9313ce780c7eb377105295dd1b0c803fe78171a26756b1914781c09c67f4bd"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.22/node-v0.10.22-darwin-x86.tar.gz#cb17ea51b6d8ac590396a72d4176903b52d6073a73a2a338dd160f326ea3ef4b"
 binary linux-x64 "https://nodejs.org/dist/v0.10.22/node-v0.10.22-linux-x64.tar.gz#ca5bebc56830260581849c1099f00d1958b549fc59acfc0d37b1f01690e7ed6d"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.22/node-v0.10.22-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.22/node-v0.10.22-sunos-x64.tar.gz#550bf8a08074e0260a8c700b377fc7e14253d3f690d8c7d8dc9becc02d406bc7"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.22/node-v0.10.22-sunos-x86.tar.gz#bb556888914f3d249176dc3a30bf3dbb9a7ce4073f326549b1379f191c1aa610"
 
-install_package "node-v0.10.22" "https://nodejs.org/dist/v0.10.22/node-v0.10.22.tar.gz#157fc58b3f1d109baefac4eb1d32ae747de5e6d55d87d0e9bec8f8dd10679e7e" warn_unsupported
+install_package "node-v0.10.22" "https://nodejs.org/dist/v0.10.22/node-v0.10.22.tar.gz#157fc58b3f1d109baefac4eb1d32ae747de5e6d55d87d0e9bec8f8dd10679e7e"

--- a/share/node-build/0.10.23
+++ b/share/node-build/0.10.23
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.23/node-v0.10.23-darwin-x64.tar.gz#295720906b3f84bd083949125c14920801d98fe7e72e234ea03caa9829af3f84"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.23/node-v0.10.23-darwin-x86.tar.gz#30973b77529cc9422831f73f6121e4e9f7d8d0cb856cf6397b2dcd435307fa8a"
 binary linux-x64 "https://nodejs.org/dist/v0.10.23/node-v0.10.23-linux-x64.tar.gz#0ebee6f9b937ed00efc777c468593e6a277dae897a3700090229c2e18d4a4304"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.23/node-v0.10.23-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.23/node-v0.10.23-sunos-x64.tar.gz#7f41c56a699d48dab5fc725a39f3b399c3244aadba5ba7ee8f3a0ea0f39387fc"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.23/node-v0.10.23-sunos-x86.tar.gz#d3a55483d7675a335f9c69db8a21995cab2fa371f5870d774bc3ee3ae7f1b75e"
 
-install_package "node-v0.10.23" "https://nodejs.org/dist/v0.10.23/node-v0.10.23.tar.gz#1a370c86720441d227e7aad3c0223da7166ab2e0900bec7158aac633ffebb4dd" warn_unsupported
+install_package "node-v0.10.23" "https://nodejs.org/dist/v0.10.23/node-v0.10.23.tar.gz#1a370c86720441d227e7aad3c0223da7166ab2e0900bec7158aac633ffebb4dd"

--- a/share/node-build/0.10.24
+++ b/share/node-build/0.10.24
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.24/node-v0.10.24-darwin-x64.tar.gz#c1c523014124a0327d71ba5d6f737a4c866a170f1749f8895482c5fa8be877b0"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.24/node-v0.10.24-darwin-x86.tar.gz#8b8d2bf9828804c3f8027d7d442713318814a36df12dea97dceda8f4aff42b3c"
 binary linux-x64 "https://nodejs.org/dist/v0.10.24/node-v0.10.24-linux-x64.tar.gz#6ef93f4a5b53cdd4471786dfc488ba9977cb3944285ed233f70c508b50f0cb5f"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.24/node-v0.10.24-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.24/node-v0.10.24-sunos-x64.tar.gz#7cb714df92055b93a908b3b6587ca388a2884b1a9b5247c708a867516994a373"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.24/node-v0.10.24-sunos-x86.tar.gz#af69ab26aae42b05841c098f5d11d17e21d22d980cd32666e2db45a53ddffe34"
 
-install_package "node-v0.10.24" "https://nodejs.org/dist/v0.10.24/node-v0.10.24.tar.gz#610cd733186842cb7f554336d6851a61b2d3d956050d62e49fa359a47640377a" warn_unsupported
+install_package "node-v0.10.24" "https://nodejs.org/dist/v0.10.24/node-v0.10.24.tar.gz#610cd733186842cb7f554336d6851a61b2d3d956050d62e49fa359a47640377a"

--- a/share/node-build/0.10.25
+++ b/share/node-build/0.10.25
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.25/node-v0.10.25-darwin-x64.tar.gz#5ae186f86564df87d82811614f667b9333a6219b02c6f405fd72807b459b8fc7"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.25/node-v0.10.25-darwin-x86.tar.gz#22af5001e5b0166fa91934107c17727e173677e5c972bd7122373743309c5372"
 binary linux-x64 "https://nodejs.org/dist/v0.10.25/node-v0.10.25-linux-x64.tar.gz#1dac61c21fa21e47fc6e799757569c6c3914897ca46fc8f4dd2c8f13f0400626"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.25/node-v0.10.25-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.25/node-v0.10.25-sunos-x64.tar.gz#931059671413872c5c5e862df5f7a56066fdb1fe2b678b9ee3c3b242b23a4198"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.25/node-v0.10.25-sunos-x86.tar.gz#61d187416814dd10074d1db5666fd0ca61be6152fbb7920f0aaa4e285db10717"
 
-install_package "node-v0.10.25" "https://nodejs.org/dist/v0.10.25/node-v0.10.25.tar.gz#46eef3b9d5475a2081dc2b2f7cf1f4c3a56824d1fc9b04e7ed1d7a88e8f6b36f" warn_unsupported
+install_package "node-v0.10.25" "https://nodejs.org/dist/v0.10.25/node-v0.10.25.tar.gz#46eef3b9d5475a2081dc2b2f7cf1f4c3a56824d1fc9b04e7ed1d7a88e8f6b36f"

--- a/share/node-build/0.10.26
+++ b/share/node-build/0.10.26
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.26/node-v0.10.26-darwin-x64.tar.gz#863ec06ea2f9f613de39b15d081cc2fa422937e3492cc09b12c73ac884c80d8f"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.26/node-v0.10.26-darwin-x86.tar.gz#1d851d281d82d49a6b910541dba9fb02851883db485e636e7e890483229effd4"
 binary linux-x64 "https://nodejs.org/dist/v0.10.26/node-v0.10.26-linux-x64.tar.gz#305bf2983c65edea6dd2c9f3669b956251af03523d31cf0a0471504fd5920aac"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.26/node-v0.10.26-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.26/node-v0.10.26-sunos-x64.tar.gz#9d9c05a76cb3353b459e7204d5283ed3988b7a363105ef9698dc0f94243aabf9"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.26/node-v0.10.26-sunos-x86.tar.gz#ac7ec92eb6839fa9aa45f0be2c586a0787d26fbdaefdcbaedc912f7c5fd17f3d"
 
-install_package "node-v0.10.26" "https://nodejs.org/dist/v0.10.26/node-v0.10.26.tar.gz#ef5e4ea6f2689ed7f781355012b942a2347e0299da0804a58de8e6281c4b1daa" warn_unsupported
+install_package "node-v0.10.26" "https://nodejs.org/dist/v0.10.26/node-v0.10.26.tar.gz#ef5e4ea6f2689ed7f781355012b942a2347e0299da0804a58de8e6281c4b1daa"

--- a/share/node-build/0.10.27
+++ b/share/node-build/0.10.27
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.27/node-v0.10.27-darwin-x64.tar.gz#17d4711d0510da53c604bacce68066891ef0dff85e830fbcd2d1b0410bd1ddde"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.27/node-v0.10.27-darwin-x86.tar.gz#8d52be48abd16bdbcaf5487367c7964632fcb5cd9b523f77382544e4783fd2ed"
 binary linux-x64 "https://nodejs.org/dist/v0.10.27/node-v0.10.27-linux-x64.tar.gz#919ef2245045f78725bec9152c711751a1278a8053b86dd181363c0b32465609"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.27/node-v0.10.27-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.27/node-v0.10.27-sunos-x64.tar.gz#37a3a1834c3b7a776ff166c070fa3b84a53b9951bc5ea3b417f62bf3a0970d9b"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.27/node-v0.10.27-sunos-x86.tar.gz#5ec564db1c643c5207c539593d1c37254d9e99f8efee04e35e110f05d190b921"
 
-install_package "node-v0.10.27" "https://nodejs.org/dist/v0.10.27/node-v0.10.27.tar.gz#911876c38974a77e1ddf141285b0a994d8c98bddac7229802d7f16600d69d1fe" warn_unsupported
+install_package "node-v0.10.27" "https://nodejs.org/dist/v0.10.27/node-v0.10.27.tar.gz#911876c38974a77e1ddf141285b0a994d8c98bddac7229802d7f16600d69d1fe"

--- a/share/node-build/0.10.28
+++ b/share/node-build/0.10.28
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.28/node-v0.10.28-darwin-x64.tar.gz#304122e04df8ba3fadaf1ff442b2eb1181bf3ce0d2539a0a7c70a62157aed1f4"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.28/node-v0.10.28-darwin-x86.tar.gz#24d9304c1a94c486c68860a78f3f086968443d11d4f4e59949bbc7c458b18e55"
 binary linux-x64 "https://nodejs.org/dist/v0.10.28/node-v0.10.28-linux-x64.tar.gz#5f41f4a90861bddaea92addc5dfba5357de40962031c2281b1683277a0f75932"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.28/node-v0.10.28-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.28/node-v0.10.28-sunos-x64.tar.gz#dadde2dde10ca1429564ac125cb67fd7f34d1e5332c82ed67abbf5e6224ded15"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.28/node-v0.10.28-sunos-x86.tar.gz#a1820e23a9f9e908079c3b4379a73b884ab4f56acefe28c7593301f51c794d0a"
 
-install_package "node-v0.10.28" "https://nodejs.org/dist/v0.10.28/node-v0.10.28.tar.gz#abddc6441e0f208f6ed8a045e0293f713ea7f6dfb2d6a9a2024bf8b1b4617710" warn_unsupported
+install_package "node-v0.10.28" "https://nodejs.org/dist/v0.10.28/node-v0.10.28.tar.gz#abddc6441e0f208f6ed8a045e0293f713ea7f6dfb2d6a9a2024bf8b1b4617710"

--- a/share/node-build/0.10.29
+++ b/share/node-build/0.10.29
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.29/node-v0.10.29-darwin-x64.tar.gz#219299cd959819e215c4fcd8dfd3ba3ebbf634972667e6ef70e0d1ead741bb27"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.29/node-v0.10.29-darwin-x86.tar.gz#ea936c173c8f14c8493983fd4e5bd9df08ac8dee268640a841ccaedbd621d49d"
 binary linux-x64 "https://nodejs.org/dist/v0.10.29/node-v0.10.29-linux-x64.tar.gz#ac52da27a4e298a6de610de25b22628bdb97b78cb29d11464ef5cfa2e57847d5"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.29/node-v0.10.29-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.29/node-v0.10.29-sunos-x64.tar.gz#988d48b7f65a94c0ee7edbef555156f555d13cf302fff54d27424fd4c0d4392f"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.29/node-v0.10.29-sunos-x86.tar.gz#ef5c2a9237c3a2b7c7ce9d4817fbcf63dd223370d2072da8f7ab2f4b46849e17"
 
-install_package "node-v0.10.29" "https://nodejs.org/dist/v0.10.29/node-v0.10.29.tar.gz#47379d01f765f87c1a1498b4e65de30e45201de50334954860d7375a8258b15d" warn_unsupported
+install_package "node-v0.10.29" "https://nodejs.org/dist/v0.10.29/node-v0.10.29.tar.gz#47379d01f765f87c1a1498b4e65de30e45201de50334954860d7375a8258b15d"

--- a/share/node-build/0.10.3
+++ b/share/node-build/0.10.3
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.3/node-v0.10.3-darwin-x64.tar.gz#5656918cc7cc480afb9fa99053623eb9a9b392db2e2a3d5f60333a1b27eeb495"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.3/node-v0.10.3-darwin-x86.tar.gz#3c16193df9bc44e6721f74341c3b26c1f31b5c28067af5cf8397014c37d4d088"
 binary linux-x64 "https://nodejs.org/dist/v0.10.3/node-v0.10.3-linux-x64.tar.gz#62ce0353c80023cd2eb0a60999b10839d732f5ae3eb75c10d7b3924745b32d21"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.3/node-v0.10.3-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.10.3/node-v0.10.3-sunos-x64.tar.gz#d9bed27c97968dc54047ef6f09161d6a1a7dee702301fa65add97ff1dee6e2af"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.3/node-v0.10.3-sunos-x86.tar.gz#5a4b8e6460a446481fe3fb8eb681d7408711fb3cfbb8bcc06a436706567bc76c"
 
-install_package "node-v0.10.3" "https://nodejs.org/dist/v0.10.3/node-v0.10.3.tar.gz#bc8796ff6414231fa0603e0383404f14648dfd2fe9fb0fa4d4a6043dfddbb328" warn_unsupported
+install_package "node-v0.10.3" "https://nodejs.org/dist/v0.10.3/node-v0.10.3.tar.gz#bc8796ff6414231fa0603e0383404f14648dfd2fe9fb0fa4d4a6043dfddbb328"

--- a/share/node-build/0.10.30
+++ b/share/node-build/0.10.30
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.30/node-v0.10.30-darwin-x64.tar.gz#d13b5ad8294c39175a434cdcb3233cc1ddecfd92b23eb4dfdec3931d65cb5796"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.30/node-v0.10.30-darwin-x86.tar.gz#a9fc5bc8e8f916010b15cf71305f6e285e64e5d1fd1be8c3472f95ff88106f67"
 binary linux-x64 "https://nodejs.org/dist/v0.10.30/node-v0.10.30-linux-x64.tar.gz#173d2b9ba4cbfb45a2472029f2904f965081498381a34d01b3889a850238de2b"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.30/node-v0.10.30-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.30/node-v0.10.30-sunos-x64.tar.gz#a7fd48d2461ce2c0673ae49140692764dc12a9c80ae5cdf6437a353b18895da4"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.30/node-v0.10.30-sunos-x86.tar.gz#63599ba80410abb30d27bc1360048607bf43d548eb762ec384f673bff2169a48"
 
-install_package "node-v0.10.30" "https://nodejs.org/dist/v0.10.30/node-v0.10.30.tar.gz#3dfcbd307f5f5f266ef174e1443107da853cd3d0aa0b2493a44235d5908625d2" warn_unsupported
+install_package "node-v0.10.30" "https://nodejs.org/dist/v0.10.30/node-v0.10.30.tar.gz#3dfcbd307f5f5f266ef174e1443107da853cd3d0aa0b2493a44235d5908625d2"

--- a/share/node-build/0.10.31
+++ b/share/node-build/0.10.31
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.31/node-v0.10.31-darwin-x64.tar.gz#4dc3e53bafefd02c3ac009dd53e7acd725f109f344121e54f76c2bea8a6638c8"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.31/node-v0.10.31-darwin-x86.tar.gz#ff93505fb81d93150f5bff7a9e9784e6b6ae86b7ce6bde8ba4589c80b01a0eaa"
 binary linux-x64 "https://nodejs.org/dist/v0.10.31/node-v0.10.31-linux-x64.tar.gz#493aa5d4fac0f34df01b07c7d276f1da8d5139df82374c599ab932e740d52147"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.31/node-v0.10.31-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.31/node-v0.10.31-sunos-x64.tar.gz#9334ffbad58b01e892831b44f122a61fd5453781299793eeb48e59dffdabd989"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.31/node-v0.10.31-sunos-x86.tar.gz#0362c780c56eb814bc5ae0d4e393663b9accdb4760e1aacd03ed76604559087b"
 
-install_package "node-v0.10.31" "https://nodejs.org/dist/v0.10.31/node-v0.10.31.tar.gz#06c781718a674dfdfb59d646b2629a46af2644bdbf52534fab8d4a0fe34c21f1" warn_unsupported
+install_package "node-v0.10.31" "https://nodejs.org/dist/v0.10.31/node-v0.10.31.tar.gz#06c781718a674dfdfb59d646b2629a46af2644bdbf52534fab8d4a0fe34c21f1"

--- a/share/node-build/0.10.32
+++ b/share/node-build/0.10.32
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.32/node-v0.10.32-darwin-x64.tar.gz#730ee5c3a44790998bbee1471ca903e6802e79080d4eba0fabf5ab92035e9037"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.32/node-v0.10.32-darwin-x86.tar.gz#637dcbf4ad656ef3ee51a527b8f1ef2c5feeeba4fbc25703eb763ed0519af9d8"
 binary linux-x64 "https://nodejs.org/dist/v0.10.32/node-v0.10.32-linux-x64.tar.gz#621777798ed9523a4ad1c4d934f94b7bc765871d769a014a53a4f1f7bcb5d5a7"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.32/node-v0.10.32-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.32/node-v0.10.32-sunos-x64.tar.gz#3abd0a03e6894a7515a6a13b5ffabe9dc98d5f86feb03b9d7c499e47250e0cfa"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.32/node-v0.10.32-sunos-x86.tar.gz#03925e461542e2601bbe1efb7434334a817c1a0c6b071fb81ab1d9a1805c7e58"
 
-install_package "node-v0.10.32" "https://nodejs.org/dist/v0.10.32/node-v0.10.32.tar.gz#c2120d0e3d2d191654cb11dbc0a33a7216d53732173317681da9502be0030f10" warn_unsupported
+install_package "node-v0.10.32" "https://nodejs.org/dist/v0.10.32/node-v0.10.32.tar.gz#c2120d0e3d2d191654cb11dbc0a33a7216d53732173317681da9502be0030f10"

--- a/share/node-build/0.10.33
+++ b/share/node-build/0.10.33
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.33/node-v0.10.33-darwin-x64.tar.gz#a5b6c3daafbdef5bee0376a147b3f74990bc032d9ab0b394600b4336b6e19f8f"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.33/node-v0.10.33-darwin-x86.tar.gz#2eaf06d4a7ddf62d83a053026744eb23b53d086b5029094676d71866e9386265"
 binary linux-x64 "https://nodejs.org/dist/v0.10.33/node-v0.10.33-linux-x64.tar.gz#159e5485d0fb5c913201baae49f68fd428a7e3b08262e9bf5003c1b399705ca8"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.33/node-v0.10.33-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.33/node-v0.10.33-sunos-x64.tar.gz#2ae96ea055262a265e6b32e4ec611efbabeedb9944fabc727035ec73025546aa"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.33/node-v0.10.33-sunos-x86.tar.gz#f01ba3a4c81c264a7f0052a4ec031f715b5e35e0337cc3686da874f4ffa91ddb"
 
-install_package "node-v0.10.33" "https://nodejs.org/dist/v0.10.33/node-v0.10.33.tar.gz#75dc26c33144e6d0dc91cb0d68aaf0570ed0a7e4b0c35f3a7a726b500edd081e" warn_unsupported
+install_package "node-v0.10.33" "https://nodejs.org/dist/v0.10.33/node-v0.10.33.tar.gz#75dc26c33144e6d0dc91cb0d68aaf0570ed0a7e4b0c35f3a7a726b500edd081e"

--- a/share/node-build/0.10.34
+++ b/share/node-build/0.10.34
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.34/node-v0.10.34-darwin-x64.tar.gz#a3aa311213c3491b550b9b96835d4b4e18754524a2f82c6a1bb7fcdf3a6773e3"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.34/node-v0.10.34-darwin-x86.tar.gz#538882716236f49cb3e059edaa53397de68e47942cbcbd506bf91b4ba8f6ffb2"
 binary linux-x64 "https://nodejs.org/dist/v0.10.34/node-v0.10.34-linux-x64.tar.gz#d9242c1b04327e8b4069ab1da96794383e562b0610942da501656e53243d04dc"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.34/node-v0.10.34-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.34/node-v0.10.34-sunos-x64.tar.gz#4e1d09ec38413380b5297edc3dc5a1fe4b28bddda3c189dbaceabadb42cae98f"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.34/node-v0.10.34-sunos-x86.tar.gz#36db9122efa7130fa5bcdb1d9660f145c3880432f86c9ced52bd898c53a448f6"
 
-install_package "node-v0.10.34" "https://nodejs.org/dist/v0.10.34/node-v0.10.34.tar.gz#d7f8473b5849873039f7e62595e12dcdb78c8dffda317e1253b3123876bf3415" warn_unsupported
+install_package "node-v0.10.34" "https://nodejs.org/dist/v0.10.34/node-v0.10.34.tar.gz#d7f8473b5849873039f7e62595e12dcdb78c8dffda317e1253b3123876bf3415"

--- a/share/node-build/0.10.35
+++ b/share/node-build/0.10.35
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.35/node-v0.10.35-darwin-x64.tar.gz#e3ab19876c8cfafbda9587a108c90bb9e975d073af5d545a34f6336afe5c7924"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.35/node-v0.10.35-darwin-x86.tar.gz#c8faabb6afbd26a73f02e655738e5513a2861a51817cea0ce2e6930dc794352c"
 binary linux-x64 "https://nodejs.org/dist/v0.10.35/node-v0.10.35-linux-x64.tar.gz#11f1e0ba34fb77d87db6f2c56898de881fdcf5bcde3e727f00456bfd976d2603"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.35/node-v0.10.35-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.35/node-v0.10.35-sunos-x64.tar.gz#0cb651edf73601d35ba48316a36a34662a6412bc54fd4ea4ce019b50d6374720"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.35/node-v0.10.35-sunos-x86.tar.gz#909ae0755d9c9bfbc7a2a2feb24b4df23fab5801924d4061768c07375b4e7f73"
 
-install_package "node-v0.10.35" "https://nodejs.org/dist/v0.10.35/node-v0.10.35.tar.gz#0043656bb1724cb09dbdc960a2fd6ee37d3badb2f9c75562b2d11235daa40a03" warn_unsupported
+install_package "node-v0.10.35" "https://nodejs.org/dist/v0.10.35/node-v0.10.35.tar.gz#0043656bb1724cb09dbdc960a2fd6ee37d3badb2f9c75562b2d11235daa40a03"

--- a/share/node-build/0.10.36
+++ b/share/node-build/0.10.36
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.36/node-v0.10.36-darwin-x64.tar.gz#f5768eaabc692fd3ed0cb063d17962c933951b78dec09af3c30eb76c3189d9ee"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.36/node-v0.10.36-darwin-x86.tar.gz#b0fe1dc7ed538b14c253de2d3b0bb49317126d0736855f5eed64a79ade99fe4e"
 binary linux-x64 "https://nodejs.org/dist/v0.10.36/node-v0.10.36-linux-x64.tar.gz#2bc13477684a9fe534bdc9d8f4a8caf6257a11953b57c42cad9b919ee259a0d5"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.36/node-v0.10.36-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.36/node-v0.10.36-sunos-x64.tar.gz#0b4edef67c9ace5f2846b465a26d225850416db7b5272066c08574f28ac15444"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.36/node-v0.10.36-sunos-x86.tar.gz#8186cf8261d3135a3431cacd0de086c73774d99b27c0ab00110565653945ff06"
 
-install_package "node-v0.10.36" "https://nodejs.org/dist/v0.10.36/node-v0.10.36.tar.gz#b9d7d1d0294bce46686b13a05da6fc5b1e7743b597544aa888e8e64a9f178c81" warn_unsupported
+install_package "node-v0.10.36" "https://nodejs.org/dist/v0.10.36/node-v0.10.36.tar.gz#b9d7d1d0294bce46686b13a05da6fc5b1e7743b597544aa888e8e64a9f178c81"

--- a/share/node-build/0.10.37
+++ b/share/node-build/0.10.37
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.37/node-v0.10.37-darwin-x64.tar.gz#260561bd0f19fbaf2bc371b7dd23133e4cb1f97bc0135d1bde807bdcdcfbd017"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.37/node-v0.10.37-darwin-x86.tar.gz#d2b1a95abf56b1abc55b005ee3354fecc172f50fd2efa741dd98411280cde32d"
 binary linux-x64 "https://nodejs.org/dist/v0.10.37/node-v0.10.37-linux-x64.tar.gz#a7d597995b2da1b81c99256bd562dc698e18a12114e67162279dcc23add1f06c"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.37/node-v0.10.37-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.37/node-v0.10.37-sunos-x64.tar.gz#464c664215213a88d73cadd4a2822c76dae498069f867283e11f3f7debcb3d10"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.37/node-v0.10.37-sunos-x86.tar.gz#635e219f453ccddb16d2e53cf049687e1d5ea92b087eb820067a0f009e53751c"
 
-install_package "node-v0.10.37" "https://nodejs.org/dist/v0.10.37/node-v0.10.37.tar.gz#a5afad14117bb194731e73b4b6635f36950e9476d3873638856cba8dbb4783a5" warn_unsupported
+install_package "node-v0.10.37" "https://nodejs.org/dist/v0.10.37/node-v0.10.37.tar.gz#a5afad14117bb194731e73b4b6635f36950e9476d3873638856cba8dbb4783a5"

--- a/share/node-build/0.10.38
+++ b/share/node-build/0.10.38
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.38/node-v0.10.38-darwin-x64.tar.gz#039644613dc9c953559ea93fcea90f278dd97c3154289759033426c7902db69f"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.38/node-v0.10.38-darwin-x86.tar.gz#09772c15d1d19cd18c44c6d3ded1ff42168e49a3eddb589a46e369ddfa550c2b"
 binary linux-x64 "https://nodejs.org/dist/v0.10.38/node-v0.10.38-linux-x64.tar.gz#d0f5771c3adefa4a3c1718206521c603526a3b67d5b1b66abd2e155d0fb77f5e"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.38/node-v0.10.38-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.38/node-v0.10.38-sunos-x64.tar.gz#d277ae4995bc56f39f09240e102e09257d4e7d00b5e9b60428d28fe6ca057e43"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.38/node-v0.10.38-sunos-x86.tar.gz#3930ad6e6e005a347fdf96d6721e52ebf291dabf9531348d8bb60403b1475701"
 
-install_package "node-v0.10.38" "https://nodejs.org/dist/v0.10.38/node-v0.10.38.tar.gz#513da8ed5e48abefdfab664f1cabc160238d314a0481148804aff8fc6552b78b" warn_unsupported
+install_package "node-v0.10.38" "https://nodejs.org/dist/v0.10.38/node-v0.10.38.tar.gz#513da8ed5e48abefdfab664f1cabc160238d314a0481148804aff8fc6552b78b"

--- a/share/node-build/0.10.39
+++ b/share/node-build/0.10.39
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.39/node-v0.10.39-darwin-x64.tar.gz#0fde1b6449fb4a39b55239241258fd6a2a176eaf30ba0d3c50124f64ba485002"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.39/node-v0.10.39-darwin-x86.tar.gz#7400527ab1b2025fa862365489d0226d01da8527583cf9389e8e9c72edabfbc4"
 binary linux-x64 "https://nodejs.org/dist/v0.10.39/node-v0.10.39-linux-x64.tar.gz#f7b2f1a7fee90d004fc6eb5629ddde358d96f0ca2fd7ed28f53931127f9875be"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.39/node-v0.10.39-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.39/node-v0.10.39-sunos-x64.tar.gz#d016ef2ccf10f1be625b7b62898e4c4aa91fe35c03dc3a7cc96a481a07fc5728"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.39/node-v0.10.39-sunos-x86.tar.gz#e0f2b65ae59341c34c401c41ec3d937c16ff32c6b17e32e5e7b9be3a716bd4c5"
 
-install_package "node-v0.10.39" "https://nodejs.org/dist/v0.10.39/node-v0.10.39.tar.gz#68f8d8f9515c4e77e2a06034b742e19e9848c1fee5bcadedc1d68f3e4302df37" warn_unsupported
+install_package "node-v0.10.39" "https://nodejs.org/dist/v0.10.39/node-v0.10.39.tar.gz#68f8d8f9515c4e77e2a06034b742e19e9848c1fee5bcadedc1d68f3e4302df37"

--- a/share/node-build/0.10.4
+++ b/share/node-build/0.10.4
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.4/node-v0.10.4-darwin-x64.tar.gz#b7d9a8df207e8cd41798ab507e3e28fe92d1a5667014ecfef8c1ce8b9ea39203"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.4/node-v0.10.4-darwin-x86.tar.gz#7ebdbb7be03ed07f31bd69f17d39c1e122d4a77c9efd01194fa1834953175fbd"
 binary linux-x64 "https://nodejs.org/dist/v0.10.4/node-v0.10.4-linux-x64.tar.gz#6d3eb0cf0438513c2a71a1ff5e9ad140574ffca5a7a100308157aa9005c5d333"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.4/node-v0.10.4-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.10.4/node-v0.10.4-sunos-x64.tar.gz#db639ab5e3e309278e9728d899aab00d9ebaa40458a0964282c5457d09bdce49"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.4/node-v0.10.4-sunos-x86.tar.gz#ef52596d5c6cc3fa25cb43fd6820437473e1bd036d3f3b8c6d75916a34b4930a"
 
-install_package "node-v0.10.4" "https://nodejs.org/dist/v0.10.4/node-v0.10.4.tar.gz#1c960d2822447a9e4f7c46b832ff05e86743033c6643d644975af1cbf6a44fb8" warn_unsupported
+install_package "node-v0.10.4" "https://nodejs.org/dist/v0.10.4/node-v0.10.4.tar.gz#1c960d2822447a9e4f7c46b832ff05e86743033c6643d644975af1cbf6a44fb8"

--- a/share/node-build/0.10.40
+++ b/share/node-build/0.10.40
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.40/node-v0.10.40-darwin-x64.tar.gz#c6587b133c77c0cc858c10910dea3796a719b190aab0f62ad3e46bcee1fe08d1"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.40/node-v0.10.40-darwin-x86.tar.gz#39610adf6887001d79ea8721f9643ca653cfed6c300bdd558affd007d01cf40c"
 binary linux-x64 "https://nodejs.org/dist/v0.10.40/node-v0.10.40-linux-x64.tar.gz#0bb15c00fc4668ce3dc1a70a84b80b1aaaaea61ad7efe05dd4eb91165620a17e"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.40/node-v0.10.40-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.40/node-v0.10.40-sunos-x64.tar.gz#4f90a86d869957592a73b548e1bfad960513f4928b41549f0e19c1e536e1bf3f"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.40/node-v0.10.40-sunos-x86.tar.gz#fc4ff51c3d1549601d421689ec4c504a62d9fd71945fe588a49ef68e3902eb4c"
 
-install_package "node-v0.10.40" "https://nodejs.org/dist/v0.10.40/node-v0.10.40.tar.gz#bae79c2fd959aebe1629af36077bebbb760128db753da226d2344cd91499149f" warn_unsupported
+install_package "node-v0.10.40" "https://nodejs.org/dist/v0.10.40/node-v0.10.40.tar.gz#bae79c2fd959aebe1629af36077bebbb760128db753da226d2344cd91499149f"

--- a/share/node-build/0.10.41
+++ b/share/node-build/0.10.41
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.41/node-v0.10.41-darwin-x64.tar.gz#f55050a8774828846670fea91695a8da754768021cf1121cf91f788bb3e89d20"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.41/node-v0.10.41-darwin-x86.tar.gz#d0deae5ea05b8fae90ca98851e55dbd0fe8b88dab5ed658ebdb61d3e47bc0a5e"
 binary linux-x64 "https://nodejs.org/dist/v0.10.41/node-v0.10.41-linux-x64.tar.gz#ebda18d4c6545ac42b3404d629504feea0b2b9e7c7fa68de2a5bcc9059a6dc6c"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.41/node-v0.10.41-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.41/node-v0.10.41-sunos-x64.tar.gz#9621df2ffed088f87632c5f4d176e5d49438fce5aeb7b4ce8d2eff0de153a5bf"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.41/node-v0.10.41-sunos-x86.tar.gz#a5f5ed4d8200e231323db083f3f2735cec13ac6584523b94ac953ad0e4874b66"
 
-install_package "node-v0.10.41" "https://nodejs.org/dist/v0.10.41/node-v0.10.41.tar.gz#79f694e2a5c42543b75d0c69f6860499d7593136d0f6b59e7163b9e66fb2c995" warn_unsupported
+install_package "node-v0.10.41" "https://nodejs.org/dist/v0.10.41/node-v0.10.41.tar.gz#79f694e2a5c42543b75d0c69f6860499d7593136d0f6b59e7163b9e66fb2c995"

--- a/share/node-build/0.10.42
+++ b/share/node-build/0.10.42
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.42/node-v0.10.42-darwin-x64.tar.gz#356b4891c7060b6a68cf126837689807c30d43b709120b7fe6f167404612eb5a"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.42/node-v0.10.42-darwin-x86.tar.gz#ff61d24f80db9c5e6b007103751cdb8ac6cb3ff4180972ce1532bcb934847e0c"
 binary linux-x64 "https://nodejs.org/dist/v0.10.42/node-v0.10.42-linux-x64.tar.gz#a9b80fb22efc483b6aef282ebb0254b5d9b092ed8091521977af593069a81d53"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.42/node-v0.10.42-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.42/node-v0.10.42-sunos-x64.tar.gz#af15246d6889db4449dc46d5c4a549bb56b19481cbb801d30a09153ba71b88e1"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.42/node-v0.10.42-sunos-x86.tar.gz#3333f1fd394bdde5aafa424d945b002b0d0876e17396f864af9c230c81aac08b"
 
-install_package "node-v0.10.42" "https://nodejs.org/dist/v0.10.42/node-v0.10.42.tar.gz#ebc1d53698f80c5a7b0b948e1108d7858f93d2d9ebf4541c12688d85704de105" warn_unsupported
+install_package "node-v0.10.42" "https://nodejs.org/dist/v0.10.42/node-v0.10.42.tar.gz#ebc1d53698f80c5a7b0b948e1108d7858f93d2d9ebf4541c12688d85704de105"

--- a/share/node-build/0.10.43
+++ b/share/node-build/0.10.43
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.43/node-v0.10.43-darwin-x64.tar.gz#c7fb30129206fa2d74d72d3c1a86fa5cb768a1165c41be9f7c724e35c3b53ca9"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.43/node-v0.10.43-darwin-x86.tar.gz#a62a819832db4d6a1e9c10d286faa74c2917288a011dc7aca0476725b85cc0ae"
 binary linux-x64 "https://nodejs.org/dist/v0.10.43/node-v0.10.43-linux-x64.tar.gz#8a439e17af1971432798ec79a70abf8fa21e03e2aa994bb7150bc088bfa482f2"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.43/node-v0.10.43-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.43/node-v0.10.43-sunos-x64.tar.gz#f6cf66e77e1def7fa854ddb83a176d89f9a5b349fbb1e0bcdb742778c31e1510"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.43/node-v0.10.43-sunos-x86.tar.gz#b3badbc35d085723a2ad30847c5109398363b13649e199db6d22fe5f56e74c52"
 
-install_package "node-v0.10.43" "https://nodejs.org/dist/v0.10.43/node-v0.10.43.tar.gz#c672452a61dd37cf2779bc158b65a5a22af343da19fec1cddf9bced382a2595a" warn_unsupported
+install_package "node-v0.10.43" "https://nodejs.org/dist/v0.10.43/node-v0.10.43.tar.gz#c672452a61dd37cf2779bc158b65a5a22af343da19fec1cddf9bced382a2595a"

--- a/share/node-build/0.10.44
+++ b/share/node-build/0.10.44
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.44/node-v0.10.44-darwin-x64.tar.gz#cc9916991a16395c4a561db6d091a9a1e9af13e66dddbd03d3c687d0ab3e52a9"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.44/node-v0.10.44-darwin-x86.tar.gz#7c582b190050d268b4fa4d1a4e4b3456be1a9c224407a4ef61258af6e95f01d8"
 binary linux-x64 "https://nodejs.org/dist/v0.10.44/node-v0.10.44-linux-x64.tar.gz#b5f4acc54e5527d793463e05b5435f11dd1f0997168aa71d53a1ff1a06c7b144"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.44/node-v0.10.44-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.44/node-v0.10.44-sunos-x64.tar.gz#ee2867b193b53ffab308bea6f0e4c197222903ae308b1748eceaa786402d6c15"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.44/node-v0.10.44-sunos-x86.tar.gz#0b385a3aa1f9122bca205515917a2406ab24782ecbbb886ceb5dcba93f3a9758"
 
-install_package "node-v0.10.44" "https://nodejs.org/dist/v0.10.44/node-v0.10.44.tar.gz#4155639d71e690cafd885f58a8be3bf97a93c28875212aac991923d3ee589be8" warn_unsupported
+install_package "node-v0.10.44" "https://nodejs.org/dist/v0.10.44/node-v0.10.44.tar.gz#4155639d71e690cafd885f58a8be3bf97a93c28875212aac991923d3ee589be8"

--- a/share/node-build/0.10.45
+++ b/share/node-build/0.10.45
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.45/node-v0.10.45-darwin-x64.tar.gz#d1ab69f49365a0dc6b10a363965452f37f3589adee19974940cbd2b991965e70"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.45/node-v0.10.45-darwin-x86.tar.gz#3db0e42736fbdedc8a985269595251d9c4e4860594ce1eee4a692f8621ee5918"
 binary linux-x64 "https://nodejs.org/dist/v0.10.45/node-v0.10.45-linux-x64.tar.gz#54d095d12b6227460f08ec81e50f9db930ec51fa05af1b7722fa85bd2cabb5d7"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.45/node-v0.10.45-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.10.45/node-v0.10.45-sunos-x64.tar.gz#019a1c40daff7b05efb2bd27c586d9ba9c5fe5048550b74e67e171d1495d4e30"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.45/node-v0.10.45-sunos-x86.tar.gz#39a0790a7e533dd77f473c009c11458a5205cfc438777139a5e9658be63dfee2"
 
-install_package "node-v0.10.45" "https://nodejs.org/dist/v0.10.45/node-v0.10.45.tar.gz#d184bb74758d4ac69826823934cda1d46e81402fc16ebdb2ecacdc1a8fe0b568" warn_unsupported
+install_package "node-v0.10.45" "https://nodejs.org/dist/v0.10.45/node-v0.10.45.tar.gz#d184bb74758d4ac69826823934cda1d46e81402fc16ebdb2ecacdc1a8fe0b568"

--- a/share/node-build/0.10.46
+++ b/share/node-build/0.10.46
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.46/node-v0.10.46-darwin-x64.tar.gz#ab9eafa76c4c9a2e0d43e6727d82b331157dc7f43fde9a3f2a4881102df9ff3a"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.46/node-v0.10.46-darwin-x86.tar.gz#32c03a60eac3f1650d4a9219fc8510119bff19262255b868ee23850ef56cd0c9"
 binary linux-x64 "https://nodejs.org/dist/v0.10.46/node-v0.10.46-linux-x64.tar.gz#58116256f3060703e2e71f2cb5dc265a1d9fab7854a4eee15e78a95a0a87c750"

--- a/share/node-build/0.10.47
+++ b/share/node-build/0.10.47
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.47/node-v0.10.47-darwin-x64.tar.gz#6920608a46761c33056d78e504222a3a42dc8c0cf8ab6ff7497cd4a81b06d090"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.47/node-v0.10.47-darwin-x86.tar.gz#0907e94e81dc63e284e9dcb18925ceed102ceffb8a4cefab8f729c203f371c93"
 binary linux-x64 "https://nodejs.org/dist/v0.10.47/node-v0.10.47-linux-x64.tar.gz#80757ae8f7bc3161fe44615344c784918ebd93a51ca6f789a75e3d472972eb77"

--- a/share/node-build/0.10.48
+++ b/share/node-build/0.10.48
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.48/node-v0.10.48-darwin-x64.tar.gz#35d510ca5e8dd0c21cb11c2bf33b90f3715f92281aaaa49645f61c565c8adceb"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.48/node-v0.10.48-darwin-x86.tar.gz#0054a05d99e36a1e50af321d6c13ef84afde895063abd5c5e808bb84d33c2296"
 binary linux-x64 "https://nodejs.org/dist/v0.10.48/node-v0.10.48-linux-x64.tar.gz#82f5fe186349ca69d8889d1079dbb86ae77ce54fce5282b806c359ce360cec7b"

--- a/share/node-build/0.10.5
+++ b/share/node-build/0.10.5
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.5/node-v0.10.5-darwin-x64.tar.gz#5957284e645dd815a4a7a4898584eebe846e2a09a8d2629ec76e0f69087a400a"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.5/node-v0.10.5-darwin-x86.tar.gz#9c488bcd41ce48481248937afded91eb5d8d4ec068b29abe1054b58cc975e651"
 binary linux-arm-pi "https://nodejs.org/dist/v0.10.5/node-v0.10.5-linux-arm-pi.tar.gz#b9e806dd50f66363fbb1350b54da216a764749acd7d7c810bb28a0244d01fdb5"
@@ -6,4 +10,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.5/node-v0.10.5-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.10.5/node-v0.10.5-sunos-x64.tar.gz#508d295599796814a9cbe79d1a254f8a2072d702ffcb1c288376cfec1dd317fd"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.5/node-v0.10.5-sunos-x86.tar.gz#3b7626bcd8550b95a08695bae781debebd06d575ac17c8404b388d949c8f3d55"
 
-install_package "node-v0.10.5" "https://nodejs.org/dist/v0.10.5/node-v0.10.5.tar.gz#1c22bd15cb13b1109610ee256699300ec6999b335f3bc85dc3c0312ec9312cfd" warn_unsupported
+install_package "node-v0.10.5" "https://nodejs.org/dist/v0.10.5/node-v0.10.5.tar.gz#1c22bd15cb13b1109610ee256699300ec6999b335f3bc85dc3c0312ec9312cfd"

--- a/share/node-build/0.10.6
+++ b/share/node-build/0.10.6
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.6/node-v0.10.6-darwin-x64.tar.gz#662cbb2068aeb464aa61346cd4cb838b2c4d629ad3519fdf1915ea1da18dc470"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.6/node-v0.10.6-darwin-x86.tar.gz#330cb1225748991506a0c98fe703ea97c842746f23796d63d9a877f5e2ec186f"
 binary linux-x64 "https://nodejs.org/dist/v0.10.6/node-v0.10.6-linux-x64.tar.gz#cc7ccfce24ae0ebb0c50661ef8d98b5db07fc1cd4a222c5d1ae232260d5834ca"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.6/node-v0.10.6-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.10.6/node-v0.10.6-sunos-x64.tar.gz#554ff5ade28f20b4cb17ed18a7265a7a5486de29b971f1228ed8984b40900e95"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.6/node-v0.10.6-sunos-x86.tar.gz#a0a7412f7087ebbc726e4fffe8205fbc775ec3b59c890e425ebb00c782eb11e2"
 
-install_package "node-v0.10.6" "https://nodejs.org/dist/v0.10.6/node-v0.10.6.tar.gz#7e2079394efe82f62798178f617888c9d6a39150c76122c432ae9ea73ce28e79" warn_unsupported
+install_package "node-v0.10.6" "https://nodejs.org/dist/v0.10.6/node-v0.10.6.tar.gz#7e2079394efe82f62798178f617888c9d6a39150c76122c432ae9ea73ce28e79"

--- a/share/node-build/0.10.7
+++ b/share/node-build/0.10.7
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.7/node-v0.10.7-darwin-x64.tar.gz#879550ddc6fa8e56ed8ffed7c0bc27dee1d21867b07c398a44180fba34e6b029"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.7/node-v0.10.7-darwin-x86.tar.gz#cb7b2c196d60a61116f07c4de09ab9ffade9974d6ba46e9162fa9847c5b59df2"
 binary linux-x64 "https://nodejs.org/dist/v0.10.7/node-v0.10.7-linux-x64.tar.gz#9fdc924b9732ddf5fe278b7888a6c2c61074b15c71795f10e908b59387d3acd8"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.7/node-v0.10.7-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.10.7/node-v0.10.7-sunos-x64.tar.gz#1c858bf96ebbd2c88e0a5e47c49fe0e4e679746e81b11ade9adc155a8d8466ff"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.7/node-v0.10.7-sunos-x86.tar.gz#a947ac0b8eeae290ab3e06d4fa69d9f6424ac793ea2786b9423f5b199c36c7fa"
 
-install_package "node-v0.10.7" "https://nodejs.org/dist/v0.10.7/node-v0.10.7.tar.gz#22d1d211f5260dfa5b842cebdb04633f28df180843105ff3eb792ca35ed425e0" warn_unsupported
+install_package "node-v0.10.7" "https://nodejs.org/dist/v0.10.7/node-v0.10.7.tar.gz#22d1d211f5260dfa5b842cebdb04633f28df180843105ff3eb792ca35ed425e0"

--- a/share/node-build/0.10.8
+++ b/share/node-build/0.10.8
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.8/node-v0.10.8-darwin-x64.tar.gz#2253d67aec2e3525e0a649c7befb30a28d71425c1e902a86a5708be92ac6c28e"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.8/node-v0.10.8-darwin-x86.tar.gz#b18264a1c3b781429cf9abca14e410b73eaeda2778c52cd350b968d56f3b07b8"
 binary linux-x64 "https://nodejs.org/dist/v0.10.8/node-v0.10.8-linux-x64.tar.gz#47903aa0bc81df9d4503a1fe55f2b2914dfa74ac0dd5be3d554dc4282695f427"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.8/node-v0.10.8-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.10.8/node-v0.10.8-sunos-x64.tar.gz#67ed50f8c1d80fd7601c7c2acd3b7fe9cbe667be3210075851b682f1f4b26d04"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.8/node-v0.10.8-sunos-x86.tar.gz#9d9b4b003df50e856614f104cf38681bd6c2f6c391e8210649b576ee0dc763cb"
 
-install_package "node-v0.10.8" "https://nodejs.org/dist/v0.10.8/node-v0.10.8.tar.gz#edf6f766c8ccc7ef5b02a50c94567343eb1ffae479db93684ba89976e3f18354" warn_unsupported
+install_package "node-v0.10.8" "https://nodejs.org/dist/v0.10.8/node-v0.10.8.tar.gz#edf6f766c8ccc7ef5b02a50c94567343eb1ffae479db93684ba89976e3f18354"

--- a/share/node-build/0.10.9
+++ b/share/node-build/0.10.9
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.10.9/node-v0.10.9-darwin-x64.tar.gz#3b0cbd1ac4b7e514ccd68fcd3089ccb1f13606fb41dbd2a776693bb984623bbd"
 binary darwin-x86 "https://nodejs.org/dist/v0.10.9/node-v0.10.9-darwin-x86.tar.gz#36b935fc789754d48afbb8007acb54fca023c21d6d710aee74838dfa028ed3f5"
 binary linux-x64 "https://nodejs.org/dist/v0.10.9/node-v0.10.9-linux-x64.tar.gz#27159f584e108dbe5a9a884a98200a413203d339bf8596a3dbcaff9577fe1b1c"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.10.9/node-v0.10.9-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.10.9/node-v0.10.9-sunos-x64.tar.gz#35cefbee05e13ce6fc78641c0cf5437eee07df844af0d6c0ae56db3e51f907fe"
 binary sunos-x86 "https://nodejs.org/dist/v0.10.9/node-v0.10.9-sunos-x86.tar.gz#a802e9614349c2b33c0b713dcace56b6aa747107669a3899f97be9e542ffab1c"
 
-install_package "node-v0.10.9" "https://nodejs.org/dist/v0.10.9/node-v0.10.9.tar.gz#25fb276ac6765ebb19f44d3e3775ed1c0275f874c896755d0d619226caee9c30" warn_unsupported
+install_package "node-v0.10.9" "https://nodejs.org/dist/v0.10.9/node-v0.10.9.tar.gz#25fb276ac6765ebb19f44d3e3775ed1c0275f874c896755d0d619226caee9c30"

--- a/share/node-build/0.11.0
+++ b/share/node-build/0.11.0
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.11.0/node-v0.11.0-darwin-x64.tar.gz#734693d7a388dcc46d5f6e3c3146fecde9b6de0c4afb9d4389c066be655095fc"
 binary darwin-x86 "https://nodejs.org/dist/v0.11.0/node-v0.11.0-darwin-x86.tar.gz#497dc2d7d594ceff9c28cef53527b7f6337600ee9f1df2151847b42c95ab48d1"
 binary linux-x64 "https://nodejs.org/dist/v0.11.0/node-v0.11.0-linux-x64.tar.gz#ab86c554ae27e3938b588083488ae93531a5fba2428bdbcd0fb07a687f514c94"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.0/node-v0.11.0-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.11.0/node-v0.11.0-sunos-x64.tar.gz#e6756250650d286da47e9113b2e8a767dcb5fe5f2544fedda36eeb4fbc60a0e9"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.0/node-v0.11.0-sunos-x86.tar.gz#eddc6728d6f7739b213e23462c7f62f35059d5145713f81858322c890208457f"
 
-install_package "node-v0.11.0" "https://nodejs.org/dist/v0.11.0/node-v0.11.0.tar.gz#a1887957fd6f0091379d1317f1daeb791bbf4301e58d693d17ad1d0fdbfa7898" warn_eol
+install_package "node-v0.11.0" "https://nodejs.org/dist/v0.11.0/node-v0.11.0.tar.gz#a1887957fd6f0091379d1317f1daeb791bbf4301e58d693d17ad1d0fdbfa7898"

--- a/share/node-build/0.11.1
+++ b/share/node-build/0.11.1
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.11.1/node-v0.11.1-darwin-x64.tar.gz#bfa6644b345dedc26ed8a72f190ca825ce39f4332a423435a5eef67e078232be"
 binary darwin-x86 "https://nodejs.org/dist/v0.11.1/node-v0.11.1-darwin-x86.tar.gz#96216adbeb90950b945fde0793b1b8cc80d35ae2a283a9ea8b93bce33e356c5c"
 binary linux-x64 "https://nodejs.org/dist/v0.11.1/node-v0.11.1-linux-x64.tar.gz#c6c977e8b828114002f0f9f3cdc9a37370da41ac856ce107190f00ea0065d0d6"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.1/node-v0.11.1-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.11.1/node-v0.11.1-sunos-x64.tar.gz#22453736b491481eb270ec273e1a938ce73534e5f7a9979c831291865822d726"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.1/node-v0.11.1-sunos-x86.tar.gz#7d566f108e1b1115aedec5abc988720b75f23f4abee9b638a8c4f8074077bd2e"
 
-install_package "node-v0.11.1" "https://nodejs.org/dist/v0.11.1/node-v0.11.1.tar.gz#1042853f6f288185e9dda60eaf57de50768aec5d32df7c7f462b713c56bd096f" warn_eol
+install_package "node-v0.11.1" "https://nodejs.org/dist/v0.11.1/node-v0.11.1.tar.gz#1042853f6f288185e9dda60eaf57de50768aec5d32df7c7f462b713c56bd096f"

--- a/share/node-build/0.11.10
+++ b/share/node-build/0.11.10
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.11.10/node-v0.11.10-darwin-x64.tar.gz#3beb0693c395272d07f1fbf7fdcdeeaf018f9571e813ea085422f81a03188eb7"
 binary darwin-x86 "https://nodejs.org/dist/v0.11.10/node-v0.11.10-darwin-x86.tar.gz#b256f095431a6258505c21cec9bd2f3a3524f6c3881db10ee8e1c1b6d0ff263d"
 binary linux-x64 "https://nodejs.org/dist/v0.11.10/node-v0.11.10-linux-x64.tar.gz#5397e1e79c3052b7155deb73525761e3a97d5fcb0868d1e269efb25d7ec0c127"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.10/node-v0.11.10-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.11.10/node-v0.11.10-sunos-x64.tar.gz#eb921e47fcb0deddb9f2c75f8d087ec16de11c3cd3b50ecd6ec68a7ac08c7873"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.10/node-v0.11.10-sunos-x86.tar.gz#bf4bef098f7fddec5692f9c7aefdab916c2ff8a5e6856423429dfb008b957b4c"
 
-install_package "node-v0.11.10" "https://nodejs.org/dist/v0.11.10/node-v0.11.10.tar.gz#6f7b5971c23049645bb955ad787714bf1e8ead14bab2d4e30da328f13fa86040" warn_eol
+install_package "node-v0.11.10" "https://nodejs.org/dist/v0.11.10/node-v0.11.10.tar.gz#6f7b5971c23049645bb955ad787714bf1e8ead14bab2d4e30da328f13fa86040"

--- a/share/node-build/0.11.11
+++ b/share/node-build/0.11.11
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.11.11/node-v0.11.11-darwin-x64.tar.gz#f10deff61ab2659fbcb92ebd20d90689008a4152fe1b989e2b3b49cc468f534b"
 binary darwin-x86 "https://nodejs.org/dist/v0.11.11/node-v0.11.11-darwin-x86.tar.gz#d3e11f71abf5f1aa695f98faf9660a4d482db3ae10b07de16840bd4febff83af"
 binary linux-x64 "https://nodejs.org/dist/v0.11.11/node-v0.11.11-linux-x64.tar.gz#1cf91a851ecb3cb5c4dbd9c14ab59eb53b77ab0cda714b564190746fed67534c"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.11/node-v0.11.11-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.11.11/node-v0.11.11-sunos-x64.tar.gz#cc0e76fe45755885c606939ae63be113ddc698bad65820cd19044e128b6fb270"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.11/node-v0.11.11-sunos-x86.tar.gz#cd58120e6660931ad24eed0534f499edbf152265c64a83b629bd501768f4f579"
 
-install_package "node-v0.11.11" "https://nodejs.org/dist/v0.11.11/node-v0.11.11.tar.gz#7098763353011a92bca25192c0ed4a7cae5a115805223bcc6d5a81e4d20dc87a" warn_eol
+install_package "node-v0.11.11" "https://nodejs.org/dist/v0.11.11/node-v0.11.11.tar.gz#7098763353011a92bca25192c0ed4a7cae5a115805223bcc6d5a81e4d20dc87a"

--- a/share/node-build/0.11.12
+++ b/share/node-build/0.11.12
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.11.12/node-v0.11.12-darwin-x64.tar.gz#2265e5a755e442fbd923119df673816bdf4f2a2931f93821e6c1075fdc678451"
 binary darwin-x86 "https://nodejs.org/dist/v0.11.12/node-v0.11.12-darwin-x86.tar.gz#4f17a0c42957ba70700e2e5f9c87454a68a99f8a9ea5d94cbf87752cfa17e4c2"
 binary linux-x64 "https://nodejs.org/dist/v0.11.12/node-v0.11.12-linux-x64.tar.gz#d5369c5608482bcbfcb7a8cd18a43b493a878020c6e5dc241cf55473dafa374a"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.12/node-v0.11.12-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.11.12/node-v0.11.12-sunos-x64.tar.gz#7cc56ba26dd0429deb2e72632629b051162d355cfae0bf6732c620595f684ac8"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.12/node-v0.11.12-sunos-x86.tar.gz#58cbe6416d4dba4c76d68d088d1741133242fb9825e5d3d7ba39e20d334312ed"
 
-install_package "node-v0.11.12" "https://nodejs.org/dist/v0.11.12/node-v0.11.12.tar.gz#c40968981d9f5f6fbc4abb836557acda74ecb8f8a1e9a30e84ebd2529a8c1b6a" warn_eol
+install_package "node-v0.11.12" "https://nodejs.org/dist/v0.11.12/node-v0.11.12.tar.gz#c40968981d9f5f6fbc4abb836557acda74ecb8f8a1e9a30e84ebd2529a8c1b6a"

--- a/share/node-build/0.11.13
+++ b/share/node-build/0.11.13
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.11.13/node-v0.11.13-darwin-x64.tar.gz#d642d825f8815b87a7edfc7c6057853671bda6a53711f1c6fa532735cabdaf07"
 binary darwin-x86 "https://nodejs.org/dist/v0.11.13/node-v0.11.13-darwin-x86.tar.gz#cc2d724df3370153266ff42650db2cdc8e47915bb7e0dd72321ec3973b1bcf62"
 binary linux-x64 "https://nodejs.org/dist/v0.11.13/node-v0.11.13-linux-x64.tar.gz#4609ed7780cb4aaab6703cdd015f593893e3acc09e432465ec0c9cc178c26655"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.13/node-v0.11.13-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.11.13/node-v0.11.13-sunos-x64.tar.gz#71186ff69b914f005641742676e5f65b2c0853fdb09f2c5f8cd6696e85e76763"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.13/node-v0.11.13-sunos-x86.tar.gz#2e9c0eacd1cb699360b3abd01272314dfb6d7e4ddfd3897c10822f6ac336220c"
 
-install_package "node-v0.11.13" "https://nodejs.org/dist/v0.11.13/node-v0.11.13.tar.gz#15d6e90c16adf907c0401cd5a77841b5264e90dfdaa1051d75184aa587fc8298" warn_eol
+install_package "node-v0.11.13" "https://nodejs.org/dist/v0.11.13/node-v0.11.13.tar.gz#15d6e90c16adf907c0401cd5a77841b5264e90dfdaa1051d75184aa587fc8298"

--- a/share/node-build/0.11.14
+++ b/share/node-build/0.11.14
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.11.14/node-v0.11.14-darwin-x64.tar.gz#074669d2f3d8419496076c55c2743389538996a90e87277ea5bf032f885877ad"
 binary darwin-x86 "https://nodejs.org/dist/v0.11.14/node-v0.11.14-darwin-x86.tar.gz#5d9bb59a66fd36dcae9bb44c83165dcbc09e3a5d4398e684526b8eab3659102b"
 binary linux-x64 "https://nodejs.org/dist/v0.11.14/node-v0.11.14-linux-x64.tar.gz#3ae6cb227815e7c794215244cecd90a2d3fcf97ba7a30f09accba861bb6057f8"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.14/node-v0.11.14-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.11.14/node-v0.11.14-sunos-x64.tar.gz#96cbb3f5b8a19cde8fc9855baf1e2c5664cfdaf9062675661c5920f51eb85319"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.14/node-v0.11.14-sunos-x86.tar.gz#eae7646ae5d94f055698a271daa5092dcc02fe284de01cc9e0688190d6e06a83"
 
-install_package "node-v0.11.14" "https://nodejs.org/dist/v0.11.14/node-v0.11.14.tar.gz#ce08b0a2769bcc135ca25639c9d411a038e93e0f5f5a83000ecde9b763c4dd83" warn_eol
+install_package "node-v0.11.14" "https://nodejs.org/dist/v0.11.14/node-v0.11.14.tar.gz#ce08b0a2769bcc135ca25639c9d411a038e93e0f5f5a83000ecde9b763c4dd83"

--- a/share/node-build/0.11.15
+++ b/share/node-build/0.11.15
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.11.15/node-v0.11.15-darwin-x64.tar.gz#e52e79416922eccdcc2451c9e041bac70c0b8aa9e90dd1ce0659602bc82c8ac1"
 binary darwin-x86 "https://nodejs.org/dist/v0.11.15/node-v0.11.15-darwin-x86.tar.gz#b745bd2177149deaaf8de834420946a410d414e6b0e59d508bf264fbe8941a33"
 binary linux-x64 "https://nodejs.org/dist/v0.11.15/node-v0.11.15-linux-x64.tar.gz#940bb9ab99be8be2d9b954fb152e239f2076d28805378e30e781ddcedad382eb"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.15/node-v0.11.15-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.11.15/node-v0.11.15-sunos-x64.tar.gz#08ee809bdb1800a4fd629b795038040222ee2233cdf1adb1297a3abdd18d2584"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.15/node-v0.11.15-sunos-x86.tar.gz#6b4969200aeb10532d4d23c20af4b10eb20b08ee1aa37cc486172b7237dfa0a6"
 
-install_package "node-v0.11.15" "https://nodejs.org/dist/v0.11.15/node-v0.11.15.tar.gz#e613d274baa4c99a0518038192491433f7877493a66d8505af263f6310991d01" warn_eol
+install_package "node-v0.11.15" "https://nodejs.org/dist/v0.11.15/node-v0.11.15.tar.gz#e613d274baa4c99a0518038192491433f7877493a66d8505af263f6310991d01"

--- a/share/node-build/0.11.16
+++ b/share/node-build/0.11.16
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.11.16/node-v0.11.16-darwin-x64.tar.gz#95a05f0b8d6f950121e983b1c17ef676356dbe6f8ea51453c037df200ed09ba0"
 binary darwin-x86 "https://nodejs.org/dist/v0.11.16/node-v0.11.16-darwin-x86.tar.gz#9b79b863f26531c3a38da6a5093aa4b32d71838dfe2f9db59180e0d8f049706a"
 binary linux-x64 "https://nodejs.org/dist/v0.11.16/node-v0.11.16-linux-x64.tar.gz#a1bdc19c779d13b772ac22feead14f592c637ce866d86a59ef225a3273dd7c33"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.16/node-v0.11.16-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.11.16/node-v0.11.16-sunos-x64.tar.gz#ba806e941aa532ace89a0868374dec5ec97d6abd1d3d9d97fd686b419aeb6d05"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.16/node-v0.11.16-sunos-x86.tar.gz#7a15668536ba979ebcbda23beee3e7350544d4b5e15a96afdc928dbb6d423d5a"
 
-install_package "node-v0.11.16" "https://nodejs.org/dist/v0.11.16/node-v0.11.16.tar.gz#f0d141faa1f7da3aff53e9615d76040d29c0650542be3b09ee80aca2f2cc61f6" warn_eol
+install_package "node-v0.11.16" "https://nodejs.org/dist/v0.11.16/node-v0.11.16.tar.gz#f0d141faa1f7da3aff53e9615d76040d29c0650542be3b09ee80aca2f2cc61f6"

--- a/share/node-build/0.11.2
+++ b/share/node-build/0.11.2
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.11.2/node-v0.11.2-darwin-x64.tar.gz#3221e877fa2c30a93df5fd1510913b0f85a18e09cd54fec07b363ecace84a429"
 binary darwin-x86 "https://nodejs.org/dist/v0.11.2/node-v0.11.2-darwin-x86.tar.gz#1df16df8a12a504d6f88025c78ae16ff29d419a6c33fae386b0b88fd387f0a0f"
 binary linux-x64 "https://nodejs.org/dist/v0.11.2/node-v0.11.2-linux-x64.tar.gz#44989b65a7f784cee48435234b12a253bf8e602651ffcdf0c500f7912798faa2"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.2/node-v0.11.2-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.11.2/node-v0.11.2-sunos-x64.tar.gz#f315d1c5ffa8152eeaafc602d0265c9fde19c338c159e1166e981a0bf34d39eb"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.2/node-v0.11.2-sunos-x86.tar.gz#125c52610c41638c740a71d564132e56b986d208dff04a72b7ebb97f3347df04"
 
-install_package "node-v0.11.2" "https://nodejs.org/dist/v0.11.2/node-v0.11.2.tar.gz#d115f01fea0b2c5a4c4ca489d0cc8cec70300f0212f08905d881ac55f642554a" warn_eol
+install_package "node-v0.11.2" "https://nodejs.org/dist/v0.11.2/node-v0.11.2.tar.gz#d115f01fea0b2c5a4c4ca489d0cc8cec70300f0212f08905d881ac55f642554a"

--- a/share/node-build/0.11.3
+++ b/share/node-build/0.11.3
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.11.3/node-v0.11.3-darwin-x64.tar.gz#7f441d7abde7656f01ebb268a4d61c07ecd63934f099f30a386ea7718cf1486b"
 binary darwin-x86 "https://nodejs.org/dist/v0.11.3/node-v0.11.3-darwin-x86.tar.gz#d6b1ae947d8b4006c5a2ed7519a4e423a2dfd53b64c4d4f853172ba42bd106f8"
 binary linux-x64 "https://nodejs.org/dist/v0.11.3/node-v0.11.3-linux-x64.tar.gz#50535f04bf36da6efa52ae57d29354f6e0ffd8dc773c08ec655f44314e6f47d3"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.3/node-v0.11.3-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.11.3/node-v0.11.3-sunos-x64.tar.gz#94e68581c673993901381c212cf255ad3f945a1b5a98d7d122ad40ebd9a9c23d"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.3/node-v0.11.3-sunos-x86.tar.gz#d94c49bc39e0a9c8c184d5326c7e059ead5e6be89555a5cabcdbad43f5e919c0"
 
-install_package "node-v0.11.3" "https://nodejs.org/dist/v0.11.3/node-v0.11.3.tar.gz#aa3189c4e42d3e5dae86c132b28dbe04163d53a480949ea9f1985ddfeaf39955" warn_eol
+install_package "node-v0.11.3" "https://nodejs.org/dist/v0.11.3/node-v0.11.3.tar.gz#aa3189c4e42d3e5dae86c132b28dbe04163d53a480949ea9f1985ddfeaf39955"

--- a/share/node-build/0.11.4
+++ b/share/node-build/0.11.4
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary linux-x64 "https://nodejs.org/dist/v0.11.4/node-v0.11.4-linux-x64.tar.gz#9937c02147c01fa7926ffb1cc231bde536a02b6cbed243f88d76de1d445bf97d"
 binary linux-x86 "https://nodejs.org/dist/v0.11.4/node-v0.11.4-linux-x86.tar.gz#5795f2aeb00b1d99e324850fe9ff2f0cea91ca33da4a4a12a0abc8f3c7bd352d"
 binary darwin-x86 "https://nodejs.org/dist/v0.11.4/node-v0.11.4-darwin-x86.tar.gz#7d143d9db01a34382e02997e168dd7548af810ab34ddae9ed451a482a3ec2263"
@@ -5,4 +9,4 @@ binary darwin-x64 "https://nodejs.org/dist/v0.11.4/node-v0.11.4-darwin-x64.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.11.4/node-v0.11.4-sunos-x64.tar.gz#b7ace7b597704d3b9cad1f581734c1afe51db2aca0da80739b06c557c26fce79"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.4/node-v0.11.4-sunos-x86.tar.gz#9041a18c7eecea05fd8ce331f9f8294af1725a25dd705b0410f81f948d73757c"
 
-install_package "node-v0.11.4" "https://nodejs.org/dist/v0.11.4/node-v0.11.4.tar.gz#81f36aafa4a31fa59e0301358699d82766ea7ba178be810ce00444a7fc10db47" warn_eol
+install_package "node-v0.11.4" "https://nodejs.org/dist/v0.11.4/node-v0.11.4.tar.gz#81f36aafa4a31fa59e0301358699d82766ea7ba178be810ce00444a7fc10db47"

--- a/share/node-build/0.11.5
+++ b/share/node-build/0.11.5
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.11.5/node-v0.11.5-darwin-x64.tar.gz#62034296248db29751c5748f0403c07e73a0ae3b0ef2c3384956aac70a12cd21"
 binary darwin-x86 "https://nodejs.org/dist/v0.11.5/node-v0.11.5-darwin-x86.tar.gz#ee05eb433e3215e8918abaff158a02d52e8bb3a018ddbc6e7b0f4335531f5a22"
 binary linux-x64 "https://nodejs.org/dist/v0.11.5/node-v0.11.5-linux-x64.tar.gz#c45cfeedbe7149e315f58243ec05dc6575ca2fdd16d4cf0f76853a178eaebf41"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.5/node-v0.11.5-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.11.5/node-v0.11.5-sunos-x64.tar.gz#efe9e4d9e84805f2ce485cebcfac4ee683066ae80f53c4a050e41845a3bf7de5"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.5/node-v0.11.5-sunos-x86.tar.gz#7b1a06208026da14b394dafb607408e116a93a1d2dd0d2923870cdc24007fdef"
 
-install_package "node-v0.11.5" "https://nodejs.org/dist/v0.11.5/node-v0.11.5.tar.gz#72b89f9146a2dd57e1712f1fb822f62bdf00b2d5482689510dc2e4d19ae6559e" warn_eol
+install_package "node-v0.11.5" "https://nodejs.org/dist/v0.11.5/node-v0.11.5.tar.gz#72b89f9146a2dd57e1712f1fb822f62bdf00b2d5482689510dc2e4d19ae6559e"

--- a/share/node-build/0.11.6
+++ b/share/node-build/0.11.6
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.11.6/node-v0.11.6-darwin-x64.tar.gz#71dfb9ae0cb7b43bf14ede3a78885bdcd7e376786439159e22fbac98ff7eb998"
 binary darwin-x86 "https://nodejs.org/dist/v0.11.6/node-v0.11.6-darwin-x86.tar.gz#4c609184a7dcf095a39f50b613edbe58c7f0c4df5bff566437739de8ffe0f051"
 binary linux-x64 "https://nodejs.org/dist/v0.11.6/node-v0.11.6-linux-x64.tar.gz#4d0b09d88466933439cd5b87c4fbf998732cb6705314edbc9ed3901c2cc24669"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.6/node-v0.11.6-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.11.6/node-v0.11.6-sunos-x64.tar.gz#a20a411403d693d174860140add6c20499ccefd3c7b41e78a4e7fbf349f03f61"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.6/node-v0.11.6-sunos-x86.tar.gz#21ab274fe11405dd2997763e9b4fd065604931150c47c039f22de73ed59f2902"
 
-install_package "node-v0.11.6" "https://nodejs.org/dist/v0.11.6/node-v0.11.6.tar.gz#35552aec60077270306c73507effeb4b7d9ef02f03f45681442c0d4e1951e75d" warn_eol
+install_package "node-v0.11.6" "https://nodejs.org/dist/v0.11.6/node-v0.11.6.tar.gz#35552aec60077270306c73507effeb4b7d9ef02f03f45681442c0d4e1951e75d"

--- a/share/node-build/0.11.7
+++ b/share/node-build/0.11.7
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.11.7/node-v0.11.7-darwin-x64.tar.gz#1679e0fc69202638186392be31ffca6f39d666f275875779f1f76f4dc2c10ece"
 binary darwin-x86 "https://nodejs.org/dist/v0.11.7/node-v0.11.7-darwin-x86.tar.gz#d7c9c668ae17c650c368613f8c6f1b321ac1f3de87cf36342bcd6127cf74088f"
 binary linux-x64 "https://nodejs.org/dist/v0.11.7/node-v0.11.7-linux-x64.tar.gz#67253735b86fdba070ef8af6b328e13c9ee4de38f269c60696ff498449646929"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.7/node-v0.11.7-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.11.7/node-v0.11.7-sunos-x64.tar.gz#4d4f10266e05b3d8081d3674d0d35f75703037bda85d4a10cc721d31b72ed77e"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.7/node-v0.11.7-sunos-x86.tar.gz#c1ecf77d9a9f15cd16667a76cea2e950781853e7d4ea0466481bdec82cdd602a"
 
-install_package "node-v0.11.7" "https://nodejs.org/dist/v0.11.7/node-v0.11.7.tar.gz#d915345639e340405b01f259971f386aafb5a10544b162826514cf56ddd371fe" warn_eol
+install_package "node-v0.11.7" "https://nodejs.org/dist/v0.11.7/node-v0.11.7.tar.gz#d915345639e340405b01f259971f386aafb5a10544b162826514cf56ddd371fe"

--- a/share/node-build/0.11.8
+++ b/share/node-build/0.11.8
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.11.8/node-v0.11.8-darwin-x64.tar.gz#e8d64d423b97aa50d42c917759c7ccd3cdfb3e6b257cdd08a7030eb2347e5a50"
 binary darwin-x86 "https://nodejs.org/dist/v0.11.8/node-v0.11.8-darwin-x86.tar.gz#2137c56ae3e665508cf9519fcbf6d2b56b8b4272e0fceb6ec060ca528a997ad0"
 binary linux-x64 "https://nodejs.org/dist/v0.11.8/node-v0.11.8-linux-x64.tar.gz#5ddc30cb411201cbfde7df9db8a071bd61fac3e3c7d2156b6bef0b10475c934e"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.8/node-v0.11.8-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.11.8/node-v0.11.8-sunos-x64.tar.gz#0599412586981586bddc2686f3f1a41c48862ae8dd770f810cec83d7453dc8be"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.8/node-v0.11.8-sunos-x86.tar.gz#66e20972dcd44efbfe51404b7a9e5b67e03f71b439fc966bd4e6d2524ce9c886"
 
-install_package "node-v0.11.8" "https://nodejs.org/dist/v0.11.8/node-v0.11.8.tar.gz#87c809dea764d5d66f925626fba403fb2fb0c0ccfad408bf79fdb62dc246d65b" warn_eol
+install_package "node-v0.11.8" "https://nodejs.org/dist/v0.11.8/node-v0.11.8.tar.gz#87c809dea764d5d66f925626fba403fb2fb0c0ccfad408bf79fdb62dc246d65b"

--- a/share/node-build/0.11.9
+++ b/share/node-build/0.11.9
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.11.9/node-v0.11.9-darwin-x64.tar.gz#cc523a93237645fb44d24cda3bfeb2b2d7ebd4d2265c0a175f264e3333706c45"
 binary darwin-x86 "https://nodejs.org/dist/v0.11.9/node-v0.11.9-darwin-x86.tar.gz#4bea8fbde1baa8b1ae2db187488df44c3607b5f94c84c2d0c301c3e7666cf1b8"
 binary linux-x64 "https://nodejs.org/dist/v0.11.9/node-v0.11.9-linux-x64.tar.gz#89a5013f326e67b73ebef638e765b286831a5d72363ebfdfc75b57b0818c178c"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.11.9/node-v0.11.9-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.11.9/node-v0.11.9-sunos-x64.tar.gz#b37fa67fe332c32759be413dbad9e4f8231267ac3afa7afc1d74388d9859dc73"
 binary sunos-x86 "https://nodejs.org/dist/v0.11.9/node-v0.11.9-sunos-x86.tar.gz#158bafae549cbaac88bd85bc6e00104f3fdbc84ac2562018050d9131b44d7e4f"
 
-install_package "node-v0.11.9" "https://nodejs.org/dist/v0.11.9/node-v0.11.9.tar.gz#cfcab9735a7e04a67671a96a8b0b7e71954c60c586ced5e3fe37d5c1a235b444" warn_eol
+install_package "node-v0.11.9" "https://nodejs.org/dist/v0.11.9/node-v0.11.9.tar.gz#cfcab9735a7e04a67671a96a8b0b7e71954c60c586ced5e3fe37d5c1a235b444"

--- a/share/node-build/0.12-dev
+++ b/share/node-build/0.12-dev
@@ -1,5 +1,5 @@
 before_install_package() {
-  build_package_warn_unsupported "$1"
+  build_package_warn_lts_maintenance "$1"
 }
 
 install_git "0.12-dev" "https://github.com/nodejs/node.git" "v0.12-staging" standard

--- a/share/node-build/0.12-dev
+++ b/share/node-build/0.12-dev
@@ -1,1 +1,5 @@
-install_git "0.12-dev" "https://github.com/nodejs/node.git" "v0.12-staging" standard warn_unsupported
+before_install_package() {
+  build_package_warn_unsupported "$1"
+}
+
+install_git "0.12-dev" "https://github.com/nodejs/node.git" "v0.12-staging" standard

--- a/share/node-build/0.12-next
+++ b/share/node-build/0.12-next
@@ -1,5 +1,5 @@
 before_install_package() {
-  build_package_warn_unsupported "$1"
+  build_package_warn_lts_maintenance "$1"
 }
 
 install_git "0.12-next" "https://github.com/nodejs/node.git" "v0.12" standard

--- a/share/node-build/0.12-next
+++ b/share/node-build/0.12-next
@@ -1,1 +1,5 @@
-install_git "0.12-next" "https://github.com/nodejs/node.git" "v0.12" standard warn_unsupported
+before_install_package() {
+  build_package_warn_unsupported "$1"
+}
+
+install_git "0.12-next" "https://github.com/nodejs/node.git" "v0.12" standard

--- a/share/node-build/0.12.0
+++ b/share/node-build/0.12.0
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_unsupported "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.12.0/node-v0.12.0-darwin-x64.tar.gz#880c530d11168c796c3b3e4cec1b2fa37af22e9c559faf395854b94bc7bf0cd2"
 binary darwin-x86 "https://nodejs.org/dist/v0.12.0/node-v0.12.0-darwin-x86.tar.gz#2d75cb34249884c7e36dce4d53809e020a6a215ceb1b6827d9e18ed1ded9293a"
 binary linux-x64 "https://nodejs.org/dist/v0.12.0/node-v0.12.0-linux-x64.tar.gz#3bdb7267ca7ee24ac59c54ae146741f70a6ae3a8a8afd42d06204647fe9d4206"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.0/node-v0.12.0-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.12.0/node-v0.12.0-sunos-x64.tar.gz#b775ba850a950ad405bc92f57325aae5b3a692f241bb1f01a94b1291c9b43246"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.0/node-v0.12.0-sunos-x86.tar.gz#c910021a6b756ffe89f3a91a51f5f6ed6fcebae51fd12a5dc2070b06bb400244"
 
-install_package "node-v0.12.0" "https://nodejs.org/dist/v0.12.0/node-v0.12.0.tar.gz#9700e23af4e9b3643af48cef5f2ad20a1331ff531a12154eef2bfb0bb1682e32" warn_unsupported
+install_package "node-v0.12.0" "https://nodejs.org/dist/v0.12.0/node-v0.12.0.tar.gz#9700e23af4e9b3643af48cef5f2ad20a1331ff531a12154eef2bfb0bb1682e32"

--- a/share/node-build/0.12.0
+++ b/share/node-build/0.12.0
@@ -1,5 +1,5 @@
 before_install_package() {
-  build_package_warn_unsupported "$1"
+  build_package_warn_lts_maintenance "$1"
 }
 
 binary darwin-x64 "https://nodejs.org/dist/v0.12.0/node-v0.12.0-darwin-x64.tar.gz#880c530d11168c796c3b3e4cec1b2fa37af22e9c559faf395854b94bc7bf0cd2"

--- a/share/node-build/0.12.1
+++ b/share/node-build/0.12.1
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_unsupported "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.12.1/node-v0.12.1-darwin-x64.tar.gz#1724e75c32ac58452e0ca3eae25120ab67e3b1383da7c10278b33c0f2d3385bf"
 binary darwin-x86 "https://nodejs.org/dist/v0.12.1/node-v0.12.1-darwin-x86.tar.gz#c455d68f64e4495ceb97f57399ee8cb28471d1ab7096fce3be5899754680eb8c"
 binary linux-x64 "https://nodejs.org/dist/v0.12.1/node-v0.12.1-linux-x64.tar.gz#270d478d0ffb06063f01eab932f672b788f6ecf3c117075ac8b87c0c17e0c9de"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.1/node-v0.12.1-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.12.1/node-v0.12.1-sunos-x64.tar.gz#d93ddc3f2d17da8320cfff40ef39edb4a19e0877f31254e1bf66988bae0a0616"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.1/node-v0.12.1-sunos-x86.tar.gz#b7cd96f4791e95b3698e1a6e0461acd040f14138e9fde1e64a76b279da5ea9bb"
 
-install_package "node-v0.12.1" "https://nodejs.org/dist/v0.12.1/node-v0.12.1.tar.gz#30693376519c9736bcb22d44513252aee1d9463d78ac6c744ecb6d13fd91d680" warn_unsupported
+install_package "node-v0.12.1" "https://nodejs.org/dist/v0.12.1/node-v0.12.1.tar.gz#30693376519c9736bcb22d44513252aee1d9463d78ac6c744ecb6d13fd91d680"

--- a/share/node-build/0.12.1
+++ b/share/node-build/0.12.1
@@ -1,5 +1,5 @@
 before_install_package() {
-  build_package_warn_unsupported "$1"
+  build_package_warn_lts_maintenance "$1"
 }
 
 binary darwin-x64 "https://nodejs.org/dist/v0.12.1/node-v0.12.1-darwin-x64.tar.gz#1724e75c32ac58452e0ca3eae25120ab67e3b1383da7c10278b33c0f2d3385bf"

--- a/share/node-build/0.12.10
+++ b/share/node-build/0.12.10
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_unsupported "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.12.10/node-v0.12.10-darwin-x64.tar.gz#c95df35ca1ed7b4b0ded815c1d49f36defcb1fdb882f6a8ef6106a07e3f2ffef"
 binary darwin-x86 "https://nodejs.org/dist/v0.12.10/node-v0.12.10-darwin-x86.tar.gz#d4abd2b778c9d803676ad6121e6fdbc625b9ea73e845b0ecd761c162e86150ca"
 binary linux-x64 "https://nodejs.org/dist/v0.12.10/node-v0.12.10-linux-x64.tar.gz#8fb4d6ed8934f0b0c92c26878511e1d340b068ee966c131ba0fccc1199f4349d"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.10/node-v0.12.10-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.12.10/node-v0.12.10-sunos-x64.tar.gz#d67f17540c711eb150b8a389af1b4e6ecdcab66a1648b7ce925af98ab52b2698"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.10/node-v0.12.10-sunos-x86.tar.gz#beca24cc3615c5b1858817d121bd91eecdc3af5b98ed0c4c171e1ef60afac049"
 
-install_package "node-v0.12.10" "https://nodejs.org/dist/v0.12.10/node-v0.12.10.tar.gz#edbd3710512ec7518a3de4cabf9bfee6d12f278eef2e4b53422c7b063f6b976d" warn_unsupported
+install_package "node-v0.12.10" "https://nodejs.org/dist/v0.12.10/node-v0.12.10.tar.gz#edbd3710512ec7518a3de4cabf9bfee6d12f278eef2e4b53422c7b063f6b976d"

--- a/share/node-build/0.12.10
+++ b/share/node-build/0.12.10
@@ -1,5 +1,5 @@
 before_install_package() {
-  build_package_warn_unsupported "$1"
+  build_package_warn_lts_maintenance "$1"
 }
 
 binary darwin-x64 "https://nodejs.org/dist/v0.12.10/node-v0.12.10-darwin-x64.tar.gz#c95df35ca1ed7b4b0ded815c1d49f36defcb1fdb882f6a8ef6106a07e3f2ffef"

--- a/share/node-build/0.12.11
+++ b/share/node-build/0.12.11
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_unsupported "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.12.11/node-v0.12.11-darwin-x64.tar.gz#68b949f6c308eb1ad28e96926fca68e3ac0dfb7ec997945f4e26db99fe3ad711"
 binary darwin-x86 "https://nodejs.org/dist/v0.12.11/node-v0.12.11-darwin-x86.tar.gz#057f701678c0fe0c596eaa517e8b7ba771bdca89d99a7ace8df8e1064784727b"
 binary linux-x64 "https://nodejs.org/dist/v0.12.11/node-v0.12.11-linux-x64.tar.gz#d98b76b7721a60471801e07e1f90af4fd479e8e42a632d419ede0a7b3c603cc0"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.11/node-v0.12.11-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.12.11/node-v0.12.11-sunos-x64.tar.gz#6a68d6ad04c9b73ed72e88e39002bbaa95ffc423c6cf47e3c3da5edd0abbc701"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.11/node-v0.12.11-sunos-x86.tar.gz#9e61254d7437c2498817225c62dc6cfc065bd3b2404a213d8d305419bca07a6c"
 
-install_package "node-v0.12.11" "https://nodejs.org/dist/v0.12.11/node-v0.12.11.tar.gz#e49049d82f2a11fa164549d907d4739fe1293d53c07f48bd70e1df237b238a68" warn_unsupported
+install_package "node-v0.12.11" "https://nodejs.org/dist/v0.12.11/node-v0.12.11.tar.gz#e49049d82f2a11fa164549d907d4739fe1293d53c07f48bd70e1df237b238a68"

--- a/share/node-build/0.12.11
+++ b/share/node-build/0.12.11
@@ -1,5 +1,5 @@
 before_install_package() {
-  build_package_warn_unsupported "$1"
+  build_package_warn_lts_maintenance "$1"
 }
 
 binary darwin-x64 "https://nodejs.org/dist/v0.12.11/node-v0.12.11-darwin-x64.tar.gz#68b949f6c308eb1ad28e96926fca68e3ac0dfb7ec997945f4e26db99fe3ad711"

--- a/share/node-build/0.12.12
+++ b/share/node-build/0.12.12
@@ -1,5 +1,5 @@
 before_install_package() {
-  build_package_warn_unsupported "$1"
+  build_package_warn_lts_maintenance "$1"
 }
 
 binary darwin-x64 "https://nodejs.org/dist/v0.12.12/node-v0.12.12-darwin-x64.tar.gz#b9b7b7c8f9c35fd6492bd5e60ec485ca8bf60f678651c7b6c46a3d8cf561e13c"

--- a/share/node-build/0.12.12
+++ b/share/node-build/0.12.12
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_unsupported "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.12.12/node-v0.12.12-darwin-x64.tar.gz#b9b7b7c8f9c35fd6492bd5e60ec485ca8bf60f678651c7b6c46a3d8cf561e13c"
 binary darwin-x86 "https://nodejs.org/dist/v0.12.12/node-v0.12.12-darwin-x86.tar.gz#a2faf1180ffa50dbce0ca0a63b4285982b9fd87623dcda400c8f7e2be3abaa0a"
 binary linux-x64 "https://nodejs.org/dist/v0.12.12/node-v0.12.12-linux-x64.tar.gz#a3d51cc26060fe46f9ebe69c750b20fe1f6f27a936db6046a73b8a9715bf3559"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.12/node-v0.12.12-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.12.12/node-v0.12.12-sunos-x64.tar.gz#ef361aec4a2c1e3789662e7605928717af76b4d0ed360d4facb75a606ac0a2de"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.12/node-v0.12.12-sunos-x86.tar.gz#f6d0fa1fe8cfc197fbe86c8f7517b42d610efb341218fad1b24bc7f08cc4433f"
 
-install_package "node-v0.12.12" "https://nodejs.org/dist/v0.12.12/node-v0.12.12.tar.gz#61e4c176fd882498778b1a3907a5fe5c9e95e6cc8438b0d053d953aed3620273" warn_unsupported
+install_package "node-v0.12.12" "https://nodejs.org/dist/v0.12.12/node-v0.12.12.tar.gz#61e4c176fd882498778b1a3907a5fe5c9e95e6cc8438b0d053d953aed3620273"

--- a/share/node-build/0.12.13
+++ b/share/node-build/0.12.13
@@ -1,5 +1,5 @@
 before_install_package() {
-  build_package_warn_unsupported "$1"
+  build_package_warn_lts_maintenance "$1"
 }
 
 binary darwin-x64 "https://nodejs.org/dist/v0.12.13/node-v0.12.13-darwin-x64.tar.gz#e842a8eb8b7658d177675de9d054de4d7fb7d6c77edfcda7d83adb95b029bf3d"

--- a/share/node-build/0.12.13
+++ b/share/node-build/0.12.13
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_unsupported "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.12.13/node-v0.12.13-darwin-x64.tar.gz#e842a8eb8b7658d177675de9d054de4d7fb7d6c77edfcda7d83adb95b029bf3d"
 binary darwin-x86 "https://nodejs.org/dist/v0.12.13/node-v0.12.13-darwin-x86.tar.gz#8ecdcd3b29ef0d3264bb48c0834bc024016d19a8f5c040fa6b51328191f39a60"
 binary linux-x64 "https://nodejs.org/dist/v0.12.13/node-v0.12.13-linux-x64.tar.gz#3e8b6ee32fc9a726bfe6f3961bcccf3d2b6d0ddd68326abb4434039f16e10f09"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.13/node-v0.12.13-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.12.13/node-v0.12.13-sunos-x64.tar.gz#9b40e2b657e560901c6cccf3c93d01a5055cb4d011ccfefe1b977dae7935ea42"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.13/node-v0.12.13-sunos-x86.tar.gz#83f862b0383ba6c9a15f32a043de48288b087c0f368117eac36d66779491a910"
 
-install_package "node-v0.12.13" "https://nodejs.org/dist/v0.12.13/node-v0.12.13.tar.gz#0a972ed6442cb526aa7aa1bcb10aa536b65bd90ab4956b5a1aa51b4b7bb071bd" warn_unsupported
+install_package "node-v0.12.13" "https://nodejs.org/dist/v0.12.13/node-v0.12.13.tar.gz#0a972ed6442cb526aa7aa1bcb10aa536b65bd90ab4956b5a1aa51b4b7bb071bd"

--- a/share/node-build/0.12.14
+++ b/share/node-build/0.12.14
@@ -1,5 +1,5 @@
 before_install_package() {
-  build_package_warn_unsupported "$1"
+  build_package_warn_lts_maintenance "$1"
 }
 
 binary darwin-x64 "https://nodejs.org/dist/v0.12.14/node-v0.12.14-darwin-x64.tar.gz#b4de40b8fe9cf748b36b9d7764c06f1fc955c73e3547c4eaab3d90a818663e1c"

--- a/share/node-build/0.12.14
+++ b/share/node-build/0.12.14
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_unsupported "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.12.14/node-v0.12.14-darwin-x64.tar.gz#b4de40b8fe9cf748b36b9d7764c06f1fc955c73e3547c4eaab3d90a818663e1c"
 binary darwin-x86 "https://nodejs.org/dist/v0.12.14/node-v0.12.14-darwin-x86.tar.gz#2ac52efd90931ea04dd01947e19c6320e519967a813f7274eb699bf468fe226d"
 binary linux-x64 "https://nodejs.org/dist/v0.12.14/node-v0.12.14-linux-x64.tar.gz#0f1f20f6989d32b4b67835f527ae3bf165c1c4a6a7dc3961d489288817956bae"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.14/node-v0.12.14-linux-x86.tar.g
 binary sunos-x64 "https://nodejs.org/dist/v0.12.14/node-v0.12.14-sunos-x64.tar.gz#906a44e9f6024c3f9af05a8aac5ba10c25d84bf56b9fb08c5fc1c26c5a8b9d27"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.14/node-v0.12.14-sunos-x86.tar.gz#f042bee409d4da3114571dfff496a954ea6cd614e7fb78fd3d9b50d799396757"
 
-install_package "node-v0.12.14" "https://nodejs.org/dist/v0.12.14/node-v0.12.14.tar.gz#0a55e57cbd3ffa67525c0d93ac7076d3b2ac70887b11c5c97be3e1953cb50b1d" warn_unsupported
+install_package "node-v0.12.14" "https://nodejs.org/dist/v0.12.14/node-v0.12.14.tar.gz#0a55e57cbd3ffa67525c0d93ac7076d3b2ac70887b11c5c97be3e1953cb50b1d"

--- a/share/node-build/0.12.15
+++ b/share/node-build/0.12.15
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_unsupported "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.12.15/node-v0.12.15-darwin-x64.tar.gz#125551969069284099d402d85e36e1637d9dd6f19105261f87b8f8b2020b3433"
 binary darwin-x86 "https://nodejs.org/dist/v0.12.15/node-v0.12.15-darwin-x86.tar.gz#2026bdd953a783d78e2036f67f95590d3334f06541371bbbc87d3ec4991e60e9"
 binary linux-x64 "https://nodejs.org/dist/v0.12.15/node-v0.12.15-linux-x64.tar.gz#ab2dc52174552e3959f15a438918b32b59e49409e5640f2acb1a3b9c85cf2a95"

--- a/share/node-build/0.12.15
+++ b/share/node-build/0.12.15
@@ -1,5 +1,5 @@
 before_install_package() {
-  build_package_warn_unsupported "$1"
+  build_package_warn_lts_maintenance "$1"
 }
 
 binary darwin-x64 "https://nodejs.org/dist/v0.12.15/node-v0.12.15-darwin-x64.tar.gz#125551969069284099d402d85e36e1637d9dd6f19105261f87b8f8b2020b3433"

--- a/share/node-build/0.12.16
+++ b/share/node-build/0.12.16
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_unsupported "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.12.16/node-v0.12.16-darwin-x64.tar.gz#c602cbced0d6a2fb9d97f25a72833cf564b35fdf742f8627a93b6cdb5132ea95"
 binary darwin-x86 "https://nodejs.org/dist/v0.12.16/node-v0.12.16-darwin-x86.tar.gz#2cb0b6d33deab16aa261eeadec9c0da40d23e391b626a096f36b75ded62e471f"
 binary linux-x64 "https://nodejs.org/dist/v0.12.16/node-v0.12.16-linux-x64.tar.gz#d9e1cd239844f2a5641e02e48b3c7955e3e73ff3c3d20629c24b561f08ab8219"

--- a/share/node-build/0.12.16
+++ b/share/node-build/0.12.16
@@ -1,5 +1,5 @@
 before_install_package() {
-  build_package_warn_unsupported "$1"
+  build_package_warn_lts_maintenance "$1"
 }
 
 binary darwin-x64 "https://nodejs.org/dist/v0.12.16/node-v0.12.16-darwin-x64.tar.gz#c602cbced0d6a2fb9d97f25a72833cf564b35fdf742f8627a93b6cdb5132ea95"

--- a/share/node-build/0.12.17
+++ b/share/node-build/0.12.17
@@ -1,5 +1,5 @@
 before_install_package() {
-  build_package_warn_unsupported "$1"
+  build_package_warn_lts_maintenance "$1"
 }
 
 binary darwin-x64 "https://nodejs.org/dist/v0.12.17/node-v0.12.17-darwin-x64.tar.gz#4134958fecbc56e9a25374c80e4770ec51e5acfb5eefb67c89ee1af8d80c83da"

--- a/share/node-build/0.12.17
+++ b/share/node-build/0.12.17
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_unsupported "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.12.17/node-v0.12.17-darwin-x64.tar.gz#4134958fecbc56e9a25374c80e4770ec51e5acfb5eefb67c89ee1af8d80c83da"
 binary darwin-x86 "https://nodejs.org/dist/v0.12.17/node-v0.12.17-darwin-x86.tar.gz#5a24a5ca37ee53d45e49dafcd286b6b26e9f5e2805bb768b287bab5f289573ba"
 binary linux-x64 "https://nodejs.org/dist/v0.12.17/node-v0.12.17-linux-x64.tar.gz#afeec47fc543e24a1e596d05e9bc8e019c3bdf51d45f0ddeac6aeb04f15eaece"

--- a/share/node-build/0.12.2
+++ b/share/node-build/0.12.2
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_unsupported "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.12.2/node-v0.12.2-darwin-x64.tar.gz#7d382f8988ea441e2918d9d935003177affd13d4d160020df6b3d8ee7d65ec2d"
 binary darwin-x86 "https://nodejs.org/dist/v0.12.2/node-v0.12.2-darwin-x86.tar.gz#4d814c4b16ea75f12fa9e6511ea3367c84f99116f8bf25e87a9e839d2cf05cde"
 binary linux-x64 "https://nodejs.org/dist/v0.12.2/node-v0.12.2-linux-x64.tar.gz#4e1578efc2a2cc67651413a05ccc4c5d43f6b4329c599901c556f24d93cd0508"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.2/node-v0.12.2-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.12.2/node-v0.12.2-sunos-x64.tar.gz#48112116f4d7ba15c47cf269d72df1f402efaccde1b0bce41d6176c6b653f1b3"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.2/node-v0.12.2-sunos-x86.tar.gz#86b07380c92fa4f2a82db7cd5089c63fe9b6235193c5c670736243aa015b9c8a"
 
-install_package "node-v0.12.2" "https://nodejs.org/dist/v0.12.2/node-v0.12.2.tar.gz#ac7e78ade93e633e7ed628532bb8e650caba0c9c33af33581957f3382e2a772d" warn_unsupported
+install_package "node-v0.12.2" "https://nodejs.org/dist/v0.12.2/node-v0.12.2.tar.gz#ac7e78ade93e633e7ed628532bb8e650caba0c9c33af33581957f3382e2a772d"

--- a/share/node-build/0.12.2
+++ b/share/node-build/0.12.2
@@ -1,5 +1,5 @@
 before_install_package() {
-  build_package_warn_unsupported "$1"
+  build_package_warn_lts_maintenance "$1"
 }
 
 binary darwin-x64 "https://nodejs.org/dist/v0.12.2/node-v0.12.2-darwin-x64.tar.gz#7d382f8988ea441e2918d9d935003177affd13d4d160020df6b3d8ee7d65ec2d"

--- a/share/node-build/0.12.3
+++ b/share/node-build/0.12.3
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_unsupported "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.12.3/node-v0.12.3-darwin-x64.tar.gz#74ddd964bcc7d73bb7cf893174710bf6d0b9d8950e30cccb9a50827df04f1c59"
 binary darwin-x86 "https://nodejs.org/dist/v0.12.3/node-v0.12.3-darwin-x86.tar.gz#8bfe24802ae4f56c9275a96da49101b37779fd2f92ed6a9acfb6318ebe80ffa0"
 binary linux-x64 "https://nodejs.org/dist/v0.12.3/node-v0.12.3-linux-x64.tar.gz#22478ba86906666a95010e4eb73763535211719a53da9139b95daeb5b6c170b8"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.3/node-v0.12.3-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.12.3/node-v0.12.3-sunos-x64.tar.gz#376318f3e3c14543f4419d0e8c190cebbcb6052882980beeb9203d13548f6cc1"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.3/node-v0.12.3-sunos-x86.tar.gz#8d6e3400fdfa9fe0df7f441c5f51d25fb2a8975b9ae6c43560c3bf3a71d1497d"
 
-install_package "node-v0.12.3" "https://nodejs.org/dist/v0.12.3/node-v0.12.3.tar.gz#e65d83c6f2c874e28f65c5e192ac0acd2bbb52bfcf9d77e33442d6765a3eb9da" warn_unsupported
+install_package "node-v0.12.3" "https://nodejs.org/dist/v0.12.3/node-v0.12.3.tar.gz#e65d83c6f2c874e28f65c5e192ac0acd2bbb52bfcf9d77e33442d6765a3eb9da"

--- a/share/node-build/0.12.3
+++ b/share/node-build/0.12.3
@@ -1,5 +1,5 @@
 before_install_package() {
-  build_package_warn_unsupported "$1"
+  build_package_warn_lts_maintenance "$1"
 }
 
 binary darwin-x64 "https://nodejs.org/dist/v0.12.3/node-v0.12.3-darwin-x64.tar.gz#74ddd964bcc7d73bb7cf893174710bf6d0b9d8950e30cccb9a50827df04f1c59"

--- a/share/node-build/0.12.4
+++ b/share/node-build/0.12.4
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_unsupported "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.12.4/node-v0.12.4-darwin-x64.tar.gz#757d1a2e7d3deb03b40277e9f04ae276c370b53e6e5238d44e08846f1f3c85c2"
 binary darwin-x86 "https://nodejs.org/dist/v0.12.4/node-v0.12.4-darwin-x86.tar.gz#a1b9c671ef3e16d6fe757ac16b48565f340027e217cf1bb0f461059e49394814"
 binary linux-x64 "https://nodejs.org/dist/v0.12.4/node-v0.12.4-linux-x64.tar.gz#9095c664c81d7ec90337efd0877e2af72bd055bf8f4f47056d2ac8ea909f561e"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.4/node-v0.12.4-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.12.4/node-v0.12.4-sunos-x64.tar.gz#308cb46091c613f8068a8aa30980ce4a1ac6e85ac14aa464728e83727a981f13"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.4/node-v0.12.4-sunos-x86.tar.gz#b9bd9a590f73d8c82704676794eb64a17fba01c35b285bc99c14af547dbc3fab"
 
-install_package "node-v0.12.4" "https://nodejs.org/dist/v0.12.4/node-v0.12.4.tar.gz#3298d0997613a04ac64343e8316da134d04588132554ae402eb344e3369ec912" warn_unsupported
+install_package "node-v0.12.4" "https://nodejs.org/dist/v0.12.4/node-v0.12.4.tar.gz#3298d0997613a04ac64343e8316da134d04588132554ae402eb344e3369ec912"

--- a/share/node-build/0.12.4
+++ b/share/node-build/0.12.4
@@ -1,5 +1,5 @@
 before_install_package() {
-  build_package_warn_unsupported "$1"
+  build_package_warn_lts_maintenance "$1"
 }
 
 binary darwin-x64 "https://nodejs.org/dist/v0.12.4/node-v0.12.4-darwin-x64.tar.gz#757d1a2e7d3deb03b40277e9f04ae276c370b53e6e5238d44e08846f1f3c85c2"

--- a/share/node-build/0.12.5
+++ b/share/node-build/0.12.5
@@ -1,5 +1,5 @@
 before_install_package() {
-  build_package_warn_unsupported "$1"
+  build_package_warn_lts_maintenance "$1"
 }
 
 binary darwin-x64 "https://nodejs.org/dist/v0.12.5/node-v0.12.5-darwin-x64.tar.gz#23cbcbae16488384580324a059a8716667f2ea7798589caebf038ceda2db5355"

--- a/share/node-build/0.12.5
+++ b/share/node-build/0.12.5
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_unsupported "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.12.5/node-v0.12.5-darwin-x64.tar.gz#23cbcbae16488384580324a059a8716667f2ea7798589caebf038ceda2db5355"
 binary darwin-x86 "https://nodejs.org/dist/v0.12.5/node-v0.12.5-darwin-x86.tar.gz#638163edf9810f067b94641f51fabff3b721f6ac7d893db424f987c3916fec05"
 binary linux-x64 "https://nodejs.org/dist/v0.12.5/node-v0.12.5-linux-x64.tar.gz#d4d7efb9e1370d9563ace338e01f7be31df48cf8e04ad670f54b6eb8a3c54e03"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.5/node-v0.12.5-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.12.5/node-v0.12.5-sunos-x64.tar.gz#ceb0d587ff4f85e47ed7f85fac96ada51bc42199725a218f72e109adb12766c0"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.5/node-v0.12.5-sunos-x86.tar.gz#e39121eebb362ea619de354af802bf5428105a96a87dc5f40fc20c2979e5b772"
 
-install_package "node-v0.12.5" "https://nodejs.org/dist/v0.12.5/node-v0.12.5.tar.gz#4bc1e25f4c62ac65324d3cf4aa9de2d801cd708757c3567b6ad2ced7df30cdd2" warn_unsupported
+install_package "node-v0.12.5" "https://nodejs.org/dist/v0.12.5/node-v0.12.5.tar.gz#4bc1e25f4c62ac65324d3cf4aa9de2d801cd708757c3567b6ad2ced7df30cdd2"

--- a/share/node-build/0.12.6
+++ b/share/node-build/0.12.6
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_unsupported "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.12.6/node-v0.12.6-darwin-x64.tar.gz#843b72103c461c780554c590041bc1df1086e192c07dc8eeddb5fe644f072f19"
 binary darwin-x86 "https://nodejs.org/dist/v0.12.6/node-v0.12.6-darwin-x86.tar.gz#ac491532dca62a2ae7a3315637fe01e4120ed2720be7a2eedb43d465e8f559de"
 binary linux-x64 "https://nodejs.org/dist/v0.12.6/node-v0.12.6-linux-x64.tar.gz#ebbd70ffe0daac6b33df74577c9d25cfb678dbc0016a5ea9eff99d2c5bdb3851"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.6/node-v0.12.6-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.12.6/node-v0.12.6-sunos-x64.tar.gz#cd0d0dd1ec646ac41c5b2486392662910930779b29a90e9650189b0bc2ca2a7e"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.6/node-v0.12.6-sunos-x86.tar.gz#f168959b26c0b1074d5fe24899f070d352741bfa624a556e263890b624af68c5"
 
-install_package "node-v0.12.6" "https://nodejs.org/dist/v0.12.6/node-v0.12.6.tar.gz#7a3b5ac351973a9dee8edbf0684bc8d0dea44b231e42274ffb008141ffa19ad2" warn_unsupported
+install_package "node-v0.12.6" "https://nodejs.org/dist/v0.12.6/node-v0.12.6.tar.gz#7a3b5ac351973a9dee8edbf0684bc8d0dea44b231e42274ffb008141ffa19ad2"

--- a/share/node-build/0.12.6
+++ b/share/node-build/0.12.6
@@ -1,5 +1,5 @@
 before_install_package() {
-  build_package_warn_unsupported "$1"
+  build_package_warn_lts_maintenance "$1"
 }
 
 binary darwin-x64 "https://nodejs.org/dist/v0.12.6/node-v0.12.6-darwin-x64.tar.gz#843b72103c461c780554c590041bc1df1086e192c07dc8eeddb5fe644f072f19"

--- a/share/node-build/0.12.7
+++ b/share/node-build/0.12.7
@@ -1,5 +1,5 @@
 before_install_package() {
-  build_package_warn_unsupported "$1"
+  build_package_warn_lts_maintenance "$1"
 }
 
 binary darwin-x64 "https://nodejs.org/dist/v0.12.7/node-v0.12.7-darwin-x64.tar.gz#58f24547ae5be8e0c7183bed65f96a1722af1ce363eccb1523a2321f38d83d57"

--- a/share/node-build/0.12.7
+++ b/share/node-build/0.12.7
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_unsupported "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.12.7/node-v0.12.7-darwin-x64.tar.gz#58f24547ae5be8e0c7183bed65f96a1722af1ce363eccb1523a2321f38d83d57"
 binary darwin-x86 "https://nodejs.org/dist/v0.12.7/node-v0.12.7-darwin-x86.tar.gz#8db41046537a98b60bec7c918eb25b8828c26d1b85adf3918ad260073cdb4a6d"
 binary linux-x64 "https://nodejs.org/dist/v0.12.7/node-v0.12.7-linux-x64.tar.gz#6a2b3077f293d17e2a1e6dba0297f761c9e981c255a2c82f329d4173acf9b9d5"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.7/node-v0.12.7-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.12.7/node-v0.12.7-sunos-x64.tar.gz#e5cb2f36c1e6899c6e8b268d1019459bc9dd125d8144e47fb0d740e8601e5ddb"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.7/node-v0.12.7-sunos-x86.tar.gz#c7c7af04ca624a7a08c308f172e26a7fd3182187d3da0025e0108c67c2e5c6c9"
 
-install_package "node-v0.12.7" "https://nodejs.org/dist/v0.12.7/node-v0.12.7.tar.gz#b23d64df051c9c969b0c583f802d5d71de342e53067127a5061415be7e12f39d" warn_unsupported
+install_package "node-v0.12.7" "https://nodejs.org/dist/v0.12.7/node-v0.12.7.tar.gz#b23d64df051c9c969b0c583f802d5d71de342e53067127a5061415be7e12f39d"

--- a/share/node-build/0.12.8
+++ b/share/node-build/0.12.8
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_unsupported "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.12.8/node-v0.12.8-darwin-x64.tar.gz#857155d09d62b59c675baf4091a4e76af0972f8c99a26259a18e3ac99575697b"
 binary darwin-x86 "https://nodejs.org/dist/v0.12.8/node-v0.12.8-darwin-x86.tar.gz#2ec14c53fa69836caf79822b2de071659fadb2c105b1344371b404df398bad39"
 binary linux-x64 "https://nodejs.org/dist/v0.12.8/node-v0.12.8-linux-x64.tar.gz#99f9f8792850867a21caeaf12b1f84da9f64d0cf0ac602920facc0fc4b81e8b4"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.8/node-v0.12.8-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.12.8/node-v0.12.8-sunos-x64.tar.gz#c8ca60698f99b7dc7722b94c5b4110636d08d3a20cb3df80807bd420e2c34376"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.8/node-v0.12.8-sunos-x86.tar.gz#8d9553a684b6717f0f0f2f5dcc8ed78139db50129e1402ce6033e2494c06cfd3"
 
-install_package "node-v0.12.8" "https://nodejs.org/dist/v0.12.8/node-v0.12.8.tar.gz#e0c96a6702978e2ed7f031315bebeb86b042e2c80e66d99af8ad864dc0e56436" warn_unsupported
+install_package "node-v0.12.8" "https://nodejs.org/dist/v0.12.8/node-v0.12.8.tar.gz#e0c96a6702978e2ed7f031315bebeb86b042e2c80e66d99af8ad864dc0e56436"

--- a/share/node-build/0.12.8
+++ b/share/node-build/0.12.8
@@ -1,5 +1,5 @@
 before_install_package() {
-  build_package_warn_unsupported "$1"
+  build_package_warn_lts_maintenance "$1"
 }
 
 binary darwin-x64 "https://nodejs.org/dist/v0.12.8/node-v0.12.8-darwin-x64.tar.gz#857155d09d62b59c675baf4091a4e76af0972f8c99a26259a18e3ac99575697b"

--- a/share/node-build/0.12.9
+++ b/share/node-build/0.12.9
@@ -1,5 +1,5 @@
 before_install_package() {
-  build_package_warn_unsupported "$1"
+  build_package_warn_lts_maintenance "$1"
 }
 
 binary darwin-x64 "https://nodejs.org/dist/v0.12.9/node-v0.12.9-darwin-x64.tar.gz#8a40582c8f346f4acb08ab29bdc171db5fea55603999e02be1ebfcdd2ed3ca83"

--- a/share/node-build/0.12.9
+++ b/share/node-build/0.12.9
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_unsupported "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.12.9/node-v0.12.9-darwin-x64.tar.gz#8a40582c8f346f4acb08ab29bdc171db5fea55603999e02be1ebfcdd2ed3ca83"
 binary darwin-x86 "https://nodejs.org/dist/v0.12.9/node-v0.12.9-darwin-x86.tar.gz#a89d21abe0eaae1fd4cd4753a7ccde5bb60188148742281f1b36830bb02d50fd"
 binary linux-x64 "https://nodejs.org/dist/v0.12.9/node-v0.12.9-linux-x64.tar.gz#3416451924c9c996e1d7224f5e5507df84b90dc730d4760e3f4daac1bd4c44df"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.12.9/node-v0.12.9-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.12.9/node-v0.12.9-sunos-x64.tar.gz#460a75865d6155dc39794204214c567a239b319122caf116a60f870f0987b720"
 binary sunos-x86 "https://nodejs.org/dist/v0.12.9/node-v0.12.9-sunos-x86.tar.gz#039c710094ac76bea7027cf37daceb5708e46cac0bd082d7004c9710ad77ad1f"
 
-install_package "node-v0.12.9" "https://nodejs.org/dist/v0.12.9/node-v0.12.9.tar.gz#35daad301191e5f8dd7e5d2fbb711d081b82d1837d59837b8ee224c256cfe5e4" warn_unsupported
+install_package "node-v0.12.9" "https://nodejs.org/dist/v0.12.9/node-v0.12.9.tar.gz#35daad301191e5f8dd7e5d2fbb711d081b82d1837d59837b8ee224c256cfe5e4"

--- a/share/node-build/0.2.0
+++ b/share/node-build/0.2.0
@@ -1,1 +1,5 @@
-install_package "node-v0.2.0" "https://nodejs.org/dist/v0.2.0/node-v0.2.0.tar.gz#3d3eff9287c9917af4044f3cef99ae5b17946710a71e83039de4fcb4b0a26631" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.2.0" "https://nodejs.org/dist/v0.2.0/node-v0.2.0.tar.gz#3d3eff9287c9917af4044f3cef99ae5b17946710a71e83039de4fcb4b0a26631"

--- a/share/node-build/0.2.1
+++ b/share/node-build/0.2.1
@@ -1,1 +1,5 @@
-install_package "node-v0.2.1" "https://nodejs.org/dist/v0.2.1/node-v0.2.1.tar.gz#5bb7d084b2138ce43fcb34739ed894379c450a1dd569a1c710405bc39d2861c2" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.2.1" "https://nodejs.org/dist/v0.2.1/node-v0.2.1.tar.gz#5bb7d084b2138ce43fcb34739ed894379c450a1dd569a1c710405bc39d2861c2"

--- a/share/node-build/0.2.2
+++ b/share/node-build/0.2.2
@@ -1,1 +1,5 @@
-install_package "node-v0.2.2" "https://nodejs.org/dist/v0.2.2/node-v0.2.2.tar.gz#21dc8e18cd678f55773a2dbe309a559882bf6f3b969c9e5b39f6977fb85ee480" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.2.2" "https://nodejs.org/dist/v0.2.2/node-v0.2.2.tar.gz#21dc8e18cd678f55773a2dbe309a559882bf6f3b969c9e5b39f6977fb85ee480"

--- a/share/node-build/0.2.3
+++ b/share/node-build/0.2.3
@@ -1,1 +1,5 @@
-install_package "node-v0.2.3" "https://nodejs.org/dist/v0.2.3/node-v0.2.3.tar.gz#7358f8969b7bf6da7b066185bfa72d3bbc92e80b174ff5ea0e2b536fd357c8cf" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.2.3" "https://nodejs.org/dist/v0.2.3/node-v0.2.3.tar.gz#7358f8969b7bf6da7b066185bfa72d3bbc92e80b174ff5ea0e2b536fd357c8cf"

--- a/share/node-build/0.2.4
+++ b/share/node-build/0.2.4
@@ -1,1 +1,5 @@
-install_package "node-v0.2.4" "https://nodejs.org/dist/v0.2.4/node-v0.2.4.tar.gz#e6952007dacf18d9d85ae8ede8228e25cfe46e00be21b31c4d166239ec1fa533" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.2.4" "https://nodejs.org/dist/v0.2.4/node-v0.2.4.tar.gz#e6952007dacf18d9d85ae8ede8228e25cfe46e00be21b31c4d166239ec1fa533"

--- a/share/node-build/0.2.5
+++ b/share/node-build/0.2.5
@@ -1,1 +1,5 @@
-install_package "node-v0.2.5" "https://nodejs.org/dist/v0.2.5/node-v0.2.5.tar.gz#6c964096e2fb7bfa9108b31bdd2a920465a1b7f7a603e3937128eee9538b44bb" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.2.5" "https://nodejs.org/dist/v0.2.5/node-v0.2.5.tar.gz#6c964096e2fb7bfa9108b31bdd2a920465a1b7f7a603e3937128eee9538b44bb"

--- a/share/node-build/0.2.6
+++ b/share/node-build/0.2.6
@@ -1,1 +1,5 @@
-install_package "node-v0.2.6" "https://nodejs.org/dist/v0.2.6/node-v0.2.6.tar.gz#e97fe9c81ff4b569ae9a0d46e64a0572a1f171293573a5b5290bcc3996a19701" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.2.6" "https://nodejs.org/dist/v0.2.6/node-v0.2.6.tar.gz#e97fe9c81ff4b569ae9a0d46e64a0572a1f171293573a5b5290bcc3996a19701"

--- a/share/node-build/0.3.0
+++ b/share/node-build/0.3.0
@@ -1,1 +1,5 @@
-install_package "node-v0.3.0" "https://nodejs.org/dist/v0.3.0/node-v0.3.0.tar.gz#aa53c3d136ceaa02108ad013d9d9917e6e2ea22f10e3bd7414f4ba6f6a1427b5" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.3.0" "https://nodejs.org/dist/v0.3.0/node-v0.3.0.tar.gz#aa53c3d136ceaa02108ad013d9d9917e6e2ea22f10e3bd7414f4ba6f6a1427b5"

--- a/share/node-build/0.3.1
+++ b/share/node-build/0.3.1
@@ -1,1 +1,5 @@
-install_package "node-v0.3.1" "https://nodejs.org/dist/v0.3.1/node-v0.3.1.tar.gz#19c4c6144af143fbe37f80ec5d2843c4e19b5b6054fb10225bec314b60d2d012" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.3.1" "https://nodejs.org/dist/v0.3.1/node-v0.3.1.tar.gz#19c4c6144af143fbe37f80ec5d2843c4e19b5b6054fb10225bec314b60d2d012"

--- a/share/node-build/0.3.2
+++ b/share/node-build/0.3.2
@@ -1,1 +1,5 @@
-install_package "node-v0.3.2" "https://nodejs.org/dist/v0.3.2/node-v0.3.2.tar.gz#0cfb16b60c3c32c5fe0644108abb09e9425597a192c23844f29782b3ef7f7de2" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.3.2" "https://nodejs.org/dist/v0.3.2/node-v0.3.2.tar.gz#0cfb16b60c3c32c5fe0644108abb09e9425597a192c23844f29782b3ef7f7de2"

--- a/share/node-build/0.3.3
+++ b/share/node-build/0.3.3
@@ -1,1 +1,5 @@
-install_package "node-v0.3.3" "https://nodejs.org/dist/v0.3.3/node-v0.3.3.tar.gz#7f0dd072fbfa2dca8d873f56a4f57fdecbf4aba794b821654bec86daf3f980bc" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.3.3" "https://nodejs.org/dist/v0.3.3/node-v0.3.3.tar.gz#7f0dd072fbfa2dca8d873f56a4f57fdecbf4aba794b821654bec86daf3f980bc"

--- a/share/node-build/0.3.4
+++ b/share/node-build/0.3.4
@@ -1,1 +1,5 @@
-install_package "node-v0.3.4" "https://nodejs.org/dist/v0.3.4/node-v0.3.4.tar.gz#6980300d371ea182d719722a92706a495d19bd2efc6e1c3cdfe1c8fff74b5717" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.3.4" "https://nodejs.org/dist/v0.3.4/node-v0.3.4.tar.gz#6980300d371ea182d719722a92706a495d19bd2efc6e1c3cdfe1c8fff74b5717"

--- a/share/node-build/0.3.5
+++ b/share/node-build/0.3.5
@@ -1,1 +1,5 @@
-install_package "node-v0.3.5" "https://nodejs.org/dist/v0.3.5/node-v0.3.5.tar.gz#affdf4cbe8aaab74f99ea0a534d913a6203de353652c2fe01e1ce75707d730c7" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.3.5" "https://nodejs.org/dist/v0.3.5/node-v0.3.5.tar.gz#affdf4cbe8aaab74f99ea0a534d913a6203de353652c2fe01e1ce75707d730c7"

--- a/share/node-build/0.3.6
+++ b/share/node-build/0.3.6
@@ -1,1 +1,5 @@
-install_package "node-v0.3.6" "https://nodejs.org/dist/v0.3.6/node-v0.3.6.tar.gz#682709b86be119927015a95418a519542caadb95cbadb635ef51f7d0732fe305" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.3.6" "https://nodejs.org/dist/v0.3.6/node-v0.3.6.tar.gz#682709b86be119927015a95418a519542caadb95cbadb635ef51f7d0732fe305"

--- a/share/node-build/0.3.7
+++ b/share/node-build/0.3.7
@@ -1,1 +1,5 @@
-install_package "node-v0.3.7" "https://nodejs.org/dist/v0.3.7/node-v0.3.7.tar.gz#21c53e74684a8a3c3d14d14a49a07fa8250f0e41514b448182ef0d1f5bbba52f" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.3.7" "https://nodejs.org/dist/v0.3.7/node-v0.3.7.tar.gz#21c53e74684a8a3c3d14d14a49a07fa8250f0e41514b448182ef0d1f5bbba52f"

--- a/share/node-build/0.3.8
+++ b/share/node-build/0.3.8
@@ -1,1 +1,5 @@
-install_package "node-v0.3.8" "https://nodejs.org/dist/v0.3.8/node-v0.3.8.tar.gz#fc71861d339ec9ced9c85cb714f14e3e6e51651833ef0fec2abf41ad113172f1" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.3.8" "https://nodejs.org/dist/v0.3.8/node-v0.3.8.tar.gz#fc71861d339ec9ced9c85cb714f14e3e6e51651833ef0fec2abf41ad113172f1"

--- a/share/node-build/0.4.0
+++ b/share/node-build/0.4.0
@@ -1,1 +1,5 @@
-install_package "node-v0.4.0" "https://nodejs.org/dist/v0.4.0/node-v0.4.0.tar.gz#4a30bd9963373cb86a994479bdd451ab3b6f2124f0089493366315da79d3408e" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.4.0" "https://nodejs.org/dist/v0.4.0/node-v0.4.0.tar.gz#4a30bd9963373cb86a994479bdd451ab3b6f2124f0089493366315da79d3408e"

--- a/share/node-build/0.4.1
+++ b/share/node-build/0.4.1
@@ -1,1 +1,5 @@
-install_package "node-v0.4.1" "https://nodejs.org/dist/v0.4.1/node-v0.4.1.tar.gz#fdd61c479a0c9f30102454ee53d2ba0c5fc9f6d06d1073958ae2fd3fc314de23" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.4.1" "https://nodejs.org/dist/v0.4.1/node-v0.4.1.tar.gz#fdd61c479a0c9f30102454ee53d2ba0c5fc9f6d06d1073958ae2fd3fc314de23"

--- a/share/node-build/0.4.10
+++ b/share/node-build/0.4.10
@@ -1,1 +1,5 @@
-install_package "node-v0.4.10" "https://nodejs.org/dist/v0.4.10/node-v0.4.10.tar.gz#57fa7ed5a818308ff485bb1c1a8ec8f1eb6a7800e14201dff65d88ce657da50a" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.4.10" "https://nodejs.org/dist/v0.4.10/node-v0.4.10.tar.gz#57fa7ed5a818308ff485bb1c1a8ec8f1eb6a7800e14201dff65d88ce657da50a"

--- a/share/node-build/0.4.11
+++ b/share/node-build/0.4.11
@@ -1,1 +1,5 @@
-install_package "node-v0.4.11" "https://nodejs.org/dist/v0.4.11/node-v0.4.11.tar.gz#e009522d52c4a844c46e51c63b852899d1b7e6d949d1a139cdc16b4f6c4ab63f" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.4.11" "https://nodejs.org/dist/v0.4.11/node-v0.4.11.tar.gz#e009522d52c4a844c46e51c63b852899d1b7e6d949d1a139cdc16b4f6c4ab63f"

--- a/share/node-build/0.4.12
+++ b/share/node-build/0.4.12
@@ -1,1 +1,5 @@
-install_package "node-v0.4.12" "https://nodejs.org/dist/v0.4.12/node-v0.4.12.tar.gz#c01af05b933ad4d2ca39f63cac057f54f032a4d83cff8711e42650ccee24fce4" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.4.12" "https://nodejs.org/dist/v0.4.12/node-v0.4.12.tar.gz#c01af05b933ad4d2ca39f63cac057f54f032a4d83cff8711e42650ccee24fce4"

--- a/share/node-build/0.4.2
+++ b/share/node-build/0.4.2
@@ -1,1 +1,5 @@
-install_package "node-v0.4.2" "https://nodejs.org/dist/v0.4.2/node-v0.4.2.tar.gz#09b1100ca6828eedbe52418fbeb3352d71c0b1ff3344c44a5af3efb80c5b908c" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.4.2" "https://nodejs.org/dist/v0.4.2/node-v0.4.2.tar.gz#09b1100ca6828eedbe52418fbeb3352d71c0b1ff3344c44a5af3efb80c5b908c"

--- a/share/node-build/0.4.3
+++ b/share/node-build/0.4.3
@@ -1,1 +1,5 @@
-install_package "node-v0.4.3" "https://nodejs.org/dist/v0.4.3/node-v0.4.3.tar.gz#945cd6743336933bdd1843c28e6d4c896483c8ffc899555079c1eca7a69bd81c" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.4.3" "https://nodejs.org/dist/v0.4.3/node-v0.4.3.tar.gz#945cd6743336933bdd1843c28e6d4c896483c8ffc899555079c1eca7a69bd81c"

--- a/share/node-build/0.4.4
+++ b/share/node-build/0.4.4
@@ -1,1 +1,5 @@
-install_package "node-v0.4.4" "https://nodejs.org/dist/v0.4.4/node-v0.4.4.tar.gz#ea4430909601340cb3e8adb15569facfeca4e1d59129f1932254535bb4bf3e17" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.4.4" "https://nodejs.org/dist/v0.4.4/node-v0.4.4.tar.gz#ea4430909601340cb3e8adb15569facfeca4e1d59129f1932254535bb4bf3e17"

--- a/share/node-build/0.4.5
+++ b/share/node-build/0.4.5
@@ -1,1 +1,5 @@
-install_package "node-v0.4.5" "https://nodejs.org/dist/v0.4.5/node-v0.4.5.tar.gz#63fa6acd7dbf1ea816dc5fd64ba4d066f85380396571d29934b8b9141dc2a0ee" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.4.5" "https://nodejs.org/dist/v0.4.5/node-v0.4.5.tar.gz#63fa6acd7dbf1ea816dc5fd64ba4d066f85380396571d29934b8b9141dc2a0ee"

--- a/share/node-build/0.4.6
+++ b/share/node-build/0.4.6
@@ -1,1 +1,5 @@
-install_package "node-v0.4.6" "https://nodejs.org/dist/v0.4.6/node-v0.4.6.tar.gz#0f07823f1eb32a51351739763a73a66e2b8c80ed6e3e787a1f68eec255b481f6" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.4.6" "https://nodejs.org/dist/v0.4.6/node-v0.4.6.tar.gz#0f07823f1eb32a51351739763a73a66e2b8c80ed6e3e787a1f68eec255b481f6"

--- a/share/node-build/0.4.7
+++ b/share/node-build/0.4.7
@@ -1,1 +1,5 @@
-install_package "node-v0.4.7" "https://nodejs.org/dist/v0.4.7/node-v0.4.7.tar.gz#5c405ff85549ebff49ee06d4e4391f02ed65b2b1177dc0f617f727ab48593dee" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.4.7" "https://nodejs.org/dist/v0.4.7/node-v0.4.7.tar.gz#5c405ff85549ebff49ee06d4e4391f02ed65b2b1177dc0f617f727ab48593dee"

--- a/share/node-build/0.4.8
+++ b/share/node-build/0.4.8
@@ -1,1 +1,5 @@
-install_package "node-v0.4.8" "https://nodejs.org/dist/v0.4.8/node-v0.4.8.tar.gz#c72a0136a022581e9ca5d26fd4a9af277525204547bcf06276dbe6b66e1fa112" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.4.8" "https://nodejs.org/dist/v0.4.8/node-v0.4.8.tar.gz#c72a0136a022581e9ca5d26fd4a9af277525204547bcf06276dbe6b66e1fa112"

--- a/share/node-build/0.4.9
+++ b/share/node-build/0.4.9
@@ -1,1 +1,5 @@
-install_package "node-v0.4.9" "https://nodejs.org/dist/v0.4.9/node-v0.4.9.tar.gz#f231ea6d19ea9ea4c7f8e7ff5061e7d301f1635bec7ed0ff1eef2512576ea442" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.4.9" "https://nodejs.org/dist/v0.4.9/node-v0.4.9.tar.gz#f231ea6d19ea9ea4c7f8e7ff5061e7d301f1635bec7ed0ff1eef2512576ea442"

--- a/share/node-build/0.5.0
+++ b/share/node-build/0.5.0
@@ -1,1 +1,5 @@
-install_package "node-v0.5.0" "https://nodejs.org/dist/v0.5.0/node-v0.5.0.tar.gz#ac7e786f69343654dff091e1d5a85ee001f48b7b0fe145c0a0e14040b82978b9" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.5.0" "https://nodejs.org/dist/v0.5.0/node-v0.5.0.tar.gz#ac7e786f69343654dff091e1d5a85ee001f48b7b0fe145c0a0e14040b82978b9"

--- a/share/node-build/0.5.1
+++ b/share/node-build/0.5.1
@@ -1,1 +1,5 @@
-install_package "node-v0.5.1" "https://nodejs.org/dist/v0.5.1/node-v0.5.1.tar.gz#a788469bbfd52ba56f1fa76ff28f796aff8aec9ce1cd92aca62853e72d187839" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.5.1" "https://nodejs.org/dist/v0.5.1/node-v0.5.1.tar.gz#a788469bbfd52ba56f1fa76ff28f796aff8aec9ce1cd92aca62853e72d187839"

--- a/share/node-build/0.5.10
+++ b/share/node-build/0.5.10
@@ -1,1 +1,5 @@
-install_package "node-v0.5.10" "https://nodejs.org/dist/v0.5.10/node-v0.5.10.tar.gz#56396854f85a0d2fafc038436be3d84041f991f59613761e61295fc02d662a40" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.5.10" "https://nodejs.org/dist/v0.5.10/node-v0.5.10.tar.gz#56396854f85a0d2fafc038436be3d84041f991f59613761e61295fc02d662a40"

--- a/share/node-build/0.5.2
+++ b/share/node-build/0.5.2
@@ -1,1 +1,5 @@
-install_package "node-v0.5.2" "https://nodejs.org/dist/v0.5.2/node-v0.5.2.tar.gz#198f9109bf22a9f8d88cf0b696bd36fc897dfa6b655f30102d7cc55bf033e19b" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.5.2" "https://nodejs.org/dist/v0.5.2/node-v0.5.2.tar.gz#198f9109bf22a9f8d88cf0b696bd36fc897dfa6b655f30102d7cc55bf033e19b"

--- a/share/node-build/0.5.3
+++ b/share/node-build/0.5.3
@@ -1,1 +1,5 @@
-install_package "node-v0.5.3" "https://nodejs.org/dist/v0.5.3/node-v0.5.3.tar.gz#27e5a488040e59e192b3db6675c5f0b6b00cccdd53f1a7cdf98b6477220fbb1e" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.5.3" "https://nodejs.org/dist/v0.5.3/node-v0.5.3.tar.gz#27e5a488040e59e192b3db6675c5f0b6b00cccdd53f1a7cdf98b6477220fbb1e"

--- a/share/node-build/0.5.4
+++ b/share/node-build/0.5.4
@@ -1,1 +1,5 @@
-install_package "node-v0.5.4" "https://nodejs.org/dist/v0.5.4/node-v0.5.4.tar.gz#d32d3af4e3286b383640df857d76c2fcca1a2e2cb85abb484483a0a49d09ae71" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.5.4" "https://nodejs.org/dist/v0.5.4/node-v0.5.4.tar.gz#d32d3af4e3286b383640df857d76c2fcca1a2e2cb85abb484483a0a49d09ae71"

--- a/share/node-build/0.5.5
+++ b/share/node-build/0.5.5
@@ -1,1 +1,5 @@
-install_package "node-v0.5.5" "https://nodejs.org/dist/v0.5.5/node-v0.5.5.tar.gz#6f7ef8859e43545ff9a0e178e39a070f22c6a2abcf46b2cae079f446b5750e65" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.5.5" "https://nodejs.org/dist/v0.5.5/node-v0.5.5.tar.gz#6f7ef8859e43545ff9a0e178e39a070f22c6a2abcf46b2cae079f446b5750e65"

--- a/share/node-build/0.5.6
+++ b/share/node-build/0.5.6
@@ -1,1 +1,5 @@
-install_package "node-v0.5.6" "https://nodejs.org/dist/v0.5.6/node-v0.5.6.tar.gz#f9745ab3b19be29d3ddf40c40cec6d4c4685ae94d9943389d6b67178f11ecd9b" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.5.6" "https://nodejs.org/dist/v0.5.6/node-v0.5.6.tar.gz#f9745ab3b19be29d3ddf40c40cec6d4c4685ae94d9943389d6b67178f11ecd9b"

--- a/share/node-build/0.5.7
+++ b/share/node-build/0.5.7
@@ -1,1 +1,5 @@
-install_package "node-v0.5.7" "https://nodejs.org/dist/v0.5.7/node-v0.5.7.tar.gz#bd5c1f8029517bd8070001e3099a2330bcea696fcf1855b6c857b6fb58e676c6" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.5.7" "https://nodejs.org/dist/v0.5.7/node-v0.5.7.tar.gz#bd5c1f8029517bd8070001e3099a2330bcea696fcf1855b6c857b6fb58e676c6"

--- a/share/node-build/0.5.8
+++ b/share/node-build/0.5.8
@@ -1,1 +1,5 @@
-install_package "node-v0.5.8" "https://nodejs.org/dist/v0.5.8/node-v0.5.8.tar.gz#e15214605c473d14cf73ebac4df1c8ff54d88f405b20b473bda719728e217fd2" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.5.8" "https://nodejs.org/dist/v0.5.8/node-v0.5.8.tar.gz#e15214605c473d14cf73ebac4df1c8ff54d88f405b20b473bda719728e217fd2"

--- a/share/node-build/0.5.9
+++ b/share/node-build/0.5.9
@@ -1,1 +1,5 @@
-install_package "node-v0.5.9" "https://nodejs.org/dist/v0.5.9/node-v0.5.9.tar.gz#5659cde8b36cf5c29433e73a351b0bacfac16be1b0b47e64ea138fe270b5607f" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.5.9" "https://nodejs.org/dist/v0.5.9/node-v0.5.9.tar.gz#5659cde8b36cf5c29433e73a351b0bacfac16be1b0b47e64ea138fe270b5607f"

--- a/share/node-build/0.6.0
+++ b/share/node-build/0.6.0
@@ -1,1 +1,5 @@
-install_package "node-v0.6.0" "https://nodejs.org/dist/v0.6.0/node-v0.6.0.tar.gz#1b6a34b6f2099145c44a0c20d3a5cab7c9ec063de1a195ddeda61ad55d601d7f" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.6.0" "https://nodejs.org/dist/v0.6.0/node-v0.6.0.tar.gz#1b6a34b6f2099145c44a0c20d3a5cab7c9ec063de1a195ddeda61ad55d601d7f"

--- a/share/node-build/0.6.1
+++ b/share/node-build/0.6.1
@@ -1,1 +1,5 @@
-install_package "node-v0.6.1" "https://nodejs.org/dist/v0.6.1/node-v0.6.1.tar.gz#b161050ed8cdb2d45f601181d146821e5535a8fcbf5978b2ff064e5476a8e606" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.6.1" "https://nodejs.org/dist/v0.6.1/node-v0.6.1.tar.gz#b161050ed8cdb2d45f601181d146821e5535a8fcbf5978b2ff064e5476a8e606"

--- a/share/node-build/0.6.10
+++ b/share/node-build/0.6.10
@@ -1,1 +1,5 @@
-install_package "node-v0.6.10" "https://nodejs.org/dist/v0.6.10/node-v0.6.10.tar.gz#d1d060ab53c6079409403530009a2095036f19920aabd3a1c20542e0db586bd5" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.6.10" "https://nodejs.org/dist/v0.6.10/node-v0.6.10.tar.gz#d1d060ab53c6079409403530009a2095036f19920aabd3a1c20542e0db586bd5"

--- a/share/node-build/0.6.11
+++ b/share/node-build/0.6.11
@@ -1,1 +1,5 @@
-install_package "node-v0.6.11" "https://nodejs.org/dist/v0.6.11/node-v0.6.11.tar.gz#94bbdb2d62645fd2ad5b96e41cfec68abf004fd03fabaaf7d71c48b39013cbd1" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.6.11" "https://nodejs.org/dist/v0.6.11/node-v0.6.11.tar.gz#94bbdb2d62645fd2ad5b96e41cfec68abf004fd03fabaaf7d71c48b39013cbd1"

--- a/share/node-build/0.6.12
+++ b/share/node-build/0.6.12
@@ -1,1 +1,5 @@
-install_package "node-v0.6.12" "https://nodejs.org/dist/v0.6.12/node-v0.6.12.tar.gz#a16392fb83b288bd40cb64593253756a44f8111478edf5e8cc439a64622281c4" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.6.12" "https://nodejs.org/dist/v0.6.12/node-v0.6.12.tar.gz#a16392fb83b288bd40cb64593253756a44f8111478edf5e8cc439a64622281c4"

--- a/share/node-build/0.6.13
+++ b/share/node-build/0.6.13
@@ -1,1 +1,5 @@
-install_package "node-v0.6.13" "https://nodejs.org/dist/v0.6.13/node-v0.6.13.tar.gz#fc4f3ceacfd2cfc4ec75fc59d97f1f2d04947efd5e191efaddeb552df486245b" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.6.13" "https://nodejs.org/dist/v0.6.13/node-v0.6.13.tar.gz#fc4f3ceacfd2cfc4ec75fc59d97f1f2d04947efd5e191efaddeb552df486245b"

--- a/share/node-build/0.6.14
+++ b/share/node-build/0.6.14
@@ -1,1 +1,5 @@
-install_package "node-v0.6.14" "https://nodejs.org/dist/v0.6.14/node-v0.6.14.tar.gz#e41922308155c5197c2d048948ca9cd76ea5f9a51f977e1591bd93fe17d4cf1f" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.6.14" "https://nodejs.org/dist/v0.6.14/node-v0.6.14.tar.gz#e41922308155c5197c2d048948ca9cd76ea5f9a51f977e1591bd93fe17d4cf1f"

--- a/share/node-build/0.6.15
+++ b/share/node-build/0.6.15
@@ -1,1 +1,5 @@
-install_package "node-v0.6.15" "https://nodejs.org/dist/v0.6.15/node-v0.6.15.tar.gz#78859a1a31c8e7a64d0efa040326d93c6624cc344d39b2e47e14e9c4dc3136e0" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.6.15" "https://nodejs.org/dist/v0.6.15/node-v0.6.15.tar.gz#78859a1a31c8e7a64d0efa040326d93c6624cc344d39b2e47e14e9c4dc3136e0"

--- a/share/node-build/0.6.16
+++ b/share/node-build/0.6.16
@@ -1,1 +1,5 @@
-install_package "node-v0.6.16" "https://nodejs.org/dist/v0.6.16/node-v0.6.16.tar.gz#21d9cccaa642794db69619d813adf00b3533080a8928370c2b1a4b3a6478eaa7" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.6.16" "https://nodejs.org/dist/v0.6.16/node-v0.6.16.tar.gz#21d9cccaa642794db69619d813adf00b3533080a8928370c2b1a4b3a6478eaa7"

--- a/share/node-build/0.6.17
+++ b/share/node-build/0.6.17
@@ -1,1 +1,5 @@
-install_package "node-v0.6.17" "https://nodejs.org/dist/v0.6.17/node-v0.6.17.tar.gz#8dfe5948de27e37a14af184f06e7bd89a23c3b248af44c8ef5cffcd0e4c65778" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.6.17" "https://nodejs.org/dist/v0.6.17/node-v0.6.17.tar.gz#8dfe5948de27e37a14af184f06e7bd89a23c3b248af44c8ef5cffcd0e4c65778"

--- a/share/node-build/0.6.18
+++ b/share/node-build/0.6.18
@@ -1,1 +1,5 @@
-install_package "node-v0.6.18" "https://nodejs.org/dist/v0.6.18/node-v0.6.18.tar.gz#6cf4311ecbc1700e88f4382a31b3a7017c1572cd641fd06e653fc1692c2cffff" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.6.18" "https://nodejs.org/dist/v0.6.18/node-v0.6.18.tar.gz#6cf4311ecbc1700e88f4382a31b3a7017c1572cd641fd06e653fc1692c2cffff"

--- a/share/node-build/0.6.19
+++ b/share/node-build/0.6.19
@@ -1,1 +1,5 @@
-install_package "node-v0.6.19" "https://nodejs.org/dist/v0.6.19/node-v0.6.19.tar.gz#4e33292477b01dfcf50bc628d580fd5af3e5ff807490ec46472b84100fb52fbb" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.6.19" "https://nodejs.org/dist/v0.6.19/node-v0.6.19.tar.gz#4e33292477b01dfcf50bc628d580fd5af3e5ff807490ec46472b84100fb52fbb"

--- a/share/node-build/0.6.2
+++ b/share/node-build/0.6.2
@@ -1,1 +1,5 @@
-install_package "node-v0.6.2" "https://nodejs.org/dist/v0.6.2/node-v0.6.2.tar.gz#3a24f6f91bb806a230a7b200ca638459a9680ea2daf9a427098c61f847016139" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.6.2" "https://nodejs.org/dist/v0.6.2/node-v0.6.2.tar.gz#3a24f6f91bb806a230a7b200ca638459a9680ea2daf9a427098c61f847016139"

--- a/share/node-build/0.6.20
+++ b/share/node-build/0.6.20
@@ -1,1 +1,5 @@
-install_package "node-v0.6.20" "https://nodejs.org/dist/v0.6.20/node-v0.6.20.tar.gz#b7bf4cf143ddf46ba5e975761b98a38dd3d72b176fd5d4bb2f9c9e7bbe6c4b15" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.6.20" "https://nodejs.org/dist/v0.6.20/node-v0.6.20.tar.gz#b7bf4cf143ddf46ba5e975761b98a38dd3d72b176fd5d4bb2f9c9e7bbe6c4b15"

--- a/share/node-build/0.6.21
+++ b/share/node-build/0.6.21
@@ -1,1 +1,5 @@
-install_package "node-v0.6.21" "https://nodejs.org/dist/v0.6.21/node-v0.6.21.tar.gz#22265fd07e09c22f1d058156d548e7398c9740210f534e2f848eeab5b9772117" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.6.21" "https://nodejs.org/dist/v0.6.21/node-v0.6.21.tar.gz#22265fd07e09c22f1d058156d548e7398c9740210f534e2f848eeab5b9772117"

--- a/share/node-build/0.6.3
+++ b/share/node-build/0.6.3
@@ -1,1 +1,5 @@
-install_package "node-v0.6.3" "https://nodejs.org/dist/v0.6.3/node-v0.6.3.tar.gz#fe5642d26d04cc7e7d47daa426da2a79e244bdcbae1594a12578f0d6fe03082e" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.6.3" "https://nodejs.org/dist/v0.6.3/node-v0.6.3.tar.gz#fe5642d26d04cc7e7d47daa426da2a79e244bdcbae1594a12578f0d6fe03082e"

--- a/share/node-build/0.6.4
+++ b/share/node-build/0.6.4
@@ -1,1 +1,5 @@
-install_package "node-v0.6.4" "https://nodejs.org/dist/v0.6.4/node-v0.6.4.tar.gz#67b029f0da10ffa706cda23d6a3bb7c682ca589cd7f6647a578dcfb74a78f916" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.6.4" "https://nodejs.org/dist/v0.6.4/node-v0.6.4.tar.gz#67b029f0da10ffa706cda23d6a3bb7c682ca589cd7f6647a578dcfb74a78f916"

--- a/share/node-build/0.6.5
+++ b/share/node-build/0.6.5
@@ -1,1 +1,5 @@
-install_package "node-v0.6.5" "https://nodejs.org/dist/v0.6.5/node-v0.6.5.tar.gz#72364d240fb61e678897c099df6f2913857c5931aa9b1f44e73e432d4629ca2f" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.6.5" "https://nodejs.org/dist/v0.6.5/node-v0.6.5.tar.gz#72364d240fb61e678897c099df6f2913857c5931aa9b1f44e73e432d4629ca2f"

--- a/share/node-build/0.6.6
+++ b/share/node-build/0.6.6
@@ -1,1 +1,5 @@
-install_package "node-v0.6.6" "https://nodejs.org/dist/v0.6.6/node-v0.6.6.tar.gz#7abea518b1b63fd669c9ca436bf33d0bb0b09b252f06d700ccbd290fe5222102" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.6.6" "https://nodejs.org/dist/v0.6.6/node-v0.6.6.tar.gz#7abea518b1b63fd669c9ca436bf33d0bb0b09b252f06d700ccbd290fe5222102"

--- a/share/node-build/0.6.7
+++ b/share/node-build/0.6.7
@@ -1,1 +1,5 @@
-install_package "node-v0.6.7" "https://nodejs.org/dist/v0.6.7/node-v0.6.7.tar.gz#b34387449723352d2f5b7a51d8c1358c247908a5f7acd7849cac45f980246d54" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.6.7" "https://nodejs.org/dist/v0.6.7/node-v0.6.7.tar.gz#b34387449723352d2f5b7a51d8c1358c247908a5f7acd7849cac45f980246d54"

--- a/share/node-build/0.6.8
+++ b/share/node-build/0.6.8
@@ -1,1 +1,5 @@
-install_package "node-v0.6.8" "https://nodejs.org/dist/v0.6.8/node-v0.6.8.tar.gz#e6cbfc5ccdbe10128dbbd4dc7a88c154d80f8a39c3a8477092cf7d25eef78c9c" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.6.8" "https://nodejs.org/dist/v0.6.8/node-v0.6.8.tar.gz#e6cbfc5ccdbe10128dbbd4dc7a88c154d80f8a39c3a8477092cf7d25eef78c9c"

--- a/share/node-build/0.6.9
+++ b/share/node-build/0.6.9
@@ -1,1 +1,5 @@
-install_package "node-v0.6.9" "https://nodejs.org/dist/v0.6.9/node-v0.6.9.tar.gz#484ab6b3da6195339544c16aff17f747aa85d1dd15d765d6724aa8a4ecda03ca" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.6.9" "https://nodejs.org/dist/v0.6.9/node-v0.6.9.tar.gz#484ab6b3da6195339544c16aff17f747aa85d1dd15d765d6724aa8a4ecda03ca"

--- a/share/node-build/0.7.0
+++ b/share/node-build/0.7.0
@@ -1,1 +1,5 @@
-install_package "node-v0.7.0" "https://nodejs.org/dist/v0.7.0/node-v0.7.0.tar.gz#0c716d7c61f77c53b0383e82da3f3ca8a4187f7d1c9831aec95efe7cfda9cafb" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.7.0" "https://nodejs.org/dist/v0.7.0/node-v0.7.0.tar.gz#0c716d7c61f77c53b0383e82da3f3ca8a4187f7d1c9831aec95efe7cfda9cafb"

--- a/share/node-build/0.7.1
+++ b/share/node-build/0.7.1
@@ -1,1 +1,5 @@
-install_package "node-v0.7.1" "https://nodejs.org/dist/v0.7.1/node-v0.7.1.tar.gz#903224a2c9e4510b2281d0fa72cbd930b6dfb97a750e6d02bd12442a5aa30032" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.7.1" "https://nodejs.org/dist/v0.7.1/node-v0.7.1.tar.gz#903224a2c9e4510b2281d0fa72cbd930b6dfb97a750e6d02bd12442a5aa30032"

--- a/share/node-build/0.7.10
+++ b/share/node-build/0.7.10
@@ -1,1 +1,5 @@
-install_package "node-v0.7.10" "https://nodejs.org/dist/v0.7.10/node-v0.7.10.tar.gz#9094dcd47dba984b6c2ca89a5361bd6664d1990edf41419f9a8a6d26ae774c6e" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.7.10" "https://nodejs.org/dist/v0.7.10/node-v0.7.10.tar.gz#9094dcd47dba984b6c2ca89a5361bd6664d1990edf41419f9a8a6d26ae774c6e"

--- a/share/node-build/0.7.11
+++ b/share/node-build/0.7.11
@@ -1,1 +1,5 @@
-install_package "node-v0.7.11" "https://nodejs.org/dist/v0.7.11/node-v0.7.11.tar.gz#add0db06f628ed8330b1a3450efa39f18d08c5a54d5827004c76ae23522ca842" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.7.11" "https://nodejs.org/dist/v0.7.11/node-v0.7.11.tar.gz#add0db06f628ed8330b1a3450efa39f18d08c5a54d5827004c76ae23522ca842"

--- a/share/node-build/0.7.12
+++ b/share/node-build/0.7.12
@@ -1,1 +1,5 @@
-install_package "node-v0.7.12" "https://nodejs.org/dist/v0.7.12/node-v0.7.12.tar.gz#e0be9f001467e2a9e728d53969a3c7f079da4af1ff896155822479ad92b3efbe" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.7.12" "https://nodejs.org/dist/v0.7.12/node-v0.7.12.tar.gz#e0be9f001467e2a9e728d53969a3c7f079da4af1ff896155822479ad92b3efbe"

--- a/share/node-build/0.7.2
+++ b/share/node-build/0.7.2
@@ -1,1 +1,5 @@
-install_package "node-v0.7.2" "https://nodejs.org/dist/v0.7.2/node-v0.7.2.tar.gz#de0bff9067f4cd63c4bd5fb847352725b86122eac7483aa88b764eb8272807a3" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.7.2" "https://nodejs.org/dist/v0.7.2/node-v0.7.2.tar.gz#de0bff9067f4cd63c4bd5fb847352725b86122eac7483aa88b764eb8272807a3"

--- a/share/node-build/0.7.3
+++ b/share/node-build/0.7.3
@@ -1,1 +1,5 @@
-install_package "node-v0.7.3" "https://nodejs.org/dist/v0.7.3/node-v0.7.3.tar.gz#292204f73b4007fecf7aa9d065a0360abc43a1fc007ea1138cf4fa8d553cca58" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.7.3" "https://nodejs.org/dist/v0.7.3/node-v0.7.3.tar.gz#292204f73b4007fecf7aa9d065a0360abc43a1fc007ea1138cf4fa8d553cca58"

--- a/share/node-build/0.7.4
+++ b/share/node-build/0.7.4
@@ -1,1 +1,5 @@
-install_package "node-v0.7.4" "https://nodejs.org/dist/v0.7.4/node-v0.7.4.tar.gz#14bd37525dab52d28271211002fe102ebbcc9afa01064f93d9945d66e3989660" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.7.4" "https://nodejs.org/dist/v0.7.4/node-v0.7.4.tar.gz#14bd37525dab52d28271211002fe102ebbcc9afa01064f93d9945d66e3989660"

--- a/share/node-build/0.7.5
+++ b/share/node-build/0.7.5
@@ -1,1 +1,5 @@
-install_package "node-v0.7.5" "https://nodejs.org/dist/v0.7.5/node-v0.7.5.tar.gz#f855ba273ea8d4b036f811008dc205e0070358584185dbc79abd09ffcb99d12b" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.7.5" "https://nodejs.org/dist/v0.7.5/node-v0.7.5.tar.gz#f855ba273ea8d4b036f811008dc205e0070358584185dbc79abd09ffcb99d12b"

--- a/share/node-build/0.7.6
+++ b/share/node-build/0.7.6
@@ -1,1 +1,5 @@
-install_package "node-v0.7.6" "https://nodejs.org/dist/v0.7.6/node-v0.7.6.tar.gz#ce1772b7b649121a04dbb36c94e4e4d8850a109d07746cff6bab5c4d1ed38e1c" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.7.6" "https://nodejs.org/dist/v0.7.6/node-v0.7.6.tar.gz#ce1772b7b649121a04dbb36c94e4e4d8850a109d07746cff6bab5c4d1ed38e1c"

--- a/share/node-build/0.7.7
+++ b/share/node-build/0.7.7
@@ -1,1 +1,5 @@
-install_package "node-v0.7.7" "https://nodejs.org/dist/v0.7.7/node-v0.7.7.tar.gz#40d67cdaba5fdef522fc49e31220ffc3278c90cb5ca1dc5dbb6e43cbc938f8d1" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.7.7" "https://nodejs.org/dist/v0.7.7/node-v0.7.7.tar.gz#40d67cdaba5fdef522fc49e31220ffc3278c90cb5ca1dc5dbb6e43cbc938f8d1"

--- a/share/node-build/0.7.8
+++ b/share/node-build/0.7.8
@@ -1,1 +1,5 @@
-install_package "node-v0.7.8" "https://nodejs.org/dist/v0.7.8/node-v0.7.8.tar.gz#59722d4a71c26963a8bbd31aadc64aeff2c0a2902fb4d9542d161f458487355e" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.7.8" "https://nodejs.org/dist/v0.7.8/node-v0.7.8.tar.gz#59722d4a71c26963a8bbd31aadc64aeff2c0a2902fb4d9542d161f458487355e"

--- a/share/node-build/0.7.9
+++ b/share/node-build/0.7.9
@@ -1,1 +1,5 @@
-install_package "node-v0.7.9" "https://nodejs.org/dist/v0.7.9/node-v0.7.9.tar.gz#0a94de8743420c0a664b3bc9bec876098e4035b5079a4b2b4e3e3dc1acc9f926" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.7.9" "https://nodejs.org/dist/v0.7.9/node-v0.7.9.tar.gz#0a94de8743420c0a664b3bc9bec876098e4035b5079a4b2b4e3e3dc1acc9f926"

--- a/share/node-build/0.8.0
+++ b/share/node-build/0.8.0
@@ -1,1 +1,5 @@
-install_package "node-v0.8.0" "https://nodejs.org/dist/v0.8.0/node-v0.8.0.tar.gz#ecafca018b5109a28537633d0433d513f68b1bae7191a1821e8eaa84ccf128ee" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.8.0" "https://nodejs.org/dist/v0.8.0/node-v0.8.0.tar.gz#ecafca018b5109a28537633d0433d513f68b1bae7191a1821e8eaa84ccf128ee"

--- a/share/node-build/0.8.1
+++ b/share/node-build/0.8.1
@@ -1,1 +1,5 @@
-install_package "node-v0.8.1" "https://nodejs.org/dist/v0.8.1/node-v0.8.1.tar.gz#0cda1325a010ce18f68501ae68e0ce97f0094e7a282c34a451f552621643a884" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.8.1" "https://nodejs.org/dist/v0.8.1/node-v0.8.1.tar.gz#0cda1325a010ce18f68501ae68e0ce97f0094e7a282c34a451f552621643a884"

--- a/share/node-build/0.8.10
+++ b/share/node-build/0.8.10
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.8.10/node-v0.8.10-darwin-x64.tar.gz#3b347b17f295ef4683278c589eed695db3544d2fba4d5969d0700173153da336"
 binary darwin-x86 "https://nodejs.org/dist/v0.8.10/node-v0.8.10-darwin-x86.tar.gz#0059d0ad27725a7c3f9b413fdb5fd09dfc7b7879f42025977504849d3c9e2ab5"
 binary linux-x64 "https://nodejs.org/dist/v0.8.10/node-v0.8.10-linux-x64.tar.gz#536b88491d8d5db046897a4024209b076be1c25dbf92474b85f8b854812c2c21"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.10/node-v0.8.10-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.10/node-v0.8.10-sunos-x64.tar.gz#15d6adf4d457a820ef62d07e52a00b42d8ce23a59cc55a54a3cc564e86f5c56a"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.10/node-v0.8.10-sunos-x86.tar.gz#1efe7482197330c59067a9646d67c0af3fa638ccec32cd3d3c71ecc6729511f2"
 
-install_package "node-v0.8.10" "https://nodejs.org/dist/v0.8.10/node-v0.8.10.tar.gz#ce495ab8fee58b4df49d46be2b08fabdd2fcb3880982aedda8e88751e2a2011b" warn_eol
+install_package "node-v0.8.10" "https://nodejs.org/dist/v0.8.10/node-v0.8.10.tar.gz#ce495ab8fee58b4df49d46be2b08fabdd2fcb3880982aedda8e88751e2a2011b"

--- a/share/node-build/0.8.11
+++ b/share/node-build/0.8.11
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.8.11/node-v0.8.11-darwin-x64.tar.gz#7199b8260f3b02c362b7a347a27d9527c9fac37f4ca5d6c5e1d3c2ebd4d271c7"
 binary darwin-x86 "https://nodejs.org/dist/v0.8.11/node-v0.8.11-darwin-x86.tar.gz#7c857174ba99de693c8134055cb9d675c6953e31af2cd4380615ada6ebb4519d"
 binary linux-x64 "https://nodejs.org/dist/v0.8.11/node-v0.8.11-linux-x64.tar.gz#8586d1e89977567c5c3d75a974409a2453a5fc9f26f8ea634016dee255595347"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.11/node-v0.8.11-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.11/node-v0.8.11-sunos-x64.tar.gz#9633b53df777c6b5a41dc3e6c106c51f20fbe151c793d82c80c93ca17ccc6975"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.11/node-v0.8.11-sunos-x86.tar.gz#038d1b1774bdd9c260c5967380bd89df3145a7aeb190effd681ae2091f9e1676"
 
-install_package "node-v0.8.11" "https://nodejs.org/dist/v0.8.11/node-v0.8.11.tar.gz#e9594460f992b5862e21fb4d8ef27907839254c646b4ed5e8ab1ec25b4ccd29d" warn_eol
+install_package "node-v0.8.11" "https://nodejs.org/dist/v0.8.11/node-v0.8.11.tar.gz#e9594460f992b5862e21fb4d8ef27907839254c646b4ed5e8ab1ec25b4ccd29d"

--- a/share/node-build/0.8.12
+++ b/share/node-build/0.8.12
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.8.12/node-v0.8.12-darwin-x64.tar.gz#05836e0924b67713e0306f710adca8ce0fbf1941dd959a354f000b8d3bb039f6"
 binary darwin-x86 "https://nodejs.org/dist/v0.8.12/node-v0.8.12-darwin-x86.tar.gz#63807554c451e07fb07496bd9539bf7c67b7d082e52b12a4209f02b015c786d0"
 binary linux-x64 "https://nodejs.org/dist/v0.8.12/node-v0.8.12-linux-x64.tar.gz#7a5437d5c088f1b787444b2ac049add8fd11f21f0486819491ac1b3965d6f288"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.12/node-v0.8.12-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.12/node-v0.8.12-sunos-x64.tar.gz#94f9cc5425094f2103f1324e3dbe6d277bdc0dab1171a4be4f90466958df324e"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.12/node-v0.8.12-sunos-x86.tar.gz#f2b5e658fbcd5df94d36b75b9b8fb8c1929adb4a79015ebcdab7e1e494da7264"
 
-install_package "node-v0.8.12" "https://nodejs.org/dist/v0.8.12/node-v0.8.12.tar.gz#d64a7f2ab8f4419a11bde5379d6065666fd1cc4593ec828cb5ac57385efafa45" warn_eol
+install_package "node-v0.8.12" "https://nodejs.org/dist/v0.8.12/node-v0.8.12.tar.gz#d64a7f2ab8f4419a11bde5379d6065666fd1cc4593ec828cb5ac57385efafa45"

--- a/share/node-build/0.8.13
+++ b/share/node-build/0.8.13
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.8.13/node-v0.8.13-darwin-x64.tar.gz#2f2317359a8d10429f6b69f18c659c5cbbee40d948d994fb469237e9bb138b73"
 binary darwin-x86 "https://nodejs.org/dist/v0.8.13/node-v0.8.13-darwin-x86.tar.gz#e86aa770b74ddf64f4beda3171e65c2adb39a2ff99455ad17af91d92703b2d72"
 binary linux-x64 "https://nodejs.org/dist/v0.8.13/node-v0.8.13-linux-x64.tar.gz#963b0187643a2c60a597ffcdb71343765e4a0acb8cb53ff14f8c3a3bd4226b58"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.13/node-v0.8.13-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.13/node-v0.8.13-sunos-x64.tar.gz#e0563da18e7b127e040e2f356a51db38816e3b3a71d50f6735946d2c4646ad7b"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.13/node-v0.8.13-sunos-x86.tar.gz#b070262e2ce8d0f2eedcae8632e512f2fafca31f5eb51a8994a8b58ef65e8083"
 
-install_package "node-v0.8.13" "https://nodejs.org/dist/v0.8.13/node-v0.8.13.tar.gz#4d85486079aed1749b8bd77899cb728820325384881c874cf78480696f3d8c8c" warn_eol
+install_package "node-v0.8.13" "https://nodejs.org/dist/v0.8.13/node-v0.8.13.tar.gz#4d85486079aed1749b8bd77899cb728820325384881c874cf78480696f3d8c8c"

--- a/share/node-build/0.8.14
+++ b/share/node-build/0.8.14
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.8.14/node-v0.8.14-darwin-x64.tar.gz#7713f0f5379a8b4a026ea9ec14f55394f34bb61c91e27dd08eea28a7edc31edd"
 binary darwin-x86 "https://nodejs.org/dist/v0.8.14/node-v0.8.14-darwin-x86.tar.gz#f062fed150892fe18c2f50d5d05d6757216ffcfca58c035ac67e77e76a3e7c48"
 binary linux-x64 "https://nodejs.org/dist/v0.8.14/node-v0.8.14-linux-x64.tar.gz#032aeede8ef2f147c10327aa310430554a67c30c6fe3b041426e7afb39932320"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.14/node-v0.8.14-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.14/node-v0.8.14-sunos-x64.tar.gz#bd24375f0064abb29a48b7f0975bd719c4175cc4ae8fb47cace2d26db352f35d"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.14/node-v0.8.14-sunos-x86.tar.gz#76b110657c0bdc9b75d85efc259f0df390c854e885a093213674fdca8d92edc5"
 
-install_package "node-v0.8.14" "https://nodejs.org/dist/v0.8.14/node-v0.8.14.tar.gz#e5ce2aadb4df3ea4ca7a021106ffe09d286474476454038e9ed0135eac18e6d0" warn_eol
+install_package "node-v0.8.14" "https://nodejs.org/dist/v0.8.14/node-v0.8.14.tar.gz#e5ce2aadb4df3ea4ca7a021106ffe09d286474476454038e9ed0135eac18e6d0"

--- a/share/node-build/0.8.15
+++ b/share/node-build/0.8.15
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.8.15/node-v0.8.15-darwin-x64.tar.gz#c1050151d178017a2d9fbf842d63e014beb63104c96031b42b5c6d1476f5a2c4"
 binary darwin-x86 "https://nodejs.org/dist/v0.8.15/node-v0.8.15-darwin-x86.tar.gz#735d20eb41ba56a97ae3d0331179dc64d9cf1296d8f483b8b568d3764b5089a9"
 binary linux-x64 "https://nodejs.org/dist/v0.8.15/node-v0.8.15-linux-x64.tar.gz#97026c2a421737ac54b0faa95ea0d261b9940f7524bf2bcf5ce0aadf05f98377"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.15/node-v0.8.15-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.15/node-v0.8.15-sunos-x64.tar.gz#fa0e1bf5cbd46c5ff476e88d1fbee571ab96b038cee9eb38f703da5b45c60a6a"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.15/node-v0.8.15-sunos-x86.tar.gz#bb51410611a8c97998c4e587e75aa6ef6746236ef45454fa3b9c42a05fa8a649"
 
-install_package "node-v0.8.15" "https://nodejs.org/dist/v0.8.15/node-v0.8.15.tar.gz#1758639c6df3e081fe26585472d0f1961c5703b44ba6c57ecdf66a4c015792b1" warn_eol
+install_package "node-v0.8.15" "https://nodejs.org/dist/v0.8.15/node-v0.8.15.tar.gz#1758639c6df3e081fe26585472d0f1961c5703b44ba6c57ecdf66a4c015792b1"

--- a/share/node-build/0.8.16
+++ b/share/node-build/0.8.16
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.8.16/node-v0.8.16-darwin-x64.tar.gz#348dfbb41a322d4e365667aa01a2c3fb722a9650638efd0d5b280a6ec31e5315"
 binary darwin-x86 "https://nodejs.org/dist/v0.8.16/node-v0.8.16-darwin-x86.tar.gz#3712a28e479ab0836a7cb9b583d7a233a531724524ef337fe1a06f47e0b3aab1"
 binary linux-x64 "https://nodejs.org/dist/v0.8.16/node-v0.8.16-linux-x64.tar.gz#528ca5b68c04bf13dd9eaf784328dcfe6128449b32a409c5ef798200e7f15350"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.16/node-v0.8.16-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.16/node-v0.8.16-sunos-x64.tar.gz#832a394c1cfbbd67be7f397a229561c17bec28df65d00716d767e835ba9cae28"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.16/node-v0.8.16-sunos-x86.tar.gz#37a3e1f9b9e2f77eb23681792be1ac65b80455f4a5dbf710a7722ac2efb804d0"
 
-install_package "node-v0.8.16" "https://nodejs.org/dist/v0.8.16/node-v0.8.16.tar.gz#2cd09d4227c787d6886be45dc54dad5aed779d7bd4b1e15ba930101d9d1ed2a4" warn_eol
+install_package "node-v0.8.16" "https://nodejs.org/dist/v0.8.16/node-v0.8.16.tar.gz#2cd09d4227c787d6886be45dc54dad5aed779d7bd4b1e15ba930101d9d1ed2a4"

--- a/share/node-build/0.8.17
+++ b/share/node-build/0.8.17
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.8.17/node-v0.8.17-darwin-x64.tar.gz#0b6a2c9f295c59c7c7364a03e51467b0bf6614cb0d46d590d6ee8b89438a6206"
 binary darwin-x86 "https://nodejs.org/dist/v0.8.17/node-v0.8.17-darwin-x86.tar.gz#ed93a1ce083dd6d1b616ce97c4535ff752865e8a9a45fe2df86960b4f7ece350"
 binary linux-arm-pi "https://nodejs.org/dist/v0.8.17/node-v0.8.17-linux-arm-pi.tar.gz#7caff731ddf6f95543abbd749b7c85f7a15bb3b396549cd64c48ebf8d51f9e0d"
@@ -6,4 +10,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.17/node-v0.8.17-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.17/node-v0.8.17-sunos-x64.tar.gz#9bf6565ffbcf47b1e2f328b73bac0748659e5ed0b94b07dd8462c232af2cc91b"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.17/node-v0.8.17-sunos-x86.tar.gz#ddf05292902728bec9494fe0ce460cbb182e0638aebf5bc9d28d929e7c78d87d"
 
-install_package "node-v0.8.17" "https://nodejs.org/dist/v0.8.17/node-v0.8.17.tar.gz#8f070b42ffb84fde9d3ed2f802b08664b94dda327a36bf08a80c8b7efcf8b29e" warn_eol
+install_package "node-v0.8.17" "https://nodejs.org/dist/v0.8.17/node-v0.8.17.tar.gz#8f070b42ffb84fde9d3ed2f802b08664b94dda327a36bf08a80c8b7efcf8b29e"

--- a/share/node-build/0.8.18
+++ b/share/node-build/0.8.18
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.8.18/node-v0.8.18-darwin-x64.tar.gz#45f2a4ab27018e84dd83b7172c8f1560fbc0c3d24a6b6d03ca1bfc1b33bdb240"
 binary darwin-x86 "https://nodejs.org/dist/v0.8.18/node-v0.8.18-darwin-x86.tar.gz#fa5addf17bc82cf9b553b00381e1ca8498a5a89085309dfe07f970384eaf925f"
 binary linux-arm-pi "https://nodejs.org/dist/v0.8.18/node-v0.8.18-linux-arm-pi.tar.gz#1237c7bffdcc6a3bc6bdcebadd0a4729c2d180a003871e2955a2644e57ce97e1"
@@ -6,4 +10,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.18/node-v0.8.18-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.18/node-v0.8.18-sunos-x64.tar.gz#7c36db277ce3f7dd59dc9cc792f16f02266d9dfdcd22b3658370e425ebe95080"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.18/node-v0.8.18-sunos-x86.tar.gz#306263031eeff00ded073b08f5344831b572034ab0d3a98af01a5f46c614411b"
 
-install_package "node-v0.8.18" "https://nodejs.org/dist/v0.8.18/node-v0.8.18.tar.gz#1d63dd42f9bd22f087585ddf80a881c6acbe1664891b1dda3b71306fe9ae00f9" warn_eol
+install_package "node-v0.8.18" "https://nodejs.org/dist/v0.8.18/node-v0.8.18.tar.gz#1d63dd42f9bd22f087585ddf80a881c6acbe1664891b1dda3b71306fe9ae00f9"

--- a/share/node-build/0.8.19
+++ b/share/node-build/0.8.19
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.8.19/node-v0.8.19-darwin-x64.tar.gz#39387dfb03c7c5421bdd117963d520ac1db1b26a74e0931125aa636d182e8aa2"
 binary darwin-x86 "https://nodejs.org/dist/v0.8.19/node-v0.8.19-darwin-x86.tar.gz#e2272cd0985c29d100a4f4114a1d5957c076ab076705b04855ceb68ebc816dd5"
 binary linux-arm-pi "https://nodejs.org/dist/v0.8.19/node-v0.8.19-linux-arm-pi.tar.gz#35a921869eb6957a612f4437db9cc93bbc989d5db2fcea3626f4757d0ce10d2c"
@@ -6,4 +10,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.19/node-v0.8.19-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.19/node-v0.8.19-sunos-x64.tar.gz#fb32343c8bafbd7698db5db2f2b103769e2ef2eccc20586000d8c3ccb8a9fdbc"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.19/node-v0.8.19-sunos-x86.tar.gz#d296d478ad60114d6f26848c63881d98e24a5c499695805d17e70368d8678f6e"
 
-install_package "node-v0.8.19" "https://nodejs.org/dist/v0.8.19/node-v0.8.19.tar.gz#703207d7b394bd3d4035dc3c94b417ee441fd3ea66aa90cd3d7c9bb28e5f9df4" warn_eol
+install_package "node-v0.8.19" "https://nodejs.org/dist/v0.8.19/node-v0.8.19.tar.gz#703207d7b394bd3d4035dc3c94b417ee441fd3ea66aa90cd3d7c9bb28e5f9df4"

--- a/share/node-build/0.8.2
+++ b/share/node-build/0.8.2
@@ -1,1 +1,5 @@
-install_package "node-v0.8.2" "https://nodejs.org/dist/v0.8.2/node-v0.8.2.tar.gz#6830ed4eaf6c191243fb3afbe3ca3283d7e3a537c8f3ce508fa2af1328fe4baf" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.8.2" "https://nodejs.org/dist/v0.8.2/node-v0.8.2.tar.gz#6830ed4eaf6c191243fb3afbe3ca3283d7e3a537c8f3ce508fa2af1328fe4baf"

--- a/share/node-build/0.8.20
+++ b/share/node-build/0.8.20
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.8.20/node-v0.8.20-darwin-x64.tar.gz#f81d2dff6097a80606b8807cd4eaa4c77b2c83630394a1bcfba885679b6caa1a"
 binary darwin-x86 "https://nodejs.org/dist/v0.8.20/node-v0.8.20-darwin-x86.tar.gz#7f2863ffe3cabebc33930924bfd1ebf3108c070ed052eeb02ccd292c85f6658a"
 binary linux-arm-pi "https://nodejs.org/dist/v0.8.20/node-v0.8.20-linux-arm-pi.tar.gz#a051fb79f7f7b68d38e9933669cddea093bd2a1068558db75b5c95e963199a16"
@@ -6,4 +10,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.20/node-v0.8.20-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.20/node-v0.8.20-sunos-x64.tar.gz#73e8c9951ab6cc4641eadf2bdfffa5f8c8b2efe21fef2ac915f41e4e4915c8af"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.20/node-v0.8.20-sunos-x86.tar.gz#3595c38edcd478d9d728fa152022511420d3864a89234b79a5b64d7ec3924598"
 
-install_package "node-v0.8.20" "https://nodejs.org/dist/v0.8.20/node-v0.8.20.tar.gz#e4461bfded531f4880839829ab3bce5b824905d6e181876e3d0309a366bf57ee" warn_eol
+install_package "node-v0.8.20" "https://nodejs.org/dist/v0.8.20/node-v0.8.20.tar.gz#e4461bfded531f4880839829ab3bce5b824905d6e181876e3d0309a366bf57ee"

--- a/share/node-build/0.8.21
+++ b/share/node-build/0.8.21
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.8.21/node-v0.8.21-darwin-x64.tar.gz#6db45e7118329c94b733d49b0adb27f26769d48915c75cf812cf6d4b4fff49bf"
 binary darwin-x86 "https://nodejs.org/dist/v0.8.21/node-v0.8.21-darwin-x86.tar.gz#50fc316020d7ed1ad9a52a2ff2cd74046b057f18cdd1abaa01def02c860fc22f"
 binary linux-arm-pi "https://nodejs.org/dist/v0.8.21/node-v0.8.21-linux-arm-pi.tar.gz#de560f70e6d2e0588c7a13763f27329b443327afc3880b12f1a3464284efa8cd"
@@ -6,4 +10,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.21/node-v0.8.21-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.21/node-v0.8.21-sunos-x64.tar.gz#51ca34ac742efb321720144110c9df1672f3aa53521f73591c11cbf0a5a8754c"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.21/node-v0.8.21-sunos-x86.tar.gz#f34358c23e9145db8a28f41a9269f3a75c0066b32ff0f19d05bacb04eb2192c6"
 
-install_package "node-v0.8.21" "https://nodejs.org/dist/v0.8.21/node-v0.8.21.tar.gz#e526f56d22bb2ebee5a607bd1e7a16dcc8530b916e3a372192e6cd5fa97d08e6" warn_eol
+install_package "node-v0.8.21" "https://nodejs.org/dist/v0.8.21/node-v0.8.21.tar.gz#e526f56d22bb2ebee5a607bd1e7a16dcc8530b916e3a372192e6cd5fa97d08e6"

--- a/share/node-build/0.8.22
+++ b/share/node-build/0.8.22
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.8.22/node-v0.8.22-darwin-x64.tar.gz#640cb11ecad00b9cddaadb2d95d760123523c26e0dcbf2abe9ef5ab3c2e41206"
 binary darwin-x86 "https://nodejs.org/dist/v0.8.22/node-v0.8.22-darwin-x86.tar.gz#e725e8a2fcebc6d799e94f40eb757c731764cfb76d12e2332858d242cfcb9eeb"
 binary linux-arm-pi "https://nodejs.org/dist/v0.8.22/node-v0.8.22-linux-arm-pi.tar.gz#0fb6c6c6a0e9e24c9343d2216e059f16dd7d7da2701efe882e2de0dc0e0e408b"
@@ -6,4 +10,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.22/node-v0.8.22-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.22/node-v0.8.22-sunos-x64.tar.gz#8807dcc3192d3a8c0aae407b620e7ccea62ea3c8ba00a9c99118684cc9c43b77"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.22/node-v0.8.22-sunos-x86.tar.gz#1eb0aa09ba0c5e99e81dd267ee63586f40ea6c3c4ea0b1134a659cb3a86472c4"
 
-install_package "node-v0.8.22" "https://nodejs.org/dist/v0.8.22/node-v0.8.22.tar.gz#3f61152cf5cd8fc1ab5c6c18101819841b947da79e1e44b51418c0ad2e6db8e8" warn_eol
+install_package "node-v0.8.22" "https://nodejs.org/dist/v0.8.22/node-v0.8.22.tar.gz#3f61152cf5cd8fc1ab5c6c18101819841b947da79e1e44b51418c0ad2e6db8e8"

--- a/share/node-build/0.8.23
+++ b/share/node-build/0.8.23
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.8.23/node-v0.8.23-darwin-x64.tar.gz#fa1835e56992b0608ae6d19e031e33545a86becbb0d2695809403d70aff58258"
 binary darwin-x86 "https://nodejs.org/dist/v0.8.23/node-v0.8.23-darwin-x86.tar.gz#1243625fd442e68d232566aa2ed5919f3e792a9bf6a85bb5da360a53f7035691"
 binary linux-x64 "https://nodejs.org/dist/v0.8.23/node-v0.8.23-linux-x64.tar.gz#b88284ec2a5944154962bfe3221238a003aa0a6b5306f777ad1554c22e89698b"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.23/node-v0.8.23-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.23/node-v0.8.23-sunos-x64.tar.gz#8bd2f6ab2ed42416dd93e63dae996c5cf4b6ac1f1f5809b31d2c1d6302f55288"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.23/node-v0.8.23-sunos-x86.tar.gz#5784b479f6430abe8f8c58f1f6a1f457fe7f841bd390bb7e6c2cdd2abf02025c"
 
-install_package "node-v0.8.23" "https://nodejs.org/dist/v0.8.23/node-v0.8.23.tar.gz#382432638aedc25495e655dda338adcf41c6fa1d35f355936d659784c1deed9d" warn_eol
+install_package "node-v0.8.23" "https://nodejs.org/dist/v0.8.23/node-v0.8.23.tar.gz#382432638aedc25495e655dda338adcf41c6fa1d35f355936d659784c1deed9d"

--- a/share/node-build/0.8.24
+++ b/share/node-build/0.8.24
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.8.24/node-v0.8.24-darwin-x64.tar.gz#8a15b6b40ba03fc361342faf2ddb3cc0480ebf5e63fb9adbaab6cda757697311"
 binary darwin-x86 "https://nodejs.org/dist/v0.8.24/node-v0.8.24-darwin-x86.tar.gz#1f06a3e8c887322479ae9f9a63f573e0638ed9cc1b72668d2f917062810b8278"
 binary linux-x64 "https://nodejs.org/dist/v0.8.24/node-v0.8.24-linux-x64.tar.gz#1296b795fb1d8406d7548372caef82454c460111b3ed4ef6d4b67dca6cfa4a76"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.24/node-v0.8.24-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.24/node-v0.8.24-sunos-x64.tar.gz#71578fd0ae413bdd41e336959889db70f1268084da92c37ba8467701b60ac995"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.24/node-v0.8.24-sunos-x86.tar.gz#ce340c74abff8c6d462ce373ed8c6882c522a1032d327474ef17541403448b82"
 
-install_package "node-v0.8.24" "https://nodejs.org/dist/v0.8.24/node-v0.8.24.tar.gz#a0836e210da50106329e573532d5c590594ff1fcb9564fe8b55a04f04ff77705" warn_eol
+install_package "node-v0.8.24" "https://nodejs.org/dist/v0.8.24/node-v0.8.24.tar.gz#a0836e210da50106329e573532d5c590594ff1fcb9564fe8b55a04f04ff77705"

--- a/share/node-build/0.8.25
+++ b/share/node-build/0.8.25
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.8.25/node-v0.8.25-darwin-x64.tar.gz#22aa30210b989c8800d0625c880153594cd1e39015a30a85e0c2085c9497c09d"
 binary darwin-x86 "https://nodejs.org/dist/v0.8.25/node-v0.8.25-darwin-x86.tar.gz#c91abac167f9f8e2b3ff455731c77fb6319b2d11afce80757e65df4aa1beac2d"
 binary linux-x64 "https://nodejs.org/dist/v0.8.25/node-v0.8.25-linux-x64.tar.gz#7eedbece123b5acacfa5ca9d1e7a1ab6bd9b32bed5b3c92f6853cca57be82d07"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.25/node-v0.8.25-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.25/node-v0.8.25-sunos-x64.tar.gz#371ba8792e979ad0b2b1e780436e3ed4201ed2c1ffb916c01bc5de94178cd0d8"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.25/node-v0.8.25-sunos-x86.tar.gz#0ad7c35c45e929edc13ab1ed699ed02b9bfc4155a643db979baa0ee121c5b8d6"
 
-install_package "node-v0.8.25" "https://nodejs.org/dist/v0.8.25/node-v0.8.25.tar.gz#3dad0149020102e9b5604edae3cecd5842221c6657f26d35717bffaaf376caec" warn_eol
+install_package "node-v0.8.25" "https://nodejs.org/dist/v0.8.25/node-v0.8.25.tar.gz#3dad0149020102e9b5604edae3cecd5842221c6657f26d35717bffaaf376caec"

--- a/share/node-build/0.8.26
+++ b/share/node-build/0.8.26
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.8.26/node-v0.8.26-darwin-x64.tar.gz#1c25e4ca125ddda22648957e1a40f4c7d37a0eda52cbe9ae1620b8bce9da317b"
 binary darwin-x86 "https://nodejs.org/dist/v0.8.26/node-v0.8.26-darwin-x86.tar.gz#512cb20374466fd4b26b44f52aea6300d7f0cb529e80311fea85b136de242b24"
 binary linux-x64 "https://nodejs.org/dist/v0.8.26/node-v0.8.26-linux-x64.tar.gz#57e70b7571393cc32019f0ff6d086183198b8e7824c3690ebed504d37f52c298"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.26/node-v0.8.26-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.26/node-v0.8.26-sunos-x64.tar.gz#c216e547c7f84e397c71241b99a1565de78a22bbcc3f9c39005a4b28dd741896"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.26/node-v0.8.26-sunos-x86.tar.gz#faaaab76ca39712a17af2928ad71a0ce94bd6af599b7d3472912e5e4724e7aab"
 
-install_package "node-v0.8.26" "https://nodejs.org/dist/v0.8.26/node-v0.8.26.tar.gz#d873216685774b96139af534ce015077d2c93ddfc4e3596e128853f3c08a5413" warn_eol
+install_package "node-v0.8.26" "https://nodejs.org/dist/v0.8.26/node-v0.8.26.tar.gz#d873216685774b96139af534ce015077d2c93ddfc4e3596e128853f3c08a5413"

--- a/share/node-build/0.8.27
+++ b/share/node-build/0.8.27
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.8.27/node-v0.8.27-darwin-x64.tar.gz#593044136647bd73d29c709d16c4c27ff295c41129015d8414f5ea1f935efd2d"
 binary darwin-x86 "https://nodejs.org/dist/v0.8.27/node-v0.8.27-darwin-x86.tar.gz#98d086a42fc54b2c90b5890732497ab957b7ded4bfc57aa7997b4984d4faf0ef"
 binary linux-x64 "https://nodejs.org/dist/v0.8.27/node-v0.8.27-linux-x64.tar.gz#d65fafd755ed630abc6df04548dc3075282c06661cfd44f1af42c5e15a8c6826"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.27/node-v0.8.27-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.27/node-v0.8.27-sunos-x64.tar.gz#6340f05c2b56160fcfb796723d6702f28d0100595b7180acf715d7304a03d1bd"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.27/node-v0.8.27-sunos-x86.tar.gz#5e41e9e31fdd849483ef2b81c5dae7cf9487e70780bda2d216447b34c2707265"
 
-install_package "node-v0.8.27" "https://nodejs.org/dist/v0.8.27/node-v0.8.27.tar.gz#30608f9dcd9ad122f7e8e6212f95969979e3dc35309d0c422a56486334a9369e" warn_eol
+install_package "node-v0.8.27" "https://nodejs.org/dist/v0.8.27/node-v0.8.27.tar.gz#30608f9dcd9ad122f7e8e6212f95969979e3dc35309d0c422a56486334a9369e"

--- a/share/node-build/0.8.28
+++ b/share/node-build/0.8.28
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.8.28/node-v0.8.28-darwin-x64.tar.gz#e2ce196394765bee8fbb703651dbc4024cd840f802d2277e7adff91f5a6e1656"
 binary darwin-x86 "https://nodejs.org/dist/v0.8.28/node-v0.8.28-darwin-x86.tar.gz#2f9081ef6e4ab46eb74c52395e7eb886c647466a9aa57add2945649cd351c87a"
 binary linux-x64 "https://nodejs.org/dist/v0.8.28/node-v0.8.28-linux-x64.tar.gz#9ea0be4f08ade1645d2acb3fc4e294eb4d1ca595a405168caec2d7a0d41ca84e"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.28/node-v0.8.28-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.8.28/node-v0.8.28-sunos-x64.tar.gz#5966bb3ca9ed4a30a9391b0329c41a1075e01410b38d5d8245271f7d2bfa0db2"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.28/node-v0.8.28-sunos-x86.tar.gz#784c45b07e1e9b664cbe1cefa5d0ddaf6de5397a70cd3b529f8953182a2b5b4e"
 
-install_package "node-v0.8.28" "https://nodejs.org/dist/v0.8.28/node-v0.8.28.tar.gz#50e9a4282a741c923bd41c3ebb76698edbd7b1324024fe70cedc1e34b782d44f" warn_eol
+install_package "node-v0.8.28" "https://nodejs.org/dist/v0.8.28/node-v0.8.28.tar.gz#50e9a4282a741c923bd41c3ebb76698edbd7b1324024fe70cedc1e34b782d44f"

--- a/share/node-build/0.8.3
+++ b/share/node-build/0.8.3
@@ -1,1 +1,5 @@
-install_package "node-v0.8.3" "https://nodejs.org/dist/v0.8.3/node-v0.8.3.tar.gz#600a1d88744937dbad048f65f60d1259b814c59777d7b9d8665def77b1e1ec35" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.8.3" "https://nodejs.org/dist/v0.8.3/node-v0.8.3.tar.gz#600a1d88744937dbad048f65f60d1259b814c59777d7b9d8665def77b1e1ec35"

--- a/share/node-build/0.8.4
+++ b/share/node-build/0.8.4
@@ -1,1 +1,5 @@
-install_package "node-v0.8.4" "https://nodejs.org/dist/v0.8.4/node-v0.8.4.tar.gz#d0a3b0d2028ddd6bbaab5d3fe38dd6f80d7e810fe9e55efab3230a7c90d31174" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.8.4" "https://nodejs.org/dist/v0.8.4/node-v0.8.4.tar.gz#d0a3b0d2028ddd6bbaab5d3fe38dd6f80d7e810fe9e55efab3230a7c90d31174"

--- a/share/node-build/0.8.5
+++ b/share/node-build/0.8.5
@@ -1,1 +1,5 @@
-install_package "node-v0.8.5" "https://nodejs.org/dist/v0.8.5/node-v0.8.5.tar.gz#022a924973b15291f98b57437b53c59eaabee02348a2534259836e837f9ea6c0" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.8.5" "https://nodejs.org/dist/v0.8.5/node-v0.8.5.tar.gz#022a924973b15291f98b57437b53c59eaabee02348a2534259836e837f9ea6c0"

--- a/share/node-build/0.8.6
+++ b/share/node-build/0.8.6
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.8.6/node-v0.8.6-darwin-x64.tar.gz#42c853c0adb8052da0d2976cfc2cbb29152dc9904d69efd7e61c71afbf9492af"
 binary darwin-x86 "https://nodejs.org/dist/v0.8.6/node-v0.8.6-darwin-x86.tar.gz#36ee1c7fbe2a7e9e3dc8a215e5cb64905774f62f694cc710493f9d618016c631"
 binary linux-x64 "https://nodejs.org/dist/v0.8.6/node-v0.8.6-linux-x64.tar.gz#d2c04ae64f9070b6ab5b7da7ccfc6d22f019e165ce6cce06d3ab422dfbeded1f"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.6/node-v0.8.6-linux-x86.tar.gz#d5
 binary sunos-x64 "https://nodejs.org/dist/v0.8.6/node-v0.8.6-sunos-x64.tar.gz#41b42ceec543c8087a5bc3f66ad7788003409d58daf16b9ee872bea29a9ee98d"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.6/node-v0.8.6-sunos-x86.tar.gz#94fa004e74f2e176022c03c07fd3cabb84de3bfc25c801e741be38a152a46341"
 
-install_package "node-v0.8.6" "https://nodejs.org/dist/v0.8.6/node-v0.8.6.tar.gz#dbd42800e69644beff5c2cf11a9d4cf6dfbd644a9a36ffdd5e8c6b8db9240854" warn_eol
+install_package "node-v0.8.6" "https://nodejs.org/dist/v0.8.6/node-v0.8.6.tar.gz#dbd42800e69644beff5c2cf11a9d4cf6dfbd644a9a36ffdd5e8c6b8db9240854"

--- a/share/node-build/0.8.7
+++ b/share/node-build/0.8.7
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.8.7/node-v0.8.7-darwin-x64.tar.gz#3966ba6007b13ba8f47af101c2a329b39412a532ba9aa089860d4af54b51efcd"
 binary darwin-x86 "https://nodejs.org/dist/v0.8.7/node-v0.8.7-darwin-x86.tar.gz#60812a5c2e0a70360d855b7d765a7ab45fc8ddd00da1b26c5e086257bb25ff73"
 binary linux-x64 "https://nodejs.org/dist/v0.8.7/node-v0.8.7-linux-x64.tar.gz#a9fa9e6ea54bb8cc940264dab60c867f8231aef00b4d1b07be63f3150e91067e"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.7/node-v0.8.7-linux-x86.tar.gz#60
 binary sunos-x64 "https://nodejs.org/dist/v0.8.7/node-v0.8.7-sunos-x64.tar.gz#de4b5134884eec075c5e00eda81086cd92187e81c2e910462aca36a848e008a7"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.7/node-v0.8.7-sunos-x86.tar.gz#3219c5efd7bf1f069d424c34fd75332b094f7870e24f33eb46916f4d509a1ecb"
 
-install_package "node-v0.8.7" "https://nodejs.org/dist/v0.8.7/node-v0.8.7.tar.gz#fa979488347ad08ea6e36d3fe9c543807cd6f84cad31b22bfc6179b54b1e9d04" warn_eol
+install_package "node-v0.8.7" "https://nodejs.org/dist/v0.8.7/node-v0.8.7.tar.gz#fa979488347ad08ea6e36d3fe9c543807cd6f84cad31b22bfc6179b54b1e9d04"

--- a/share/node-build/0.8.8
+++ b/share/node-build/0.8.8
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.8.8/node-v0.8.8-darwin-x64.tar.gz#69e5f514e22c2139454f9469c58c8bb0f4092c29e1115bc446afd12f75a467e7"
 binary darwin-x86 "https://nodejs.org/dist/v0.8.8/node-v0.8.8-darwin-x86.tar.gz#e8e4572c89b16c4f0f48d5060bbe4dd2f8db299711262417300b82b2df790cbb"
 binary linux-x64 "https://nodejs.org/dist/v0.8.8/node-v0.8.8-linux-x64.tar.gz#bc0038a4ec650578b8d9a55aa4f86be22b43c0115a1efe0378d6a177a8ee3bca"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.8/node-v0.8.8-linux-x86.tar.gz#b2
 binary sunos-x64 "https://nodejs.org/dist/v0.8.8/node-v0.8.8-sunos-x64.tar.gz#b94b63c97bdaa963ce5945a75d9bc73f694eca29df7be3a0070713e03acea295"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.8/node-v0.8.8-sunos-x86.tar.gz#e5fe9ecbc4dbbe65558cfb8d01678515ce3bb98573fff7a43810f99e404cd33e"
 
-install_package "node-v0.8.8" "https://nodejs.org/dist/v0.8.8/node-v0.8.8.tar.gz#092b7045b8e956f838a2a3da36cdcf7954e9e0d16fb88b14e2b7d090422e3133" warn_eol
+install_package "node-v0.8.8" "https://nodejs.org/dist/v0.8.8/node-v0.8.8.tar.gz#092b7045b8e956f838a2a3da36cdcf7954e9e0d16fb88b14e2b7d090422e3133"

--- a/share/node-build/0.8.9
+++ b/share/node-build/0.8.9
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.8.9/node-v0.8.9-darwin-x64.tar.gz#c41002cac64f4198e55ed6a78f2e321e721c6150854d3ca27603cb912782c04e"
 binary darwin-x86 "https://nodejs.org/dist/v0.8.9/node-v0.8.9-darwin-x86.tar.gz#b7c67a983777d86fe21395ed2d0fe619364b27788e507bb8249eff56b57e2352"
 binary linux-x64 "https://nodejs.org/dist/v0.8.9/node-v0.8.9-linux-x64.tar.gz#ee785197324d0a0335de12a2be124b2eaf49865fc791d600651edff3d3831aea"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.8.9/node-v0.8.9-linux-x86.tar.gz#ed
 binary sunos-x64 "https://nodejs.org/dist/v0.8.9/node-v0.8.9-sunos-x64.tar.gz#dbc20cfc4d665497d772d8c1a7f4140f63617cfeab83ac73649d1914fabf9c90"
 binary sunos-x86 "https://nodejs.org/dist/v0.8.9/node-v0.8.9-sunos-x86.tar.gz#e93a229d09e5032aa7add4a2c255b9aea53ff634419956d732e0f6e154fcd896"
 
-install_package "node-v0.8.9" "https://nodejs.org/dist/v0.8.9/node-v0.8.9.tar.gz#320f06877c5e4b4dcc407c76c4d6dcf24384211c2ee22f8bc794a8ec898136ba" warn_eol
+install_package "node-v0.8.9" "https://nodejs.org/dist/v0.8.9/node-v0.8.9.tar.gz#320f06877c5e4b4dcc407c76c4d6dcf24384211c2ee22f8bc794a8ec898136ba"

--- a/share/node-build/0.9.0
+++ b/share/node-build/0.9.0
@@ -1,1 +1,5 @@
-install_package "node-v0.9.0" "https://nodejs.org/dist/v0.9.0/node-v0.9.0.tar.gz#4d2e5d7c8b345f6e401eed7d06b4bbc6cb012aefc34b46e7c3aedb4a0fccd258" warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_package "node-v0.9.0" "https://nodejs.org/dist/v0.9.0/node-v0.9.0.tar.gz#4d2e5d7c8b345f6e401eed7d06b4bbc6cb012aefc34b46e7c3aedb4a0fccd258"

--- a/share/node-build/0.9.1
+++ b/share/node-build/0.9.1
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.9.1/node-v0.9.1-darwin-x64.tar.gz#1758e8bcb881e507506e743e3d23d3f1bc8101330492f7d8f0818f1ac4c6317f"
 binary darwin-x86 "https://nodejs.org/dist/v0.9.1/node-v0.9.1-darwin-x86.tar.gz#33cfbbdb5aa14bd0c9ee8a6b424af3421c1197586c7a6a7fa290c1f3b096c5af"
 binary linux-x64 "https://nodejs.org/dist/v0.9.1/node-v0.9.1-linux-x64.tar.gz#094afa13511cac6638f69b100ca4990392ea5430f2277b7acd93a1f2378e3b86"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.1/node-v0.9.1-linux-x86.tar.gz#31
 binary sunos-x64 "https://nodejs.org/dist/v0.9.1/node-v0.9.1-sunos-x64.tar.gz#971283d3b205dd624d750ecf66f45faf8738cae2e05cab24edcf68188bab5d0b"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.1/node-v0.9.1-sunos-x86.tar.gz#3b7cd36578e3703bd3c4141e3af389598c954e180985aac5d33035c698fd1e53"
 
-install_package "node-v0.9.1" "https://nodejs.org/dist/v0.9.1/node-v0.9.1.tar.gz#12bc0deb1a0c3fdcd5c54ffd241c1e291d372620944c3f97388d38f460f222b9" warn_eol
+install_package "node-v0.9.1" "https://nodejs.org/dist/v0.9.1/node-v0.9.1.tar.gz#12bc0deb1a0c3fdcd5c54ffd241c1e291d372620944c3f97388d38f460f222b9"

--- a/share/node-build/0.9.10
+++ b/share/node-build/0.9.10
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.9.10/node-v0.9.10-darwin-x64.tar.gz#71d26152e960d85918001c1c8db7a66bbbc3293edd58f75a63d649fbc3c14d20"
 binary darwin-x86 "https://nodejs.org/dist/v0.9.10/node-v0.9.10-darwin-x86.tar.gz#1ce7bd920e6a6fdbe24ed9c55a8516c7b813785f08ed5312c2969aa3a7bf56d9"
 binary linux-arm-pi "https://nodejs.org/dist/v0.9.10/node-v0.9.10-linux-arm-pi.tar.gz#438f7df584667d54e4756269d78b413d1188600b1d00c60298cdbeb9406c58ec"
@@ -6,4 +10,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.10/node-v0.9.10-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.9.10/node-v0.9.10-sunos-x64.tar.gz#99ae3de4362861a0eec4c181fb42d585e72fd4ad30e61ff894702fd2eb0d46d0"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.10/node-v0.9.10-sunos-x86.tar.gz#3623fbe87783fff3508ddd042b9dd23a2ea76ea0e711463dea0a085cda847a0d"
 
-install_package "node-v0.9.10" "https://nodejs.org/dist/v0.9.10/node-v0.9.10.tar.gz#efdb49fc4ce2b4876c2fac00f5a2d8458f6aba42fa85001b0cb01f7a4b234ec9" warn_eol
+install_package "node-v0.9.10" "https://nodejs.org/dist/v0.9.10/node-v0.9.10.tar.gz#efdb49fc4ce2b4876c2fac00f5a2d8458f6aba42fa85001b0cb01f7a4b234ec9"

--- a/share/node-build/0.9.11
+++ b/share/node-build/0.9.11
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.9.11/node-v0.9.11-darwin-x64.tar.gz#20653e45e6e1ab3e4ef639ef7072b51fe858616cff27fca105f61a5bba26d434"
 binary darwin-x86 "https://nodejs.org/dist/v0.9.11/node-v0.9.11-darwin-x86.tar.gz#3e903a5d410122d7819952d85b5fb88af9d75cb6146c42b08919d9881f202c12"
 binary linux-arm-pi "https://nodejs.org/dist/v0.9.11/node-v0.9.11-linux-arm-pi.tar.gz#2a63fe7655a4ac6a795c976ec8f94580a198273344a2f446c442dea1c64dd448"
@@ -6,4 +10,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.11/node-v0.9.11-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.9.11/node-v0.9.11-sunos-x64.tar.gz#c84a2db0e0839400c4ef4ee7de1b9a3cbc44d7bc66beda324497227019d9f44d"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.11/node-v0.9.11-sunos-x86.tar.gz#eb793e5c212571a434b63afd92618fcd6da1b41e325bf6153550dce5a2871389"
 
-install_package "node-v0.9.11" "https://nodejs.org/dist/v0.9.11/node-v0.9.11.tar.gz#2e22a9ecd838527f69d31e35fa5781d4b8099e3b33891b5f7d7e46f2291d6988" warn_eol
+install_package "node-v0.9.11" "https://nodejs.org/dist/v0.9.11/node-v0.9.11.tar.gz#2e22a9ecd838527f69d31e35fa5781d4b8099e3b33891b5f7d7e46f2291d6988"

--- a/share/node-build/0.9.12
+++ b/share/node-build/0.9.12
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.9.12/node-v0.9.12-darwin-x64.tar.gz#3e9db5d098688b4caa80c3de29f6623ff7c8420e43cb10d3a2b25d50dcf0e1db"
 binary darwin-x86 "https://nodejs.org/dist/v0.9.12/node-v0.9.12-darwin-x86.tar.gz#688c75eae59835335f537c4effa96a2ea51b0df2a630ef5f410f5796f71e8acd"
 binary linux-arm-pi "https://nodejs.org/dist/v0.9.12/node-v0.9.12-linux-arm-pi.tar.gz#8b44c62a58e8a8b39328a536759b663e8e0710db32b0b48cc0f6217096af0b50"
@@ -6,4 +10,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.12/node-v0.9.12-linux-x86.tar.gz#
 binary sunos-x64 "https://nodejs.org/dist/v0.9.12/node-v0.9.12-sunos-x64.tar.gz#b2dcc56ca896e9f0297ea3e41bb521e81cdea801dd6cb3ea1a4fe6b82be358f4"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.12/node-v0.9.12-sunos-x86.tar.gz#cf3f8db68ae33e1b07a7a0e8eb84cec116765347814188c04528903803a97bdc"
 
-install_package "node-v0.9.12" "https://nodejs.org/dist/v0.9.12/node-v0.9.12.tar.gz#d1dbf425eb72b7c6d931f5fabf79b1e67ce1b2808c19c4b06a9aafe313ac2474" warn_eol
+install_package "node-v0.9.12" "https://nodejs.org/dist/v0.9.12/node-v0.9.12.tar.gz#d1dbf425eb72b7c6d931f5fabf79b1e67ce1b2808c19c4b06a9aafe313ac2474"

--- a/share/node-build/0.9.2
+++ b/share/node-build/0.9.2
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.9.2/node-v0.9.2-darwin-x64.tar.gz#19d9a9c60f3a2fee9b910846daad9615ef761bbf6ce8dcbea372b725f5e470e8"
 binary darwin-x86 "https://nodejs.org/dist/v0.9.2/node-v0.9.2-darwin-x86.tar.gz#b275e42626754b575eaea33a27fd29837db02ed28736495577f159e1c55133d4"
 binary linux-x64 "https://nodejs.org/dist/v0.9.2/node-v0.9.2-linux-x64.tar.gz#db2b1740f652ffdfeecb073d1ca91863783675f42c31c2fe6f7643da11268331"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.2/node-v0.9.2-linux-x86.tar.gz#fa
 binary sunos-x64 "https://nodejs.org/dist/v0.9.2/node-v0.9.2-sunos-x64.tar.gz#0d87e660f1cc57cfcb1a9c1cc85b4ed305f08f6d3463d6d6cdcfd537ca79138a"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.2/node-v0.9.2-sunos-x86.tar.gz#7d47f6c89e9036247f754a80b47eb36ae1973f1f200b9a70cabc413933e17684"
 
-install_package "node-v0.9.2" "https://nodejs.org/dist/v0.9.2/node-v0.9.2.tar.gz#84dc31888a5d53a0188ebc04ef4b84488b2f0361dd4696b7ae047af7372102c1" warn_eol
+install_package "node-v0.9.2" "https://nodejs.org/dist/v0.9.2/node-v0.9.2.tar.gz#84dc31888a5d53a0188ebc04ef4b84488b2f0361dd4696b7ae047af7372102c1"

--- a/share/node-build/0.9.3
+++ b/share/node-build/0.9.3
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.9.3/node-v0.9.3-darwin-x64.tar.gz#d2ceeba6ea15f02cdefa6a91181bbe931452f5ddd69f9594d4bed57c6eeb95c9"
 binary darwin-x86 "https://nodejs.org/dist/v0.9.3/node-v0.9.3-darwin-x86.tar.gz#c49d32771ddb2d2f0b03db6ba7e698d3d91f7d5cab512cb1b867cd93cef79ce0"
 binary linux-x64 "https://nodejs.org/dist/v0.9.3/node-v0.9.3-linux-x64.tar.gz#fa92deff7cffd10130520245c1bc724a22c61d89e50d0e232af5c51eeb80dcfe"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.3/node-v0.9.3-linux-x86.tar.gz#8d
 binary sunos-x64 "https://nodejs.org/dist/v0.9.3/node-v0.9.3-sunos-x64.tar.gz#fc34d3614624f27b3801f4c2f3019f6cd2c7ad5b05d97d8dd28524d9ff4c4ebe"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.3/node-v0.9.3-sunos-x86.tar.gz#df4cb58d17cb545dd8a91e49b1f270fa1dd4f1b2cd81d6afd8ec24f0ce1c6049"
 
-install_package "node-v0.9.3" "https://nodejs.org/dist/v0.9.3/node-v0.9.3.tar.gz#7e1750cd47d7b8c13c7cf12457b6a528fa2abf8a10b7c9a35c13ed47cebaab41" warn_eol
+install_package "node-v0.9.3" "https://nodejs.org/dist/v0.9.3/node-v0.9.3.tar.gz#7e1750cd47d7b8c13c7cf12457b6a528fa2abf8a10b7c9a35c13ed47cebaab41"

--- a/share/node-build/0.9.4
+++ b/share/node-build/0.9.4
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.9.4/node-v0.9.4-darwin-x64.tar.gz#a01c42debabffd9b99ed7eef89c8bb87e08bc3e40e147b3eb809be469ff0c947"
 binary darwin-x86 "https://nodejs.org/dist/v0.9.4/node-v0.9.4-darwin-x86.tar.gz#19e72f86bbb610ec8dc0182e8276c0efd73cf75dd3097c4276730bf6176f4775"
 binary linux-x64 "https://nodejs.org/dist/v0.9.4/node-v0.9.4-linux-x64.tar.gz#10daa5991f2e82874ac5a2ad3c223dea4e7f2f67587825135396906edbfb16d1"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.4/node-v0.9.4-linux-x86.tar.gz#f7
 binary sunos-x64 "https://nodejs.org/dist/v0.9.4/node-v0.9.4-sunos-x64.tar.gz#fd52e94f51f78b8d55d450cf8c389ee5e2e283d4a0deb602c3bb10964181539d"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.4/node-v0.9.4-sunos-x86.tar.gz#1cac9ed70d26d3465efb45c4ca2ff4d99af786407fe44dbfef135a0ce80ea64a"
 
-install_package "node-v0.9.4" "https://nodejs.org/dist/v0.9.4/node-v0.9.4.tar.gz#6978981caceff7b83a23a6e3c89dba5734d27a623d2c3d26ecd77e41f2bd39f7" warn_eol
+install_package "node-v0.9.4" "https://nodejs.org/dist/v0.9.4/node-v0.9.4.tar.gz#6978981caceff7b83a23a6e3c89dba5734d27a623d2c3d26ecd77e41f2bd39f7"

--- a/share/node-build/0.9.5
+++ b/share/node-build/0.9.5
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.9.5/node-v0.9.5-darwin-x64.tar.gz#490890fa1259aaa5e0aa66a4aae432831c10ef20729c1dee235e86579af2615e"
 binary darwin-x86 "https://nodejs.org/dist/v0.9.5/node-v0.9.5-darwin-x86.tar.gz#0a7aba386032fae9b47a4cd7ee6196c0febc227aac50e47cb7b71b837e53a1fe"
 binary linux-x64 "https://nodejs.org/dist/v0.9.5/node-v0.9.5-linux-x64.tar.gz#e6a28d6946bd15132b6af44e00e91c15b7fabfb66713189449b71b2ccf2a3123"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.5/node-v0.9.5-linux-x86.tar.gz#62
 binary sunos-x64 "https://nodejs.org/dist/v0.9.5/node-v0.9.5-sunos-x64.tar.gz#c4cf7cedcf151b263a9adca424deba0d21312dc61ac654ec5b77ff277dca1844"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.5/node-v0.9.5-sunos-x86.tar.gz#1750c8713ac29814a09d470156029e1841b3bc6d210a5d3bdfebf06b6104ae4b"
 
-install_package "node-v0.9.5" "https://nodejs.org/dist/v0.9.5/node-v0.9.5.tar.gz#0235bffe94b6e1fca312436e6b8cf62e6d35fe02c752d0c57e4af9ae63e021d1" warn_eol
+install_package "node-v0.9.5" "https://nodejs.org/dist/v0.9.5/node-v0.9.5.tar.gz#0235bffe94b6e1fca312436e6b8cf62e6d35fe02c752d0c57e4af9ae63e021d1"

--- a/share/node-build/0.9.6
+++ b/share/node-build/0.9.6
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.9.6/node-v0.9.6-darwin-x64.tar.gz#e069593a5a97a390ce32443cdd4a385424281a1bbb1b72382763c5ac9834c70b"
 binary darwin-x86 "https://nodejs.org/dist/v0.9.6/node-v0.9.6-darwin-x86.tar.gz#0d7f55021174c1e82e43ac2267ea2ead7b121d07229a69b11f18f960ccea986e"
 binary linux-x64 "https://nodejs.org/dist/v0.9.6/node-v0.9.6-linux-x64.tar.gz#739e20d6bc3fefe50b07dd01fa524389b846b6b6caa31a1b2e1ca0246d8f7c56"
@@ -5,4 +9,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.6/node-v0.9.6-linux-x86.tar.gz#cc
 binary sunos-x64 "https://nodejs.org/dist/v0.9.6/node-v0.9.6-sunos-x64.tar.gz#d9bf25de31b127535f98b109a0481f1c1fcae97aca783b2f3b457205784adbd3"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.6/node-v0.9.6-sunos-x86.tar.gz#2d36b537597f0c20ab95a14b244c9093e8949c71c522f361bd48f6e97f2d1a0a"
 
-install_package "node-v0.9.6" "https://nodejs.org/dist/v0.9.6/node-v0.9.6.tar.gz#e314c69555a53241eb809132b8d76b6843d44b7f8afb68cf2f60fcf86e05c916" warn_eol
+install_package "node-v0.9.6" "https://nodejs.org/dist/v0.9.6/node-v0.9.6.tar.gz#e314c69555a53241eb809132b8d76b6843d44b7f8afb68cf2f60fcf86e05c916"

--- a/share/node-build/0.9.7
+++ b/share/node-build/0.9.7
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.9.7/node-v0.9.7-darwin-x64.tar.gz#c7904122355d9756a72c8a49ecf5c3bc23d76d319b25c18616a9c611179aea17"
 binary darwin-x86 "https://nodejs.org/dist/v0.9.7/node-v0.9.7-darwin-x86.tar.gz#489691e519c60ca428c7613c242fba8b273d0ccddeb5862c01cd16361956a364"
 binary linux-arm-pi "https://nodejs.org/dist/v0.9.7/node-v0.9.7-linux-arm-pi.tar.gz#344d59cb2a92b2bbf95c727baa1bd4a70f9930785d7be8b1ca3cbd49e44a0cb4"
@@ -6,4 +10,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.7/node-v0.9.7-linux-x86.tar.gz#bf
 binary sunos-x64 "https://nodejs.org/dist/v0.9.7/node-v0.9.7-sunos-x64.tar.gz#a5eb8ccf2dae8cc5d532f244ee28621f52535891e321313a9b0afd8f4d6cc737"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.7/node-v0.9.7-sunos-x86.tar.gz#7533414da857d30e3cd9747b0dfc769fb34c393af80b0935f0877a4bcc6e29ad"
 
-install_package "node-v0.9.7" "https://nodejs.org/dist/v0.9.7/node-v0.9.7.tar.gz#c05fe0a304d3a7edc2ace4a9ce8e4c37d29332d908d8b578b075d2ac2c2b71b8" warn_eol
+install_package "node-v0.9.7" "https://nodejs.org/dist/v0.9.7/node-v0.9.7.tar.gz#c05fe0a304d3a7edc2ace4a9ce8e4c37d29332d908d8b578b075d2ac2c2b71b8"

--- a/share/node-build/0.9.8
+++ b/share/node-build/0.9.8
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.9.8/node-v0.9.8-darwin-x64.tar.gz#370fbeb63a187b6519464d2f7f2ac0f808ea7fe9810dcc74545365488e5627b4"
 binary darwin-x86 "https://nodejs.org/dist/v0.9.8/node-v0.9.8-darwin-x86.tar.gz#aacd484f35b828266697824053ad8ec8d6316cf4054ca5a53e26ee9c87581789"
 binary linux-arm-pi "https://nodejs.org/dist/v0.9.8/node-v0.9.8-linux-arm-pi.tar.gz#d163a85689e3e62cfcb5ab5e083b485441178933cecae93fb76229d20b6d84f2"
@@ -6,4 +10,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.8/node-v0.9.8-linux-x86.tar.gz#c2
 binary sunos-x64 "https://nodejs.org/dist/v0.9.8/node-v0.9.8-sunos-x64.tar.gz#654dd17df28a6ac7704c7b977cf906580153830553dd8a2ed684b3b70cbcf732"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.8/node-v0.9.8-sunos-x86.tar.gz#2d767fa5502e4b24ba85feb32f6918833a4654b7b2d0236cbf9e039dc2c5a145"
 
-install_package "node-v0.9.8" "https://nodejs.org/dist/v0.9.8/node-v0.9.8.tar.gz#b7ad7d9f02d5eaca73a288a261578965c67d3847c2392ee09527acf72549b2e5" warn_eol
+install_package "node-v0.9.8" "https://nodejs.org/dist/v0.9.8/node-v0.9.8.tar.gz#b7ad7d9f02d5eaca73a288a261578965c67d3847c2392ee09527acf72549b2e5"

--- a/share/node-build/0.9.9
+++ b/share/node-build/0.9.9
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v0.9.9/node-v0.9.9-darwin-x64.tar.gz#e1a886746b4afa453e08505284d0c11c765299651135fa11d01b0ffb3493e2fc"
 binary darwin-x86 "https://nodejs.org/dist/v0.9.9/node-v0.9.9-darwin-x86.tar.gz#771cd29b2e9c026567bd10196636908404589d95a83565026f1b9871d5719ea1"
 binary linux-arm-pi "https://nodejs.org/dist/v0.9.9/node-v0.9.9-linux-arm-pi.tar.gz#af4250daf3d05a1511c76748c42d40a888ac96bb48e79e219b2e3cbeac17dec5"
@@ -6,4 +10,4 @@ binary linux-x86 "https://nodejs.org/dist/v0.9.9/node-v0.9.9-linux-x86.tar.gz#aa
 binary sunos-x64 "https://nodejs.org/dist/v0.9.9/node-v0.9.9-sunos-x64.tar.gz#5c74ea6c3c07cb8e7b447c8a6f03b32dff81139d34610bffe651cbd38f8c60fc"
 binary sunos-x86 "https://nodejs.org/dist/v0.9.9/node-v0.9.9-sunos-x86.tar.gz#492feecab9ed2062ce645027229a8fb05de29a71382afa6ac4fb792342fb234b"
 
-install_package "node-v0.9.9" "https://nodejs.org/dist/v0.9.9/node-v0.9.9.tar.gz#d285559044db3e340ab6403d7508943fbec4cc166f1ad96a00ac441794ce8a88" warn_eol
+install_package "node-v0.9.9" "https://nodejs.org/dist/v0.9.9/node-v0.9.9.tar.gz#d285559044db3e340ab6403d7508943fbec4cc166f1ad96a00ac441794ce8a88"

--- a/share/node-build/5.0.0
+++ b/share/node-build/5.0.0
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v5.0.0/node-v5.0.0-darwin-x64.tar.gz#26f3e42df814b9b42f0b0045901c84eb79233d8196d0dcdf77a6a3c975c6f25d"
 binary linux-arm64 "https://nodejs.org/dist/v5.0.0/node-v5.0.0-linux-arm64.tar.gz#2c4517d3fdefc29b5c61aa6ea3386a0dafca831357d3bcd30fc14e97b49139d1"
 binary linux-armv6l "https://nodejs.org/dist/v5.0.0/node-v5.0.0-linux-armv6l.tar.gz#96629e271e34d14bdb7be93067a8770cb5326977b9168cf2344c80a721040784"

--- a/share/node-build/5.1.0
+++ b/share/node-build/5.1.0
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v5.1.0/node-v5.1.0-darwin-x64.tar.gz#4752961731e579a26dd45d765f76e67f70683b0026c0035fc4c30d70c7baf4f0"
 binary linux-arm64 "https://nodejs.org/dist/v5.1.0/node-v5.1.0-linux-arm64.tar.gz#8e6eb18b4499c4c509b4132d3393121a7d344d4053400798614c843977696ff3"
 binary linux-armv6l "https://nodejs.org/dist/v5.1.0/node-v5.1.0-linux-armv6l.tar.gz#a6a64bf9d2e6b792505841b187eeb1c3ac971551840dab2a9a4a4719d1e7d150"

--- a/share/node-build/5.1.1
+++ b/share/node-build/5.1.1
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v5.1.1/node-v5.1.1-darwin-x64.tar.gz#cb6c831e7c3a8432a14a0e4ddb2000295c0166abce06b2d50134cc2cccb2dc9c"
 binary linux-arm64 "https://nodejs.org/dist/v5.1.1/node-v5.1.1-linux-arm64.tar.gz#1723abf50ee9b2b2209af06374523ae657c5562166bdc44b7b8d32801484c572"
 binary linux-armv6l "https://nodejs.org/dist/v5.1.1/node-v5.1.1-linux-armv6l.tar.gz#e7b154a5f7574155df5e3b5df90af762ab0edde128e36eeac0bd8ba2a8f00697"

--- a/share/node-build/5.10.0
+++ b/share/node-build/5.10.0
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v5.10.0/node-v5.10.0-darwin-x64.tar.gz#00407892416649f7567cc20ae6f0c091650dee6186fe58eb33d2bd886f276799"
 binary linux-arm64 "https://nodejs.org/dist/v5.10.0/node-v5.10.0-linux-arm64.tar.gz#df88803bda234b32240906b620315c8f6d6200332047a88cb0ec83009cf25dd5"
 binary linux-armv6l "https://nodejs.org/dist/v5.10.0/node-v5.10.0-linux-armv6l.tar.gz#019a257faa5eebf6304686dfeffdbcb4c22f0547aa366f6e563aad39ab1b1ab1"

--- a/share/node-build/5.10.1
+++ b/share/node-build/5.10.1
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v5.10.1/node-v5.10.1-darwin-x64.tar.gz#00ffc5c662580e1a5062a8740a9b9a40dbf7dadb5c8aa16bdf0ed33c7c1dfbfb"
 binary linux-arm64 "https://nodejs.org/dist/v5.10.1/node-v5.10.1-linux-arm64.tar.gz#98e4f003818968d5b9bcf17c921d33a5e3d6866be63d80510ae7ff8877e817db"
 binary linux-armv6l "https://nodejs.org/dist/v5.10.1/node-v5.10.1-linux-armv6l.tar.gz#5d6f652ce962a0fb59edf5e305af3a7e9147489ebb90a1244f3fa67d86fcf54b"

--- a/share/node-build/5.11.0
+++ b/share/node-build/5.11.0
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v5.11.0/node-v5.11.0-darwin-x64.tar.gz#4992e1ba18cdac51383a089b1494131dbca465a5328938dbd4835cbf780f7ecc"
 binary linux-arm64 "https://nodejs.org/dist/v5.11.0/node-v5.11.0-linux-arm64.tar.gz#b6cc0dd471f07b607367b76a3f2ec1f11d9bc05f2fccbcda7b85ce76d31a3e2a"
 binary linux-armv6l "https://nodejs.org/dist/v5.11.0/node-v5.11.0-linux-armv6l.tar.gz#6bf29cbf6d78e95a895bfb77774fde49fc3a565d601320b91b7ed5849f01a08d"

--- a/share/node-build/5.11.1
+++ b/share/node-build/5.11.1
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v5.11.1/node-v5.11.1-darwin-x64.tar.gz#7a992f61dc535c696ba2e236e3664ba669680f7e1a204e42166412cc3476503a"
 binary linux-arm64 "https://nodejs.org/dist/v5.11.1/node-v5.11.1-linux-arm64.tar.gz#8df5fa56ea1f79efc6f8baa9a6784bb1b0596fb7ef1d631694e35a89b3840de6"
 binary linux-armv6l "https://nodejs.org/dist/v5.11.1/node-v5.11.1-linux-armv6l.tar.gz#d6ffd43fd0546a5830117bb76979f074a04f9f2323bfc786ca5bd25f254149bc"

--- a/share/node-build/5.12.0
+++ b/share/node-build/5.12.0
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v5.12.0/node-v5.12.0-darwin-x64.tar.gz#bcbfb16896d4b13e08184343420ab00822e9ef09a72f9dbc41ef0cfcc84b99c2"
 binary linux-arm64 "https://nodejs.org/dist/v5.12.0/node-v5.12.0-linux-arm64.tar.gz#db02351d2c205a3c60218f937a41a8b8d665f326e7dfa263954ab39f8a8a2bc3"
 binary linux-armv6l "https://nodejs.org/dist/v5.12.0/node-v5.12.0-linux-armv6l.tar.gz#f58b9db77eb82830157f814704e8c3b3ba3420079a8ded3ad39302a33e3a30af"

--- a/share/node-build/5.2.0
+++ b/share/node-build/5.2.0
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v5.2.0/node-v5.2.0-darwin-x64.tar.gz#e3d690b8a1f3aae3caaa57d931aac5ace7dbdea7237d3e9413041c30feecb4e0"
 binary linux-arm64 "https://nodejs.org/dist/v5.2.0/node-v5.2.0-linux-arm64.tar.gz#3517d9ba80217985cac970272d387f4a905f17e5b87a7c7243efcc1173751531"
 binary linux-armv6l "https://nodejs.org/dist/v5.2.0/node-v5.2.0-linux-armv6l.tar.gz#c3f2c2d3105e66d2d895711defb53becc5f8fddde177cd5cc2d981f6d9a5bd4b"

--- a/share/node-build/5.3.0
+++ b/share/node-build/5.3.0
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v5.3.0/node-v5.3.0-darwin-x64.tar.gz#bfb28ff6a02a6bcb3a77afcb66054dcf44b50e1ccdbeca807865c6220c380b6b"
 binary linux-arm64 "https://nodejs.org/dist/v5.3.0/node-v5.3.0-linux-arm64.tar.gz#0a37c919cb2e2511ee7ff60e4fc80266afa3dad7cffa9204dc73da244c3a308a"
 binary linux-armv6l "https://nodejs.org/dist/v5.3.0/node-v5.3.0-linux-armv6l.tar.gz#266bedf9f8777c98abd0f28b41b0bb2b0b3d5be888bcfb899bf46fd986188172"

--- a/share/node-build/5.4.0
+++ b/share/node-build/5.4.0
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v5.4.0/node-v5.4.0-darwin-x64.tar.gz#efc7422f46ff2c9961ea984ced72b74f9c6c2e4e73f51ad83ff35c63835323f9"
 binary linux-arm64 "https://nodejs.org/dist/v5.4.0/node-v5.4.0-linux-arm64.tar.gz#0cb2c093e75090281423a2b3681629c663c83dac4587a12b77022afccd7aedc0"
 binary linux-armv6l "https://nodejs.org/dist/v5.4.0/node-v5.4.0-linux-armv6l.tar.gz#108e6314f0b88ab6fdebe85885797a59dbfd7c4857f2976ce5b98c981162e01b"

--- a/share/node-build/5.4.1
+++ b/share/node-build/5.4.1
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v5.4.1/node-v5.4.1-darwin-x64.tar.gz#c523472a5972823e8b6baf2419f837885321c772612ec508a65614c758e25a46"
 binary linux-arm64 "https://nodejs.org/dist/v5.4.1/node-v5.4.1-linux-arm64.tar.gz#362ae4539b6be075b6757ba689f0ae522cfc9340c81061aca880f92fce9595c7"
 binary linux-armv6l "https://nodejs.org/dist/v5.4.1/node-v5.4.1-linux-armv6l.tar.gz#21617e86758f1f95a3b9444be965aa87907410d786529cfd6aa2169ab7b5e15b"

--- a/share/node-build/5.5.0
+++ b/share/node-build/5.5.0
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v5.5.0/node-v5.5.0-darwin-x64.tar.gz#d4fd29e2d501963235104fc715fb0b55b302a40b605f432c456069606b939a46"
 binary linux-arm64 "https://nodejs.org/dist/v5.5.0/node-v5.5.0-linux-arm64.tar.gz#a9ebfce36675cc8d5e1bea6fa57de7fd80e8016f5957340831fcd03560e59845"
 binary linux-armv6l "https://nodejs.org/dist/v5.5.0/node-v5.5.0-linux-armv6l.tar.gz#a156dfda7fa00ac7ea86ac3cff8d445c44bcec3c677db375776a0489ad7155bd"

--- a/share/node-build/5.6.0
+++ b/share/node-build/5.6.0
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v5.6.0/node-v5.6.0-darwin-x64.tar.gz#1ef8f5b627cf980b0d242d5b70be3c6fbefc8e61ecfcaf97930965d68c927bd9"
 binary linux-arm64 "https://nodejs.org/dist/v5.6.0/node-v5.6.0-linux-arm64.tar.gz#3b22bb5e1579d6e45f31da88c17baeb17a12ecb297c1c69447de6030d626b08d"
 binary linux-armv6l "https://nodejs.org/dist/v5.6.0/node-v5.6.0-linux-armv6l.tar.gz#5df9773a946ac571dad2bbec0d5a9e05201ea16c6512731b36018ffc9d06f902"

--- a/share/node-build/5.7.0
+++ b/share/node-build/5.7.0
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v5.7.0/node-v5.7.0-darwin-x64.tar.gz#a68a9d45527077e1e044a4036a9b0fc803faa46c97e30fed71b77a759b4fa2fe"
 binary linux-arm64 "https://nodejs.org/dist/v5.7.0/node-v5.7.0-linux-arm64.tar.gz#2b4de1cca92da4aaec0aec0bc767d7a60d8378e830987abc668176d9b6603ccd"
 binary linux-armv6l "https://nodejs.org/dist/v5.7.0/node-v5.7.0-linux-armv6l.tar.gz#844f6707f105f31096579c74ad9928c5a9cce85b2a245bb1d697c06e6a9b1ee8"

--- a/share/node-build/5.7.1
+++ b/share/node-build/5.7.1
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v5.7.1/node-v5.7.1-darwin-x64.tar.gz#25627633163e6ad47e62cd9aaab04e47707b51ecc5aaa05f35a2d6419dbe054c"
 binary linux-arm64 "https://nodejs.org/dist/v5.7.1/node-v5.7.1-linux-arm64.tar.gz#b075aa249eb1e00e1e84e6f5964d4f93c39aa6d817c25280bf885bfcf906c7fc"
 binary linux-armv6l "https://nodejs.org/dist/v5.7.1/node-v5.7.1-linux-armv6l.tar.gz#ddde92eb9b80e58efec88138fa7351e21000b22414ebff754c7ab38dedbab89f"

--- a/share/node-build/5.8.0
+++ b/share/node-build/5.8.0
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v5.8.0/node-v5.8.0-darwin-x64.tar.gz#8c16f21a1c8882ba5875d0da617c817aa5005e514bd460dbf32aaeb3ffa477fe"
 binary linux-arm64 "https://nodejs.org/dist/v5.8.0/node-v5.8.0-linux-arm64.tar.gz#0c2c0fa859c5be13cd1404f3fb14d37e38a67fb2fc075c7a37d4ae70374544bf"
 binary linux-armv6l "https://nodejs.org/dist/v5.8.0/node-v5.8.0-linux-armv6l.tar.gz#54c362af9bc80b9e283bee7807fb2b1e9207ac77e61207b13fcf9f9acecd293f"

--- a/share/node-build/5.9.0
+++ b/share/node-build/5.9.0
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v5.9.0/node-v5.9.0-darwin-x64.tar.gz#6417022026c30cfb1b8af92f1434c1b202548076ada636708e1874d8af78197b"
 binary linux-arm64 "https://nodejs.org/dist/v5.9.0/node-v5.9.0-linux-arm64.tar.gz#8ce0653a98a7507dc15bd7425154af1113685d054b6dee2c9701fed401feb12a"
 binary linux-armv6l "https://nodejs.org/dist/v5.9.0/node-v5.9.0-linux-armv6l.tar.gz#a69cc76e388b44a4c6de8007e0fad67f1308b32284894b4c483180c4aaf10cb4"

--- a/share/node-build/5.9.1
+++ b/share/node-build/5.9.1
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://nodejs.org/dist/v5.9.1/node-v5.9.1-darwin-x64.tar.gz#90dbbd2072582f0373a738114131112f3f8a2c7f7f64bbf4991a51d2808d4935"
 binary linux-arm64 "https://nodejs.org/dist/v5.9.1/node-v5.9.1-linux-arm64.tar.gz#09fd524d987e3c70aed7aa52d21f6448fe06cdd05c627a6de326384b98a3bb0e"
 binary linux-armv6l "https://nodejs.org/dist/v5.9.1/node-v5.9.1-linux-armv6l.tar.gz#755965b20e4fa991072e7bb07937bd3c075b689b10d21161bfb34037dd5c52b9"

--- a/share/node-build/5.x-next
+++ b/share/node-build/5.x-next
@@ -1,1 +1,5 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 install_git "5.x-next" "https://github.com/nodejs/node.git" "v5.x" standard

--- a/share/node-build/iojs-0.12.0-dev
+++ b/share/node-build/iojs-0.12.0-dev
@@ -1,1 +1,5 @@
-install_git "iojs-0.12.0-dev" "https://github.com/iojs/io.js.git" "v0.12" standard warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_git "iojs-0.12.0-dev" "https://github.com/iojs/io.js.git" "v0.12" standard

--- a/share/node-build/iojs-1.0.0
+++ b/share/node-build/iojs-1.0.0
@@ -1,6 +1,10 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v1.0.0/iojs-v1.0.0-darwin-x64.tar.gz#8d8083b07ea2d942f4f074a89d17795b0935993cf4bbb9850de7bcb7d141ead8"
 binary linux-armv7l "https://iojs.org/dist/v1.0.0/iojs-v1.0.0-linux-armv7l.tar.gz#b6f153b2ad223383f0c97a85de6ab604d84909edb95ea6d8f77de5d4ed2b091e"
 binary linux-x64 "https://iojs.org/dist/v1.0.0/iojs-v1.0.0-linux-x64.tar.gz#df5f5e68e820aac9366ade18db5eae947b8a6c9cc66bc0b461b32e99f66ce960"
 binary linux-x86 "https://iojs.org/dist/v1.0.0/iojs-v1.0.0-linux-x86.tar.gz#b1e9d197a1719a596c810b818f512b6ebbaf35f00f0f04f6c433e660bf511202"
 
-install_package "iojs-v1.0.0" "https://iojs.org/dist/v1.0.0/iojs-v1.0.0.tar.gz#dcc6ccd99fffa20ebe59b35acca51150cfd68171cbf36fee210b3f5480964d05" warn_eol
+install_package "iojs-v1.0.0" "https://iojs.org/dist/v1.0.0/iojs-v1.0.0.tar.gz#dcc6ccd99fffa20ebe59b35acca51150cfd68171cbf36fee210b3f5480964d05"

--- a/share/node-build/iojs-1.0.1
+++ b/share/node-build/iojs-1.0.1
@@ -1,6 +1,10 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v1.0.1/iojs-v1.0.1-darwin-x64.tar.gz#49b9cbf45066391b0fbfd410231ff13d3b6310eeaa89986453f646ed03ed54c7"
 binary linux-armv7l "https://iojs.org/dist/v1.0.1/iojs-v1.0.1-linux-armv7l.tar.gz#e2650236ae9a24528194a6f425c0583221018d30a9766d72971d938423446b58"
 binary linux-x64 "https://iojs.org/dist/v1.0.1/iojs-v1.0.1-linux-x64.tar.gz#77ba1aacc2bb79fac32abe5e348fb701ba4446e5ec5583842d59a415faeb1daa"
 binary linux-x86 "https://iojs.org/dist/v1.0.1/iojs-v1.0.1-linux-x86.tar.gz#6dae2ad4b00f6432ea0f24f93087db39e49fed3a9853b7e1c8a02f310c412436"
 
-install_package "iojs-v1.0.1" "https://iojs.org/dist/v1.0.1/iojs-v1.0.1.tar.gz#c26052dad5d9ccd8a7b9134806994ebf2d217a57d6efd5633e01c5cc1dcdedc5" warn_eol
+install_package "iojs-v1.0.1" "https://iojs.org/dist/v1.0.1/iojs-v1.0.1.tar.gz#c26052dad5d9ccd8a7b9134806994ebf2d217a57d6efd5633e01c5cc1dcdedc5"

--- a/share/node-build/iojs-1.0.2
+++ b/share/node-build/iojs-1.0.2
@@ -1,6 +1,10 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v1.0.2/iojs-v1.0.2-darwin-x64.tar.gz#fcca5777658371f7a098960e0520c06186cc472ca1b24bd4fba4f85eb40d8b44"
 binary linux-armv7l "https://iojs.org/dist/v1.0.2/iojs-v1.0.2-linux-armv7l.tar.gz#39899eaa4a25bd73d256c64e2b54b8849e53ebf797c14014ed2e73084fa59e53"
 binary linux-x64 "https://iojs.org/dist/v1.0.2/iojs-v1.0.2-linux-x64.tar.gz#e379bbbc385dd63f07a14f6d025a9dd45181081b2b4eec59524e3591493d6b57"
 binary linux-x86 "https://iojs.org/dist/v1.0.2/iojs-v1.0.2-linux-x86.tar.gz#5cf3f1cd6e87201594ac89e4feddca10a8349a91a054eedec68380e3a74c5d46"
 
-install_package "iojs-v1.0.2" "https://iojs.org/dist/v1.0.2/iojs-v1.0.2.tar.gz#39fa602bf8dda874682d9c0380311de3295997c0b674b5e8aec0b988912cd9d1" warn_eol
+install_package "iojs-v1.0.2" "https://iojs.org/dist/v1.0.2/iojs-v1.0.2.tar.gz#39fa602bf8dda874682d9c0380311de3295997c0b674b5e8aec0b988912cd9d1"

--- a/share/node-build/iojs-1.0.3
+++ b/share/node-build/iojs-1.0.3
@@ -1,6 +1,10 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v1.0.3/iojs-v1.0.3-darwin-x64.tar.gz#f390aeb7e5dc553c96afb498c613e8873f1c7a14f7e3f3c2a48e0141aa57eeb1"
 binary linux-armv7l "https://iojs.org/dist/v1.0.3/iojs-v1.0.3-linux-armv7l.tar.gz#36ca00c27b025469554ee5c866ada1775896951b04248d5b06ca24ba55f10c97"
 binary linux-x64 "https://iojs.org/dist/v1.0.3/iojs-v1.0.3-linux-x64.tar.gz#047b75b518767f0983c8159c9bb9a2939a214964ee127890e590af63f9082839"
 binary linux-x86 "https://iojs.org/dist/v1.0.3/iojs-v1.0.3-linux-x86.tar.gz#7c2d64056b430ebfc46a4f14039d21c1f7fb3fc0c8932eb9da94820e1fee4d1b"
 
-install_package "iojs-v1.0.3" "https://iojs.org/dist/v1.0.3/iojs-v1.0.3.tar.gz#c7fe7f71d9920f4cfd930f9022c7dddca7e11a0377fed1ee23e3241c2952db42" warn_eol
+install_package "iojs-v1.0.3" "https://iojs.org/dist/v1.0.3/iojs-v1.0.3.tar.gz#c7fe7f71d9920f4cfd930f9022c7dddca7e11a0377fed1ee23e3241c2952db42"

--- a/share/node-build/iojs-1.0.4
+++ b/share/node-build/iojs-1.0.4
@@ -1,6 +1,10 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v1.0.4/iojs-v1.0.4-darwin-x64.tar.gz#00c1709c029c9b055157e8fc6ac6551dd0824473c68eda18ff2b83479763e082"
 binary linux-armv7l "https://iojs.org/dist/v1.0.4/iojs-v1.0.4-linux-armv7l.tar.gz#7b69b8e97253ceb8e3a6fe8cdd449e290ac7aa05480f5629d5930dd5c5c1f8ad"
 binary linux-x64 "https://iojs.org/dist/v1.0.4/iojs-v1.0.4-linux-x64.tar.gz#9b147d4c1d8ff2c89bb1182bd145334b469ee3c71d845b99cf3b35c9c0c5652f"
 binary linux-x86 "https://iojs.org/dist/v1.0.4/iojs-v1.0.4-linux-x86.tar.gz#a532f61d882fed334662186c4d2d017c82de10b6558673823b093daca406624c"
 
-install_package "iojs-v1.0.4" "https://iojs.org/dist/v1.0.4/iojs-v1.0.4.tar.gz#59f4d34eafe70b1e96efba7491556db9ec449e5774352885a73ff41bad7c2965" warn_eol
+install_package "iojs-v1.0.4" "https://iojs.org/dist/v1.0.4/iojs-v1.0.4.tar.gz#59f4d34eafe70b1e96efba7491556db9ec449e5774352885a73ff41bad7c2965"

--- a/share/node-build/iojs-1.1.0
+++ b/share/node-build/iojs-1.1.0
@@ -1,6 +1,10 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v1.1.0/iojs-v1.1.0-darwin-x64.tar.gz#469eceab1f6ceaaddaa8c577b81db61af79b1752251b484fa44ef46ca2597ca9"
 binary linux-armv7l "https://iojs.org/dist/v1.1.0/iojs-v1.1.0-linux-armv7l.tar.gz#1456a04d7e41af3aaf792ee2ee2c8cd570fbbe440822df6b75a4dad845b199ef"
 binary linux-x64 "https://iojs.org/dist/v1.1.0/iojs-v1.1.0-linux-x64.tar.gz#a80baa514c0758fc5ccfa59d5b734de5cb52b15b09a2c1e38c8dabb860ad3420"
 binary linux-x86 "https://iojs.org/dist/v1.1.0/iojs-v1.1.0-linux-x86.tar.gz#e150da87d109095a0217627beac572388941c412723796ac5839c784a285d733"
 
-install_package "iojs-v1.1.0" "https://iojs.org/dist/v1.1.0/iojs-v1.1.0.tar.gz#f0b8a8db1bf434eaebf4d6a7fcfd6adeaf85ab22f410f202b37a9c76781e7f7b" warn_eol
+install_package "iojs-v1.1.0" "https://iojs.org/dist/v1.1.0/iojs-v1.1.0.tar.gz#f0b8a8db1bf434eaebf4d6a7fcfd6adeaf85ab22f410f202b37a9c76781e7f7b"

--- a/share/node-build/iojs-1.2.0
+++ b/share/node-build/iojs-1.2.0
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v1.2.0/iojs-v1.2.0-darwin-x64.tar.gz#07fcc65f3c6e7ecd45f9139c67c5c904226247f6f9da57b88478153b8db21d63"
 binary linux-armv6l "https://iojs.org/dist/v1.2.0/iojs-v1.2.0-linux-armv6l.tar.gz#05c2c7a47aaafb49e88e9995e1d3c459f22c25c6fd8fa4ff388b43531bb25ba1"
 binary linux-armv7l "https://iojs.org/dist/v1.2.0/iojs-v1.2.0-linux-armv7l.tar.gz#7b5fed30f19b3f11f3abdf37e47df17daee28d51f5a4fad7ff268a6d3f030581"
 binary linux-x64 "https://iojs.org/dist/v1.2.0/iojs-v1.2.0-linux-x64.tar.gz#bf475addb9e549f7005d61c13acdbefcf1e8e0fc60c73448c9baedc9795910fa"
 binary linux-x86 "https://iojs.org/dist/v1.2.0/iojs-v1.2.0-linux-x86.tar.gz#4d2d9a158fb4aff30dd3b7c354d084d95b7ba43fc3bb7dfd77284934e390ef85"
 
-install_package "iojs-v1.2.0" "https://iojs.org/dist/v1.2.0/iojs-v1.2.0.tar.gz#33666fce914ca57ef60e2e29d7b02cd64c99a8609287a9227da2087ab9c65d9d" warn_eol
+install_package "iojs-v1.2.0" "https://iojs.org/dist/v1.2.0/iojs-v1.2.0.tar.gz#33666fce914ca57ef60e2e29d7b02cd64c99a8609287a9227da2087ab9c65d9d"

--- a/share/node-build/iojs-1.3.0
+++ b/share/node-build/iojs-1.3.0
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v1.3.0/iojs-v1.3.0-darwin-x64.tar.gz#00c45575b8ce578434038655daf09903361edf5c96858e2581647f349e14a8cd"
 binary linux-armv6l "https://iojs.org/dist/v1.3.0/iojs-v1.3.0-linux-armv6l.tar.gz#d4bfcbb8e74956e1ec06c03b6b4c9b58b5b16c54e6dd4ebe58e1f7c0dd12e207"
 binary linux-armv7l "https://iojs.org/dist/v1.3.0/iojs-v1.3.0-linux-armv7l.tar.gz#7c7d7ceeea9f989c2a6c00e510329956c12a25e934b6572763c7420ee728dcf8"
 binary linux-x64 "https://iojs.org/dist/v1.3.0/iojs-v1.3.0-linux-x64.tar.gz#3fa309fce40a9ad94a612c91443034456d6e109e4e63a039f72e3ea5fc31e592"
 binary linux-x86 "https://iojs.org/dist/v1.3.0/iojs-v1.3.0-linux-x86.tar.gz#3c747f9af20824a085967042055032838acf100e35d4a90a68e67bb478aff2e7"
 
-install_package "iojs-v1.3.0" "https://iojs.org/dist/v1.3.0/iojs-v1.3.0.tar.gz#eb652fb854274e04b4a309b1b8cd4d5bb3eb45882e9442bacb129d247e9de021" warn_eol
+install_package "iojs-v1.3.0" "https://iojs.org/dist/v1.3.0/iojs-v1.3.0.tar.gz#eb652fb854274e04b4a309b1b8cd4d5bb3eb45882e9442bacb129d247e9de021"

--- a/share/node-build/iojs-1.4.1
+++ b/share/node-build/iojs-1.4.1
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v1.4.1/iojs-v1.4.1-darwin-x64.tar.gz#d0a47ab3e309fc62fa3b25c556b5c03cb27fb48a3057a90d5f0d33edba94331e"
 binary linux-armv6l "https://iojs.org/dist/v1.4.1/iojs-v1.4.1-linux-armv6l.tar.gz#4e9793867de0367deef178f7155316ecbd78056a5f5f822680d018689e5e513f"
 binary linux-armv7l "https://iojs.org/dist/v1.4.1/iojs-v1.4.1-linux-armv7l.tar.gz#dcb97564bb85aa041ccecfa3ca5a35f3b8150a1fdcd15824b00d58cb969741e5"
 binary linux-x64 "https://iojs.org/dist/v1.4.1/iojs-v1.4.1-linux-x64.tar.gz#846ca8ed78d63926a5f75e46653d173f1773241a43b65c0148eb492248a5efd2"
 binary linux-x86 "https://iojs.org/dist/v1.4.1/iojs-v1.4.1-linux-x86.tar.gz#5029ebe7eb1b446ff234d1d7f414a2479ce0b50ec421d2800aa67b7f22132a3c"
 
-install_package "iojs-v1.4.1" "https://iojs.org/dist/v1.4.1/iojs-v1.4.1.tar.gz#da7bbb2ec8d0980ddbfca9d6de2ba5e9d5b57b41f6ef50140da746577fc98c34" warn_eol
+install_package "iojs-v1.4.1" "https://iojs.org/dist/v1.4.1/iojs-v1.4.1.tar.gz#da7bbb2ec8d0980ddbfca9d6de2ba5e9d5b57b41f6ef50140da746577fc98c34"

--- a/share/node-build/iojs-1.4.2
+++ b/share/node-build/iojs-1.4.2
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v1.4.2/iojs-v1.4.2-darwin-x64.tar.gz#baaa255025eedbba9034ee72d913f980841db4553f256bfdc119d3e8b6bd1899"
 binary linux-armv6l "https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-armv6l.tar.gz#122876ea968708ebf1a0afa053c0665d0d53a287baca6712c9e5f512a1be0a98"
 binary linux-armv7l "https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-armv7l.tar.gz#c6bec020e84241e818cae55d0d8c2bf9eb6ef7006ec9c73067327eaba2fc750b"
 binary linux-x64 "https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x64.tar.gz#99e6ea760fea597caab3c198d4990ead8d7efb319ebea300f5b780bf53c72b9e"
 binary linux-x86 "https://iojs.org/dist/v1.4.2/iojs-v1.4.2-linux-x86.tar.gz#19a257b7a1490ebe1080bf24fa391113f0db1bee56e7c2bb6a9956e7e2f007c4"
 
-install_package "iojs-v1.4.2" "https://iojs.org/dist/v1.4.2/iojs-v1.4.2.tar.gz#943ea794e045ec47c8a1514c58f70be660a7a5c351601c557a86126f6827fa37" warn_eol
+install_package "iojs-v1.4.2" "https://iojs.org/dist/v1.4.2/iojs-v1.4.2.tar.gz#943ea794e045ec47c8a1514c58f70be660a7a5c351601c557a86126f6827fa37"

--- a/share/node-build/iojs-1.4.3
+++ b/share/node-build/iojs-1.4.3
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v1.4.3/iojs-v1.4.3-darwin-x64.tar.gz#9edd68ff04e7eb3043dc0b0508dcd3fa32c38926315e3221391701f899197e5d"
 binary linux-armv6l "https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-armv6l.tar.gz#a5849089cf7d2e94ef6af2b943a4516dc727261f33b97b7b3f0da487c7ed7d4c"
 binary linux-armv7l "https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-armv7l.tar.gz#3b145fb05bd8d7d284e31cfb3fc6f883aa328cfe13390874c664b33dfbe71be6"
 binary linux-x64 "https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x64.tar.gz#b66b09d58dd58c1382de842e74e951dbd75ccf3475425ef147e7b13db644704e"
 binary linux-x86 "https://iojs.org/dist/v1.4.3/iojs-v1.4.3-linux-x86.tar.gz#37b81e75b04efcf3fe56cd22dcbff9f7513234be645d7f4af5ff4c2ed58a418f"
 
-install_package "iojs-v1.4.3" "https://iojs.org/dist/v1.4.3/iojs-v1.4.3.tar.gz#86f89147606311a159dcb3d110f5e3b55fc614d1577b7cbe25d27df16b4e33b0" warn_eol
+install_package "iojs-v1.4.3" "https://iojs.org/dist/v1.4.3/iojs-v1.4.3.tar.gz#86f89147606311a159dcb3d110f5e3b55fc614d1577b7cbe25d27df16b4e33b0"

--- a/share/node-build/iojs-1.5.0
+++ b/share/node-build/iojs-1.5.0
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v1.5.0/iojs-v1.5.0-darwin-x64.tar.gz#2942d66bf1c7ad85095038c4d5b411c8453fcbf31bd1a18393bbb8690edadce5"
 binary linux-armv6l "https://iojs.org/dist/v1.5.0/iojs-v1.5.0-linux-armv6l.tar.gz#c6330c0c49f4dcbb9f35b76b239e8fc978a5e50f3b4faf3af1e283090ea657e4"
 binary linux-armv7l "https://iojs.org/dist/v1.5.0/iojs-v1.5.0-linux-armv7l.tar.gz#39785bdc23f89895ef18c53d9fa4bca0ee4b8490c3d607daf0950c68067a48b8"
 binary linux-x64 "https://iojs.org/dist/v1.5.0/iojs-v1.5.0-linux-x64.tar.gz#3f88989f5613adcc7451bf3ce7467063a6d81c94ed88221ca081c37f12ee183d"
 binary linux-x86 "https://iojs.org/dist/v1.5.0/iojs-v1.5.0-linux-x86.tar.gz#2ce1d22367bc9d3918e6ddd70aa5e3e8bc9148b3d47f3c21628a8b2e9f3071fb"
 
-install_package "iojs-v1.5.0" "https://iojs.org/dist/v1.5.0/iojs-v1.5.0.tar.gz#83fc43cff80ebbbcb670110037fb2999202b00398ad5c63c7e76a8080b6a3b8a" warn_eol
+install_package "iojs-v1.5.0" "https://iojs.org/dist/v1.5.0/iojs-v1.5.0.tar.gz#83fc43cff80ebbbcb670110037fb2999202b00398ad5c63c7e76a8080b6a3b8a"

--- a/share/node-build/iojs-1.5.1
+++ b/share/node-build/iojs-1.5.1
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v1.5.1/iojs-v1.5.1-darwin-x64.tar.gz#eaa122694f160a11a91b1c54446846e71262a51d23af9a0534e447dd9a7bdc84"
 binary linux-armv6l "https://iojs.org/dist/v1.5.1/iojs-v1.5.1-linux-armv6l.tar.gz#81c431b34191c855ceeb89d6b305b6997785fad4f94173e0d9defa4eda942f90"
 binary linux-armv7l "https://iojs.org/dist/v1.5.1/iojs-v1.5.1-linux-armv7l.tar.gz#97f741fb81370eb5945cc5f49b56b1cb49d6278c6944b82223b2d4ac7578897b"
 binary linux-x64 "https://iojs.org/dist/v1.5.1/iojs-v1.5.1-linux-x64.tar.gz#1ec0b9ce05efacda642bc3e3d6c56dbe030b43e5e97ee1569b04d6a31d9f9bea"
 binary linux-x86 "https://iojs.org/dist/v1.5.1/iojs-v1.5.1-linux-x86.tar.gz#f52b56fdcf7b0c8d092a150d4aade96ffe5655941404d9f626e062b75c0d477b"
 
-install_package "iojs-v1.5.1" "https://iojs.org/dist/v1.5.1/iojs-v1.5.1.tar.gz#46e8a405392e6557b833f43229d19fc7d9bc8f9a6b7423cd6d667a60d36abd7d" warn_eol
+install_package "iojs-v1.5.1" "https://iojs.org/dist/v1.5.1/iojs-v1.5.1.tar.gz#46e8a405392e6557b833f43229d19fc7d9bc8f9a6b7423cd6d667a60d36abd7d"

--- a/share/node-build/iojs-1.6.0
+++ b/share/node-build/iojs-1.6.0
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v1.6.0/iojs-v1.6.0-darwin-x64.tar.gz#d56b7118eca39f984405f6568af53cc2ac5bd90d1f755035e4c4f8f36ed49732"
 binary linux-armv6l "https://iojs.org/dist/v1.6.0/iojs-v1.6.0-linux-armv6l.tar.gz#acd3e39ebde7df7e6caba00b8a0942bb16d7b85cb3f37d227b94eb3b05eb21e3"
 binary linux-armv7l "https://iojs.org/dist/v1.6.0/iojs-v1.6.0-linux-armv7l.tar.gz#587be80209b1dc516f10f46089a395952f5ff2746081e4c958f9e88e31928513"
 binary linux-x64 "https://iojs.org/dist/v1.6.0/iojs-v1.6.0-linux-x64.tar.gz#775b50ae89ea78e5225fb19be834b01db7109b964567140b09dc90a395d9d40e"
 binary linux-x86 "https://iojs.org/dist/v1.6.0/iojs-v1.6.0-linux-x86.tar.gz#843efa08130cdba711eaf351be05ff473d0a0bc5189a8c32bf61a1ddb41d6f1a"
 
-install_package "iojs-v1.6.0" "https://iojs.org/dist/v1.6.0/iojs-v1.6.0.tar.gz#da337d5fc915a54cc9def2eec9c97d2eefc0b50da45f553c4b15b9b5e24579df" warn_eol
+install_package "iojs-v1.6.0" "https://iojs.org/dist/v1.6.0/iojs-v1.6.0.tar.gz#da337d5fc915a54cc9def2eec9c97d2eefc0b50da45f553c4b15b9b5e24579df"

--- a/share/node-build/iojs-1.6.1
+++ b/share/node-build/iojs-1.6.1
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v1.6.1/iojs-v1.6.1-darwin-x64.tar.gz#14d4fd03f47c580b38a2b093c7c8daffefa815006d4acdc3d3a215c38cbefe9a"
 binary linux-armv6l "https://iojs.org/dist/v1.6.1/iojs-v1.6.1-linux-armv6l.tar.gz#b199ee32e8fed1590c16b692d5fb368988aa19f2ecea8bf47283a509f8eb3c94"
 binary linux-armv7l "https://iojs.org/dist/v1.6.1/iojs-v1.6.1-linux-armv7l.tar.gz#15dee8f9c672b6edfe2a1636ac4223bfac1a49cf6c39f0adacea7198b354aa16"
 binary linux-x64 "https://iojs.org/dist/v1.6.1/iojs-v1.6.1-linux-x64.tar.gz#6cf8f9cd065dc1d0fee5f1c77c5cd8bc71fc4a0b0854d06d7a97fe557aa71384"
 binary linux-x86 "https://iojs.org/dist/v1.6.1/iojs-v1.6.1-linux-x86.tar.gz#744d93fc17ab493ca05ba3b242e8e1ce1c4738e0f7828115979873b8840916d9"
 
-install_package "iojs-v1.6.1" "https://iojs.org/dist/v1.6.1/iojs-v1.6.1.tar.gz#1cd70dc07b9b38c27539b0202536caee31a8d63f45dd7945d9293cac5da30df2" warn_eol
+install_package "iojs-v1.6.1" "https://iojs.org/dist/v1.6.1/iojs-v1.6.1.tar.gz#1cd70dc07b9b38c27539b0202536caee31a8d63f45dd7945d9293cac5da30df2"

--- a/share/node-build/iojs-1.6.2
+++ b/share/node-build/iojs-1.6.2
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v1.6.2/iojs-v1.6.2-darwin-x64.tar.gz#d4b835463b41028b2f6ee97936d283412efc2b14f9d81836437efd4b11718690"
 binary linux-armv6l "https://iojs.org/dist/v1.6.2/iojs-v1.6.2-linux-armv6l.tar.gz#80ac234402360b613676df89febcad05a22cc14071ea7cee7d90b4610792fc77"
 binary linux-armv7l "https://iojs.org/dist/v1.6.2/iojs-v1.6.2-linux-armv7l.tar.gz#845399d756acc63dca567ac4871bb1b34a38a186bfffd69bf08f4bdf6817f3a5"
 binary linux-x64 "https://iojs.org/dist/v1.6.2/iojs-v1.6.2-linux-x64.tar.gz#1598b95cb6e1a4b664ea0a8fc69d0cf53e597bbd1164a94966fc3e34f63a7447"
 binary linux-x86 "https://iojs.org/dist/v1.6.2/iojs-v1.6.2-linux-x86.tar.gz#fc82c32221c48d1021b1bee5867bf8c54ae2d5914c7d1f8281be587ad4307576"
 
-install_package "iojs-v1.6.2" "https://iojs.org/dist/v1.6.2/iojs-v1.6.2.tar.gz#ea537c47a46a15fdae0eab884a7c8f947905bd0cadc3b0d3ca4dbc51fe4afb5f" warn_eol
+install_package "iojs-v1.6.2" "https://iojs.org/dist/v1.6.2/iojs-v1.6.2.tar.gz#ea537c47a46a15fdae0eab884a7c8f947905bd0cadc3b0d3ca4dbc51fe4afb5f"

--- a/share/node-build/iojs-1.6.3
+++ b/share/node-build/iojs-1.6.3
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v1.6.3/iojs-v1.6.3-darwin-x64.tar.gz#535655698736de5ceaa7522bcd2f0351dd0229bd52fb873409329de7721d1433"
 binary linux-armv6l "https://iojs.org/dist/v1.6.3/iojs-v1.6.3-linux-armv6l.tar.gz#ee58e0344b558c1ef85a05ff4ac3b8393b0f802a15c79c2c67f0d21bb4c11ca0"
 binary linux-armv7l "https://iojs.org/dist/v1.6.3/iojs-v1.6.3-linux-armv7l.tar.gz#b45e4ac7a363a4aab4930b68b036f514dd41bcb533ce202c7eed4a55da598b50"
 binary linux-x64 "https://iojs.org/dist/v1.6.3/iojs-v1.6.3-linux-x64.tar.gz#cf0b5308dc27118c607bc36478f99ab0be0cc5b13e80e4696fda0189810f00af"
 binary linux-x86 "https://iojs.org/dist/v1.6.3/iojs-v1.6.3-linux-x86.tar.gz#ff370875a5fc2c9ab03581c6f06b800f284377d0056f1ce2f4ba7e9d70774594"
 
-install_package "iojs-v1.6.3" "https://iojs.org/dist/v1.6.3/iojs-v1.6.3.tar.gz#7ab455fc96af90512325848e8c508c19a622a52b1371d233f1c8fa9c41e64660" warn_eol
+install_package "iojs-v1.6.3" "https://iojs.org/dist/v1.6.3/iojs-v1.6.3.tar.gz#7ab455fc96af90512325848e8c508c19a622a52b1371d233f1c8fa9c41e64660"

--- a/share/node-build/iojs-1.6.4
+++ b/share/node-build/iojs-1.6.4
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v1.6.4/iojs-v1.6.4-darwin-x64.tar.gz#736134fa946afce284a91d339dc93d3b31cf6e31b0e1b559de88c72df966fafd"
 binary linux-armv6l "https://iojs.org/dist/v1.6.4/iojs-v1.6.4-linux-armv6l.tar.gz#07e55fff5e078c7d317b460417a66e500339a321833d10c69f3723901257a921"
 binary linux-armv7l "https://iojs.org/dist/v1.6.4/iojs-v1.6.4-linux-armv7l.tar.gz#b46e550a8c844c1deb4c190a4fec7a66b92d0e2d3bb1dfd253728ff9e49d2dd8"
 binary linux-x64 "https://iojs.org/dist/v1.6.4/iojs-v1.6.4-linux-x64.tar.gz#932a577e53a014f5c1017da437db59a30f3283ae780ab4167374979d46854660"
 binary linux-x86 "https://iojs.org/dist/v1.6.4/iojs-v1.6.4-linux-x86.tar.gz#aef972d0e0fe4113fd0c39455159dfd50688818d571566792c274e854752c4c6"
 
-install_package "iojs-v1.6.4" "https://iojs.org/dist/v1.6.4/iojs-v1.6.4.tar.gz#875db123a05b3e0ebf2e7f6bb88c0d70275099bc970f61fbbfb79d42de71fbe3" warn_eol
+install_package "iojs-v1.6.4" "https://iojs.org/dist/v1.6.4/iojs-v1.6.4.tar.gz#875db123a05b3e0ebf2e7f6bb88c0d70275099bc970f61fbbfb79d42de71fbe3"

--- a/share/node-build/iojs-1.7.1
+++ b/share/node-build/iojs-1.7.1
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v1.7.1/iojs-v1.7.1-darwin-x64.tar.gz#00b1c1bc679aa909a6a2c1ea3b46155a7befe4006a6b5e0371bc957b234979df"
 binary linux-armv6l "https://iojs.org/dist/v1.7.1/iojs-v1.7.1-linux-armv6l.tar.gz#d1eab88be766742167d54a85f38b25899e4246de70139a54533e883c8a544564"
 binary linux-armv7l "https://iojs.org/dist/v1.7.1/iojs-v1.7.1-linux-armv7l.tar.gz#78035f0d19984d55de37f4f98d989b0ef1a0bbce2c9e1c1982c4b5bd87a94799"
 binary linux-x64 "https://iojs.org/dist/v1.7.1/iojs-v1.7.1-linux-x64.tar.gz#e6eca168d3735f164a2e79c8cb5d8b2bf3a8b42c86f43853b5028a210d62e77b"
 binary linux-x86 "https://iojs.org/dist/v1.7.1/iojs-v1.7.1-linux-x86.tar.gz#7b9460df57e093d411f47dacce2dc73a7eca7c37d72f36348e7d6265bdb568f7"
 
-install_package "iojs-v1.7.1" "https://iojs.org/dist/v1.7.1/iojs-v1.7.1.tar.gz#8f7c6927bbded5912d9bd3903e779b534ddc742ea3aa669859369263b179eff9" warn_eol
+install_package "iojs-v1.7.1" "https://iojs.org/dist/v1.7.1/iojs-v1.7.1.tar.gz#8f7c6927bbded5912d9bd3903e779b534ddc742ea3aa669859369263b179eff9"

--- a/share/node-build/iojs-1.8.1
+++ b/share/node-build/iojs-1.8.1
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v1.8.1/iojs-v1.8.1-darwin-x64.tar.gz#1d8b6b8fa3fccb9cefefb407a00b1c733ccee122285a7bb567b487030cf5cc5a"
 binary linux-armv6l "https://iojs.org/dist/v1.8.1/iojs-v1.8.1-linux-armv6l.tar.gz#01f6af1b426fe83d9bfbdbe072f0992df379360d601d73a9364b69506247a3ab"
 binary linux-armv7l "https://iojs.org/dist/v1.8.1/iojs-v1.8.1-linux-armv7l.tar.gz#aaf1f75f4abb56f97ff18080c880d67418cbb24c745616d3164b6072366f32ab"
 binary linux-x64 "https://iojs.org/dist/v1.8.1/iojs-v1.8.1-linux-x64.tar.gz#bc0d239487d08aefb0126cbdadce835fcf4f4efddbde8d122de89c0eeadc7e07"
 binary linux-x86 "https://iojs.org/dist/v1.8.1/iojs-v1.8.1-linux-x86.tar.gz#05968739ab978c7078cb7a209ad3f40647c5d1158f7dbe9957176ac4426d881d"
 
-install_package "iojs-v1.8.1" "https://iojs.org/dist/v1.8.1/iojs-v1.8.1.tar.gz#07d407b600cf1e7446d694338a595f1f265625b9f0b51c4366434a63bb70e11b" warn_eol
+install_package "iojs-v1.8.1" "https://iojs.org/dist/v1.8.1/iojs-v1.8.1.tar.gz#07d407b600cf1e7446d694338a595f1f265625b9f0b51c4366434a63bb70e11b"

--- a/share/node-build/iojs-1.8.2
+++ b/share/node-build/iojs-1.8.2
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v1.8.2/iojs-v1.8.2-darwin-x64.tar.gz#dcc66ef17fe385b36b728afcd7f52ddd467d0fbdab0aa59a504da1ee29c06f42"
 binary linux-armv6l "https://iojs.org/dist/v1.8.2/iojs-v1.8.2-linux-armv6l.tar.gz#bb9533c7382ee22d725fc4bf03d3cd98d1c45ba48964728d99f0fd299e72120f"
 binary linux-armv7l "https://iojs.org/dist/v1.8.2/iojs-v1.8.2-linux-armv7l.tar.gz#008122199f72ef1f7bf52ec7f3f35319d679c4135bb37cf89e317a0447bd7848"
 binary linux-x64 "https://iojs.org/dist/v1.8.2/iojs-v1.8.2-linux-x64.tar.gz#57343b5fc2879c5dcaadad4f59d9ca64d058a98e65e3b5e678e5879ac52a2eb9"
 binary linux-x86 "https://iojs.org/dist/v1.8.2/iojs-v1.8.2-linux-x86.tar.gz#11e1182c5a847ae9e02544f84d19ca5405cfcca89f3cf2935d51790f85f8a91a"
 
-install_package "iojs-v1.8.2" "https://iojs.org/dist/v1.8.2/iojs-v1.8.2.tar.gz#ea36c96061aa2b74275dc2c71ea2ff0efca0358ef628efe76ea324afeeb0e4f7" warn_eol
+install_package "iojs-v1.8.2" "https://iojs.org/dist/v1.8.2/iojs-v1.8.2.tar.gz#ea36c96061aa2b74275dc2c71ea2ff0efca0358ef628efe76ea324afeeb0e4f7"

--- a/share/node-build/iojs-1.8.3
+++ b/share/node-build/iojs-1.8.3
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v1.8.3/iojs-v1.8.3-darwin-x64.tar.gz#c1fe0cf751f1570f5fccf697359ff3c197019d6418ac7e2c90b889e4f35caaef"
 binary linux-armv6l "https://iojs.org/dist/v1.8.3/iojs-v1.8.3-linux-armv6l.tar.gz#56358a6afd0b05aecb48347cebdb60b4eb95c2848e95b0c9b099aeaba04a5382"
 binary linux-armv7l "https://iojs.org/dist/v1.8.3/iojs-v1.8.3-linux-armv7l.tar.gz#3ba83586878c7e601e6f9dc941178bf26df75747d93d83cec0fab52f7e527fd5"
 binary linux-x64 "https://iojs.org/dist/v1.8.3/iojs-v1.8.3-linux-x64.tar.gz#86502cfcb255fe60fd19807df64a1dbaeb5f0c1258188e1246f893a41a9e0c73"
 binary linux-x86 "https://iojs.org/dist/v1.8.3/iojs-v1.8.3-linux-x86.tar.gz#c1b425c56a6ade3d4204d6834b041aac5daf028f8ba6f0d183fb537a8479d613"
 
-install_package "iojs-v1.8.3" "https://iojs.org/dist/v1.8.3/iojs-v1.8.3.tar.gz#9613618c8675323801cf1fa9fe3778149e6e42ae2753ddb16a663140fdc9cd56" warn_eol
+install_package "iojs-v1.8.3" "https://iojs.org/dist/v1.8.3/iojs-v1.8.3.tar.gz#9613618c8675323801cf1fa9fe3778149e6e42ae2753ddb16a663140fdc9cd56"

--- a/share/node-build/iojs-1.8.4
+++ b/share/node-build/iojs-1.8.4
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v1.8.4/iojs-v1.8.4-darwin-x64.tar.gz#4eddcc1005108767fc26a522a30ce00be26c7e9be58bf0f2b097c868579ccbac"
 binary linux-armv6l "https://iojs.org/dist/v1.8.4/iojs-v1.8.4-linux-armv6l.tar.gz#2f5be1d6872adab6b9e2e01e4f4a6c827702343241398f3bcadbbdaecbd02446"
 binary linux-armv7l "https://iojs.org/dist/v1.8.4/iojs-v1.8.4-linux-armv7l.tar.gz#485f7a5386da6810e07bb824a34170ee8e7e818aae5f20763922ad8f7445ba4b"
 binary linux-x64 "https://iojs.org/dist/v1.8.4/iojs-v1.8.4-linux-x64.tar.gz#9d58ea690732bcf1bffe40d95d0e456869f1ed19d33a7f0a2150cd6ac112abbe"
 binary linux-x86 "https://iojs.org/dist/v1.8.4/iojs-v1.8.4-linux-x86.tar.gz#49ef83f3dd3fe3ee4e36e2f83fe2c9d397b222549667da1b4558a2a7c060c913"
 
-install_package "iojs-v1.8.4" "https://iojs.org/dist/v1.8.4/iojs-v1.8.4.tar.gz#861f4128b8ab0e292d73460b1344593d943d52925c84e9bb58ced188204a7e25" warn_eol
+install_package "iojs-v1.8.4" "https://iojs.org/dist/v1.8.4/iojs-v1.8.4.tar.gz#861f4128b8ab0e292d73460b1344593d943d52925c84e9bb58ced188204a7e25"

--- a/share/node-build/iojs-1.x-dev
+++ b/share/node-build/iojs-1.x-dev
@@ -1,1 +1,5 @@
-install_git "iojs-1.x-dev" "https://github.com/iojs/io.js.git" "v1.x" standard warn_eol
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_git "iojs-1.x-dev" "https://github.com/iojs/io.js.git" "v1.x" standard

--- a/share/node-build/iojs-2.0.0
+++ b/share/node-build/iojs-2.0.0
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v2.0.0/iojs-v2.0.0-darwin-x64.tar.gz#2f56142cdb4b4ae4a17bd931e994339f981875eaa6700d5f4274335ac2144757"
 binary linux-armv6l "https://iojs.org/dist/v2.0.0/iojs-v2.0.0-linux-armv6l.tar.gz#6c4c0c14cae0f6eb93a80d42741136e74a30a2c74dcd9e25cbad7431ca177e2b"
 binary linux-armv7l "https://iojs.org/dist/v2.0.0/iojs-v2.0.0-linux-armv7l.tar.gz#8ae7bee7e223ee648e4a1897faab8602e2cbf0858d87ed5ba379ff617d08e1f1"
 binary linux-x64 "https://iojs.org/dist/v2.0.0/iojs-v2.0.0-linux-x64.tar.gz#edf44e185b49ed01b390097ff5104f0457b59a1a37b99d0983f73ca018c58e3a"
 binary linux-x86 "https://iojs.org/dist/v2.0.0/iojs-v2.0.0-linux-x86.tar.gz#a593b44ea4729e440e8dc63549b22a00a1bdc2c6c5a1208e7549f338713a13d5"
 
-install_package "iojs-v2.0.0" "https://iojs.org/dist/v2.0.0/iojs-v2.0.0.tar.gz#e4dd47b19fd41c9fa6f59c6d76f723ae79e76c3db5474e4d9dacc873dd47767a" warn_eol
+install_package "iojs-v2.0.0" "https://iojs.org/dist/v2.0.0/iojs-v2.0.0.tar.gz#e4dd47b19fd41c9fa6f59c6d76f723ae79e76c3db5474e4d9dacc873dd47767a"

--- a/share/node-build/iojs-2.0.1
+++ b/share/node-build/iojs-2.0.1
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v2.0.1/iojs-v2.0.1-darwin-x64.tar.gz#bc354a98eb9060343d86c3df8f2b75bbd1c5db53ffed923d8e6f89c1ef73078e"
 binary linux-armv6l "https://iojs.org/dist/v2.0.1/iojs-v2.0.1-linux-armv6l.tar.gz#74bfcca8fbe44c23a390a819addc31dfdd0db34f706a800e9db374666871f7eb"
 binary linux-armv7l "https://iojs.org/dist/v2.0.1/iojs-v2.0.1-linux-armv7l.tar.gz#4fcdcd695a8965f59c974467566bbdf8c3ecef0c6d2232c17a3768e6ceeb6c6f"
 binary linux-x64 "https://iojs.org/dist/v2.0.1/iojs-v2.0.1-linux-x64.tar.gz#ae9a1bcd870774198b5ff3bc9534f7c8cc3790af2c16bca5b07e6f4a6b4a065c"
 binary linux-x86 "https://iojs.org/dist/v2.0.1/iojs-v2.0.1-linux-x86.tar.gz#ab5bf0fa89f59ba27eb5e02d70fab724ff50ba6a3e6b0419b1720a9d0fcbd87b"
 
-install_package "iojs-v2.0.1" "https://iojs.org/dist/v2.0.1/iojs-v2.0.1.tar.gz#6d27e6f632a6835b944a60eec1162d35cb6c8c3d0a2caf3e9737bf1ab8b74f47" warn_eol
+install_package "iojs-v2.0.1" "https://iojs.org/dist/v2.0.1/iojs-v2.0.1.tar.gz#6d27e6f632a6835b944a60eec1162d35cb6c8c3d0a2caf3e9737bf1ab8b74f47"

--- a/share/node-build/iojs-2.0.2
+++ b/share/node-build/iojs-2.0.2
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v2.0.2/iojs-v2.0.2-darwin-x64.tar.gz#09216fe53e77a56fac3f6b11cb17808f6e808d7d0730daae173f05eef44aeb9b"
 binary linux-armv6l "https://iojs.org/dist/v2.0.2/iojs-v2.0.2-linux-armv6l.tar.gz#b005e026ca89f44e0c506a2d4f11af61ca36c117abb9f169a2d46017d94ac2f1"
 binary linux-armv7l "https://iojs.org/dist/v2.0.2/iojs-v2.0.2-linux-armv7l.tar.gz#7a34a92e84f0e31cc97dc4f511e5d6e40456567495e9049fac68b33c6da3da39"
 binary linux-x64 "https://iojs.org/dist/v2.0.2/iojs-v2.0.2-linux-x64.tar.gz#53bd4c6c56614fe28d988ffec7e6b54cfdded57a3ffbf502a8768f94aa3f1681"
 binary linux-x86 "https://iojs.org/dist/v2.0.2/iojs-v2.0.2-linux-x86.tar.gz#48f4086f22f8801df14726e8ada0dfbc41032bf827415477abfd4888c58e8899"
 
-install_package "iojs-v2.0.2" "https://iojs.org/dist/v2.0.2/iojs-v2.0.2.tar.gz#31cc88739c368ddc1c0d259ab8dc3f2040649f5e4e91456f6fdb3be8815e3ae3" warn_eol
+install_package "iojs-v2.0.2" "https://iojs.org/dist/v2.0.2/iojs-v2.0.2.tar.gz#31cc88739c368ddc1c0d259ab8dc3f2040649f5e4e91456f6fdb3be8815e3ae3"

--- a/share/node-build/iojs-2.1.0
+++ b/share/node-build/iojs-2.1.0
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v2.1.0/iojs-v2.1.0-darwin-x64.tar.gz#21fff7a22dfb8b99156e2073eeacf48b2e40d74a0e43e02d50631423ca01f9ff"
 binary linux-armv6l "https://iojs.org/dist/v2.1.0/iojs-v2.1.0-linux-armv6l.tar.gz#296cbbcc77550711eab6d980ae1f4a6cc7e9cf946afbcdff5a52c3b22ea514ec"
 binary linux-armv7l "https://iojs.org/dist/v2.1.0/iojs-v2.1.0-linux-armv7l.tar.gz#bbee01be6556cb682eae2530532ec5aa886102956d17ce4578397682842ad3a3"
 binary linux-x64 "https://iojs.org/dist/v2.1.0/iojs-v2.1.0-linux-x64.tar.gz#b6774e268360f0ff878caa351b18815a1e4a66d12e5a01cd3479f2e34b784973"
 binary linux-x86 "https://iojs.org/dist/v2.1.0/iojs-v2.1.0-linux-x86.tar.gz#1c81a729a311f377f037787090e37b6c6a56df85314a5d149c1a1566c49b7e56"
 
-install_package "iojs-v2.1.0" "https://iojs.org/dist/v2.1.0/iojs-v2.1.0.tar.gz#f10473944dc0e4a7bd2d57efc65d7c2a1d1991852c2d7b3cb6a0fa81b3fed26c" warn_eol
+install_package "iojs-v2.1.0" "https://iojs.org/dist/v2.1.0/iojs-v2.1.0.tar.gz#f10473944dc0e4a7bd2d57efc65d7c2a1d1991852c2d7b3cb6a0fa81b3fed26c"

--- a/share/node-build/iojs-2.2.0
+++ b/share/node-build/iojs-2.2.0
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v2.2.0/iojs-v2.2.0-darwin-x64.tar.gz#3e643f92d197b6fbfaa90c7aa342dccf5434289977dc576251f0e4e6afc50f32"
 binary linux-armv6l "https://iojs.org/dist/v2.2.0/iojs-v2.2.0-linux-armv6l.tar.gz#7fe6003effae487c0fc9db693c8a26a9d4521f6f6fd5af7938db1916aedd605e"
 binary linux-armv7l "https://iojs.org/dist/v2.2.0/iojs-v2.2.0-linux-armv7l.tar.gz#3e5f61d474c6d33b18fd371614a2e66110861da9ab3fbfd52c611908a9d782f6"
 binary linux-x64 "https://iojs.org/dist/v2.2.0/iojs-v2.2.0-linux-x64.tar.gz#217502ffe322b238afbbc863be626ae5097551449d806c5c5315c78fee39e186"
 binary linux-x86 "https://iojs.org/dist/v2.2.0/iojs-v2.2.0-linux-x86.tar.gz#beec38a199fa01c81bb8f1a55a392d3372226d9a3da45da96ef141cf758070a0"
 
-install_package "iojs-v2.2.0" "https://iojs.org/dist/v2.2.0/iojs-v2.2.0.tar.gz#b816b793ff474e6502b096845165884b5871a9e021ae532182ca363c1bb8ec52" warn_eol
+install_package "iojs-v2.2.0" "https://iojs.org/dist/v2.2.0/iojs-v2.2.0.tar.gz#b816b793ff474e6502b096845165884b5871a9e021ae532182ca363c1bb8ec52"

--- a/share/node-build/iojs-2.2.1
+++ b/share/node-build/iojs-2.2.1
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v2.2.1/iojs-v2.2.1-darwin-x64.tar.gz#a01f859556b5f9ea9d852da0c6b3de83d76d8507a5cf373959cebb9280e2a0e7"
 binary linux-armv6l "https://iojs.org/dist/v2.2.1/iojs-v2.2.1-linux-armv6l.tar.gz#73eef402902f6e83a0b4be141bee8860be58bec36e29702b8698bd5451634050"
 binary linux-armv7l "https://iojs.org/dist/v2.2.1/iojs-v2.2.1-linux-armv7l.tar.gz#76ecfe86da1775903db38a10d6da7fcff243373b59fc0f3a9b377b8116c476b2"
 binary linux-x64 "https://iojs.org/dist/v2.2.1/iojs-v2.2.1-linux-x64.tar.gz#4e44b6194f189e66505739d200536edf09f26161ad50602921dde86623c3dd7d"
 binary linux-x86 "https://iojs.org/dist/v2.2.1/iojs-v2.2.1-linux-x86.tar.gz#7c1aa41127c965c754eca41ddf17686c43a49e8744041073767ad2a88e335fa1"
 
-install_package "iojs-v2.2.1" "https://iojs.org/dist/v2.2.1/iojs-v2.2.1.tar.gz#55e79cc4f4cde41f03c1e204d2af5ee4b6e4edcf14defc82e518436e939195fa" warn_eol
+install_package "iojs-v2.2.1" "https://iojs.org/dist/v2.2.1/iojs-v2.2.1.tar.gz#55e79cc4f4cde41f03c1e204d2af5ee4b6e4edcf14defc82e518436e939195fa"

--- a/share/node-build/iojs-2.3.0
+++ b/share/node-build/iojs-2.3.0
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v2.3.0/iojs-v2.3.0-darwin-x64.tar.gz#e78b011e361f2279390623224be2cd6231f48ea81e97f48e6fe49d2b04bc0218"
 binary linux-armv6l "https://iojs.org/dist/v2.3.0/iojs-v2.3.0-linux-armv6l.tar.gz#b884ec29a1ab0033dbe086a3affe19f9c26670deb7b491640a2873fa461bb42a"
 binary linux-armv7l "https://iojs.org/dist/v2.3.0/iojs-v2.3.0-linux-armv7l.tar.gz#13a5de99ac93443b79296cadaf2fb42e7e63f70ce02572884bd774fbcadb38c1"
 binary linux-x64 "https://iojs.org/dist/v2.3.0/iojs-v2.3.0-linux-x64.tar.gz#d1cee3cd8e1373ad376bed14f771c4f29a210d6d38397c28a2bd74f8fc749a78"
 binary linux-x86 "https://iojs.org/dist/v2.3.0/iojs-v2.3.0-linux-x86.tar.gz#0154fcfdc26143d9b43ad2e46de2d0e5ccec8e4eae06930899fb1127a5be0f2e"
 
-install_package "iojs-v2.3.0" "https://iojs.org/dist/v2.3.0/iojs-v2.3.0.tar.gz#556e1a2f58c993fcb7a89c55bc2a4da6fba74cd4d444777a8b64b19d57c4cc3c" warn_eol
+install_package "iojs-v2.3.0" "https://iojs.org/dist/v2.3.0/iojs-v2.3.0.tar.gz#556e1a2f58c993fcb7a89c55bc2a4da6fba74cd4d444777a8b64b19d57c4cc3c"

--- a/share/node-build/iojs-2.3.1
+++ b/share/node-build/iojs-2.3.1
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v2.3.1/iojs-v2.3.1-darwin-x64.tar.gz#3a9d52e0bc2be0d5c81d9f5939f59350ad397b819a40c808ce8a263ca9fcdd39"
 binary linux-armv6l "https://iojs.org/dist/v2.3.1/iojs-v2.3.1-linux-armv6l.tar.gz#6b679821036c35a007d5731849587eeb8fed2743cb007f2f42d2d28c8cc07d4e"
 binary linux-armv7l "https://iojs.org/dist/v2.3.1/iojs-v2.3.1-linux-armv7l.tar.gz#7b504fe7d6d2240fc81d1dfb16e8352ee71cf786983394c5c42db2ad2282f81d"
 binary linux-x64 "https://iojs.org/dist/v2.3.1/iojs-v2.3.1-linux-x64.tar.gz#26c2021becadd14b46a44c6657aafe85c5703d77ba94ce9f1f9ea5f054ad6ccd"
 binary linux-x86 "https://iojs.org/dist/v2.3.1/iojs-v2.3.1-linux-x86.tar.gz#f63e168d31642caa2cecdfa0ff1178a07992fbfc5d259725d518553932e463e7"
 
-install_package "iojs-v2.3.1" "https://iojs.org/dist/v2.3.1/iojs-v2.3.1.tar.gz#c2198e3a63fc204a4bcb11568ce9925a4985b87048222a0a7da1143f8f866aee" warn_eol
+install_package "iojs-v2.3.1" "https://iojs.org/dist/v2.3.1/iojs-v2.3.1.tar.gz#c2198e3a63fc204a4bcb11568ce9925a4985b87048222a0a7da1143f8f866aee"

--- a/share/node-build/iojs-2.3.2
+++ b/share/node-build/iojs-2.3.2
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v2.3.2/iojs-v2.3.2-darwin-x64.tar.gz#2bba8a8aa12d97447f663c9f1036f11ca1be3089bd92eb69eab6b0ebca3401fd"
 binary linux-armv6l "https://iojs.org/dist/v2.3.2/iojs-v2.3.2-linux-armv6l.tar.gz#c1d6eed919fe3b706fd99d4d9feadb85b687af0d7c4257d33f8f79ee638b0e88"
 binary linux-armv7l "https://iojs.org/dist/v2.3.2/iojs-v2.3.2-linux-armv7l.tar.gz#b64e744dcdcf37a4affeaf30aa95cdcf14560455707ec684c7fa0c11899382c5"
 binary linux-x64 "https://iojs.org/dist/v2.3.2/iojs-v2.3.2-linux-x64.tar.gz#55d9622f2f3eb5ed3976431224206735d4c696975ae9f92d50284f89a29a80fb"
 binary linux-x86 "https://iojs.org/dist/v2.3.2/iojs-v2.3.2-linux-x86.tar.gz#aabd7d4e8ea770d3b378b8bfda7ff68037f9d18395545271de9d73465a6af7c5"
 
-install_package "iojs-v2.3.2" "https://iojs.org/dist/v2.3.2/iojs-v2.3.2.tar.gz#87722b5fd2ac5e79b1ac7bb802e23613011af6095ef7a49c0b46c4fc98ecfb7b" warn_eol
+install_package "iojs-v2.3.2" "https://iojs.org/dist/v2.3.2/iojs-v2.3.2.tar.gz#87722b5fd2ac5e79b1ac7bb802e23613011af6095ef7a49c0b46c4fc98ecfb7b"

--- a/share/node-build/iojs-2.3.3
+++ b/share/node-build/iojs-2.3.3
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v2.3.3/iojs-v2.3.3-darwin-x64.tar.gz#2dc138483e2a561da15d86d6d7ba3d25e091ade7014b41a1997eaa20b135f021"
 binary linux-armv6l "https://iojs.org/dist/v2.3.3/iojs-v2.3.3-linux-armv6l.tar.gz#98e70e2173cc16d46a84194f476520ebab9e50483373a051fcf6bbd6d8e6e28d"
 binary linux-armv7l "https://iojs.org/dist/v2.3.3/iojs-v2.3.3-linux-armv7l.tar.gz#c5a5a08adf5b492aa842370449b1c934ea4f1a522eb10d29d689b8f069776802"
 binary linux-x64 "https://iojs.org/dist/v2.3.3/iojs-v2.3.3-linux-x64.tar.gz#ff910d12c522514329e1fa21c6d24e96aefc4a361e5ef0386c676ad63d3c18e1"
 binary linux-x86 "https://iojs.org/dist/v2.3.3/iojs-v2.3.3-linux-x86.tar.gz#03188ee3e472e140b1ee8c7a8d8c7698aafb75314012a043ca6a517bf1ccd47a"
 
-install_package "iojs-v2.3.3" "https://iojs.org/dist/v2.3.3/iojs-v2.3.3.tar.gz#0384ea20739124c27dc9b47b8079f0c75efb33c7011c45f02243e9a015f8cd89" warn_eol
+install_package "iojs-v2.3.3" "https://iojs.org/dist/v2.3.3/iojs-v2.3.3.tar.gz#0384ea20739124c27dc9b47b8079f0c75efb33c7011c45f02243e9a015f8cd89"

--- a/share/node-build/iojs-2.3.4
+++ b/share/node-build/iojs-2.3.4
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v2.3.4/iojs-v2.3.4-darwin-x64.tar.gz#8e18a92247fd8e27e69b811b897e1819add64b3c5541e9cf7fda06b48f4c4c78"
 binary linux-armv6l "https://iojs.org/dist/v2.3.4/iojs-v2.3.4-linux-armv6l.tar.gz#2a0cb4c3fec99e284ed1f0899af6588fe4a0c97e1ed5153f0e5d6fb21c6b59a2"
 binary linux-armv7l "https://iojs.org/dist/v2.3.4/iojs-v2.3.4-linux-armv7l.tar.gz#99c3ffd5f3782fd10e3c1ee5cc100f5127f9352a6e774337b8e6950e674134a6"
 binary linux-x64 "https://iojs.org/dist/v2.3.4/iojs-v2.3.4-linux-x64.tar.gz#655e33e62a6bad494a7feefdc8e332e00f8fe480e55ab723b50aa3008d8152d4"
 binary linux-x86 "https://iojs.org/dist/v2.3.4/iojs-v2.3.4-linux-x86.tar.gz#a9a209df1f2f26765f1ea05ea51de7c58fc2ea65efa98533ccf5bd9f9be06bbb"
 
-install_package "iojs-v2.3.4" "https://iojs.org/dist/v2.3.4/iojs-v2.3.4.tar.gz#18aeb8ad79b549f45caf6e4baa421046a0cd8f60102ac0986f19b19174962cc1" warn_eol
+install_package "iojs-v2.3.4" "https://iojs.org/dist/v2.3.4/iojs-v2.3.4.tar.gz#18aeb8ad79b549f45caf6e4baa421046a0cd8f60102ac0986f19b19174962cc1"

--- a/share/node-build/iojs-2.4.0
+++ b/share/node-build/iojs-2.4.0
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v2.4.0/iojs-v2.4.0-darwin-x64.tar.gz#749c26ca142c654caae1cd96eed57f2609042f82a37bef422703b471133b0a62"
 binary linux-armv6l "https://iojs.org/dist/v2.4.0/iojs-v2.4.0-linux-armv6l.tar.gz#27031bbf8a77a64cdf0f5ef4e4d12695bcb0aa61f20fe940b434d7c2890953eb"
 binary linux-armv7l "https://iojs.org/dist/v2.4.0/iojs-v2.4.0-linux-armv7l.tar.gz#b36fb89390862e625db8468dcc7b7f40d335f78883d23dc59bbcb67abec3cc73"
 binary linux-x64 "https://iojs.org/dist/v2.4.0/iojs-v2.4.0-linux-x64.tar.gz#b7110e8323e2ba8a6f330e2de8d98ce7003294a8cf7e3ade36022cc4cbd6266f"
 binary linux-x86 "https://iojs.org/dist/v2.4.0/iojs-v2.4.0-linux-x86.tar.gz#3289ea9bdc83d177c7e17ef0b5075ef7f8363aa2d94ab03eaa789fbdb796c683"
 
-install_package "iojs-v2.4.0" "https://iojs.org/dist/v2.4.0/iojs-v2.4.0.tar.gz#1e2546fef303f7bb99c29297459e8debda2684e27ff535a746f57d82915d013d" warn_eol
+install_package "iojs-v2.4.0" "https://iojs.org/dist/v2.4.0/iojs-v2.4.0.tar.gz#1e2546fef303f7bb99c29297459e8debda2684e27ff535a746f57d82915d013d"

--- a/share/node-build/iojs-2.5.0
+++ b/share/node-build/iojs-2.5.0
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v2.5.0/iojs-v2.5.0-darwin-x64.tar.gz#0762e5e387e567499cb0216e036d2a0a4781194bd0387f07801c2453d121b0a8"
 binary linux-armv6l "https://iojs.org/dist/v2.5.0/iojs-v2.5.0-linux-armv6l.tar.gz#1ba2fd4d36677eda2e0cedaffcdfdaf7d4648e31083a9f6c0895da651560f2fd"
 binary linux-armv7l "https://iojs.org/dist/v2.5.0/iojs-v2.5.0-linux-armv7l.tar.gz#ed740ae2deb0acfe5a8cfa5fe86bb8c2433994e14faaff06f33ba0ca5394e335"
 binary linux-x64 "https://iojs.org/dist/v2.5.0/iojs-v2.5.0-linux-x64.tar.gz#efb56b7294a5e8844c5f4a0e57e4a6cde491002d1841e784058da38e6c35e129"
 binary linux-x86 "https://iojs.org/dist/v2.5.0/iojs-v2.5.0-linux-x86.tar.gz#83da9de19605e754d2b5dcb202f718cb980f211dc23a31bf35b5ad66bf689df4"
 
-install_package "iojs-v2.5.0" "https://iojs.org/dist/v2.5.0/iojs-v2.5.0.tar.gz#8d0b5f6a28655045d04cdc6fd2d4eb76fa2e02ad0610cdfc2a441f7c39ee404a" warn_eol
+install_package "iojs-v2.5.0" "https://iojs.org/dist/v2.5.0/iojs-v2.5.0.tar.gz#8d0b5f6a28655045d04cdc6fd2d4eb76fa2e02ad0610cdfc2a441f7c39ee404a"

--- a/share/node-build/iojs-3.0.0
+++ b/share/node-build/iojs-3.0.0
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v3.0.0/iojs-v3.0.0-darwin-x64.tar.gz#42e1d2767a23d11fcdeabe15eb5a77f5e5765c87cc7d33020e00429652a41292"
 binary linux-armv6l "https://iojs.org/dist/v3.0.0/iojs-v3.0.0-linux-armv6l.tar.gz#edf1b61cf6a5c0112cfa75f60da2175e587d7ad6eacb7283d22542a2375fa585"
 binary linux-armv7l "https://iojs.org/dist/v3.0.0/iojs-v3.0.0-linux-armv7l.tar.gz#6910901797e69f40ff69202336abc06ef2a462405e302001bab15824092a51b1"
 binary linux-x64 "https://iojs.org/dist/v3.0.0/iojs-v3.0.0-linux-x64.tar.gz#bbf8d9479bbb1eb5fb374d8e7aa26974bef67f2d451d085687160b0c5d9d73e2"
 binary linux-x86 "https://iojs.org/dist/v3.0.0/iojs-v3.0.0-linux-x86.tar.gz#10da1f422f639112a0a651fa7daa32d444c1fbc5a0aa70e774ade8c82f85ba3c"
 
-install_package "iojs-v3.0.0" "https://iojs.org/dist/v3.0.0/iojs-v3.0.0.tar.gz#0e7f6bda7f500bb80c42dfdb896ed170ed5bbfb30c5a84f2f0e31f6f72ed5d55" warn_eol
+install_package "iojs-v3.0.0" "https://iojs.org/dist/v3.0.0/iojs-v3.0.0.tar.gz#0e7f6bda7f500bb80c42dfdb896ed170ed5bbfb30c5a84f2f0e31f6f72ed5d55"

--- a/share/node-build/iojs-3.1.0
+++ b/share/node-build/iojs-3.1.0
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v3.1.0/iojs-v3.1.0-darwin-x64.tar.gz#6caa317b97590e4c920d07e7a7bc054e7f4749c6dba5477ab463b1dfe6e119b2"
 binary linux-armv6l "https://iojs.org/dist/v3.1.0/iojs-v3.1.0-linux-armv6l.tar.gz#09358346ad6bbcec5f88bf4c92391941086deacdab48ce9788e5b3718d0345c9"
 binary linux-armv7l "https://iojs.org/dist/v3.1.0/iojs-v3.1.0-linux-armv7l.tar.gz#bf21d22cf86b6dbaf868eaea1272abf7a3d7839a1f8d503fba935af5e23710b7"
 binary linux-x64 "https://iojs.org/dist/v3.1.0/iojs-v3.1.0-linux-x64.tar.gz#c2bb4a848f6f7505bb7973d9b1ef9cddc5d533056f623fcd911348a06c950fe9"
 binary linux-x86 "https://iojs.org/dist/v3.1.0/iojs-v3.1.0-linux-x86.tar.gz#252391d427dc325112f8434ba6f91cba87c7ee91945c28de44e352b3e7c007f4"
 
-install_package "iojs-v3.1.0" "https://iojs.org/dist/v3.1.0/iojs-v3.1.0.tar.gz#471c6faa28d53c0290ecbf9358f6416fca4786aad079e23c44a88cc7f42d1097" warn_eol
+install_package "iojs-v3.1.0" "https://iojs.org/dist/v3.1.0/iojs-v3.1.0.tar.gz#471c6faa28d53c0290ecbf9358f6416fca4786aad079e23c44a88cc7f42d1097"

--- a/share/node-build/iojs-3.2.0
+++ b/share/node-build/iojs-3.2.0
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v3.2.0/iojs-v3.2.0-darwin-x64.tar.gz#b05a2cc9aaf4a98e359e0aa360a6ee18d9e4bee13d53d83fdf68b8a9f54c2eee"
 binary linux-armv6l "https://iojs.org/dist/v3.2.0/iojs-v3.2.0-linux-armv6l.tar.gz#ce2c3a31b0420c5f22ee8043e2bf03c4e0659c67f82a373479bb291aa5e9faef"
 binary linux-armv7l "https://iojs.org/dist/v3.2.0/iojs-v3.2.0-linux-armv7l.tar.gz#e663285b5fb3df08b94d2b112bab95480893c17443f30c2f05a0700f9fa4d649"
 binary linux-x64 "https://iojs.org/dist/v3.2.0/iojs-v3.2.0-linux-x64.tar.gz#05b4b27b1e964c9d93f21520e02e4e15c88cbe6c933bb44834c17287a305844f"
 binary linux-x86 "https://iojs.org/dist/v3.2.0/iojs-v3.2.0-linux-x86.tar.gz#9f54b33806d563cf2a32bda00963f204d7a67019b8071e79df5d50ff3612e165"
 
-install_package "iojs-v3.2.0" "https://iojs.org/dist/v3.2.0/iojs-v3.2.0.tar.gz#c31ffbbc8ba1e2aa3834efb2441b967bb309f1beeda6c7a7c9ce0cc9fa3a89ee" warn_eol
+install_package "iojs-v3.2.0" "https://iojs.org/dist/v3.2.0/iojs-v3.2.0.tar.gz#c31ffbbc8ba1e2aa3834efb2441b967bb309f1beeda6c7a7c9ce0cc9fa3a89ee"

--- a/share/node-build/iojs-3.3.0
+++ b/share/node-build/iojs-3.3.0
@@ -1,7 +1,11 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v3.3.0/iojs-v3.3.0-darwin-x64.tar.gz#3ec6fb8d7a9ad30f673a8e114a98b2dcd6b802a375b87e5b3039dac51a967423"
 binary linux-armv6l "https://iojs.org/dist/v3.3.0/iojs-v3.3.0-linux-armv6l.tar.gz#571b12fa6fcf658873ee556fc61edab07c12daae092cfe6bdeb173df3449214c"
 binary linux-armv7l "https://iojs.org/dist/v3.3.0/iojs-v3.3.0-linux-armv7l.tar.gz#af44c0644128a552896247866e283d3991934025eee4bdc8c288439bb8d5516f"
 binary linux-x64 "https://iojs.org/dist/v3.3.0/iojs-v3.3.0-linux-x64.tar.gz#c9b1c51b7cc780c19df504e29e26b27ee89f7bf6f8d601da597f52e7e39767fd"
 binary linux-x86 "https://iojs.org/dist/v3.3.0/iojs-v3.3.0-linux-x86.tar.gz#197716f55592c85e04f644f9e2ef0d276cf90fecba3cf0e01bad6d3d628446dd"
 
-install_package "iojs-v3.3.0" "https://iojs.org/dist/v3.3.0/iojs-v3.3.0.tar.gz#e84a649858e6f5c1458c0d5d7bf1952f78e93a26ea6bc519222e92e43e2fadde" warn_eol
+install_package "iojs-v3.3.0" "https://iojs.org/dist/v3.3.0/iojs-v3.3.0.tar.gz#e84a649858e6f5c1458c0d5d7bf1952f78e93a26ea6bc519222e92e43e2fadde"

--- a/share/node-build/iojs-3.3.1
+++ b/share/node-build/iojs-3.3.1
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 binary darwin-x64 "https://iojs.org/dist/v3.3.1/iojs-v3.3.1-darwin-x64.tar.gz#397ef5f7c536d724058560c3ff6311e3a55d06eac8cdf3062c12b678e6db9ae8"
 binary linux-arm64 "https://iojs.org/dist/v3.3.1/iojs-v3.3.1-linux-arm64.tar.gz#58dbbe07d5a6f401cd0e220074f784536150142a453b8a2614c459ec3c64c99a"
 binary linux-armv6l "https://iojs.org/dist/v3.3.1/iojs-v3.3.1-linux-armv6l.tar.gz#2af2abb06dded2a355c0aa531b3b68a59e168b95860eb42ed45ea0b7a56ea142"
@@ -7,4 +11,4 @@ binary linux-x86 "https://iojs.org/dist/v3.3.1/iojs-v3.3.1-linux-x86.tar.gz#88e4
 binary sunos-x64 "https://iojs.org/dist/v3.3.1/iojs-v3.3.1-sunos-x64.tar.gz#a2e2a2c22b9ef3a5459204888d7d9d9e7d1991782bda46b8b8e7dabfcb958c28"
 binary sunos-x86 "https://iojs.org/dist/v3.3.1/iojs-v3.3.1-sunos-x86.tar.gz#b85b49b9b09a100b3e5fca3c4f87591df49e832f38d0ad59ad99a3140f41a48c"
 
-install_package "iojs-v3.3.1" "https://iojs.org/dist/v3.3.1/iojs-v3.3.1.tar.gz#b1ce0bb2ddb5d012bd9f22c787a4c74ce5d1546553086e40785be91489fee1d1" warn_eol
+install_package "iojs-v3.3.1" "https://iojs.org/dist/v3.3.1/iojs-v3.3.1.tar.gz#b1ce0bb2ddb5d012bd9f22c787a4c74ce5d1546553086e40785be91489fee1d1"

--- a/share/node-build/jxcore+sm-0.3.0.0
+++ b/share/node-build/jxcore+sm-0.3.0.0
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 after_install_package() {
   fix_jxcore_directory_structure
 }
@@ -13,5 +17,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0300/jx_suse64sm.zip#5a6cc2f616
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0300/jx_ub32sm.zip#63965f2165154af1e6c9d9e343ac9b7a586459138ed6656313958ff3ab838e83"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0300/jx_ub64sm.zip#9c30cd5dbf5afb166d06e0118536af2a49fae14f49d67adee06459934a75c934"
 
-install_package jxcore-0.3.0.0 "https://github.com/jxcore/jxcore/archive/v0.3.0.tar.gz#1e76648ecd012a2370354369f6161666763b4bc028544e9dc0cb27c035a90f24" jxcore_spidermonkey standard warn_eol
-install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm warn_eol
+install_package jxcore-0.3.0.0 "https://github.com/jxcore/jxcore/archive/v0.3.0.tar.gz#1e76648ecd012a2370354369f6161666763b4bc028544e9dc0cb27c035a90f24" jxcore_spidermonkey standard
+install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm

--- a/share/node-build/jxcore+sm-0.3.0.1
+++ b/share/node-build/jxcore+sm-0.3.0.1
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 after_install_package() {
   fix_jxcore_directory_structure
 }
@@ -15,5 +19,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0301/jx_suse64sm.zip#f30284f909
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0301/jx_ub32sm.zip#c7f76539280d5131f9d01657c6c62e6b759703e720ff51aa0aa3550265a3fec4"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0301/jx_ub64sm.zip#14add2a2f0ac6909dfbcdf39301e0f779866ca2fd5cfc0c97866834f2b6a8c45"
 
-install_package jxcore-0.3.0.1 "https://github.com/jxcore/jxcore/archive/v0.3.0.1.tar.gz#fd25b575b4dd42be87f9681dbcf9812836bc6389f6d90073913092085e902a44" jxcore_spidermonkey standard warn_eol
-install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.1/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm warn_eol
+install_package jxcore-0.3.0.1 "https://github.com/jxcore/jxcore/archive/v0.3.0.1.tar.gz#fd25b575b4dd42be87f9681dbcf9812836bc6389f6d90073913092085e902a44" jxcore_spidermonkey standard
+install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.1/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm

--- a/share/node-build/jxcore+sm-0.3.0.2
+++ b/share/node-build/jxcore+sm-0.3.0.2
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 after_install_package() {
   fix_jxcore_directory_structure
 }
@@ -15,5 +19,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0302/jx_suse64sm.zip#0943b465a1
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0302/jx_ub32sm.zip#2d25443d6895dfd9f62eb9e281081eba6d5ba6fd239eeabd02a65137ef61dada"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0302/jx_ub64sm.zip#433ac458be0ac02e1ffb6f6e1db1034f35ac746286d48a40b8b65875e211e689"
 
-install_package jxcore-0.3.0.2 "https://github.com/jxcore/jxcore/archive/v0.3.0.2.tar.gz#79baa480676ef44a93d2cf6081b4d001ecf09cb746b73143cf264e8ba8601b96" jxcore_spidermonkey standard warn_eol
-install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.2/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm warn_eol
+install_package jxcore-0.3.0.2 "https://github.com/jxcore/jxcore/archive/v0.3.0.2.tar.gz#79baa480676ef44a93d2cf6081b4d001ecf09cb746b73143cf264e8ba8601b96" jxcore_spidermonkey standard
+install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.2/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm

--- a/share/node-build/jxcore+sm-0.3.0.3
+++ b/share/node-build/jxcore+sm-0.3.0.3
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 after_install_package() {
   fix_jxcore_directory_structure
 }
@@ -15,5 +19,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0303/jx_suse64sm.zip#90b970b82e
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0303/jx_ub32sm.zip#ade168bbeb6d16879b0284579d8fb77f78f0c6f983a2b9f18a8df324026a2f28"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0303/jx_ub64sm.zip#759e82a993592e91d858feb3b0a5df70fadcf42f91a393f6e8dfec5f8fb95bfd"
 
-install_package jxcore-0.3.0.3 "https://github.com/jxcore/jxcore/archive/v0.3.0.3.tar.gz#b8e4f5c791f130fb0dd51fc0489bdadf5b4dfd2ed56e050943d3269631e1ccdc" jxcore_spidermonkey standard warn_eol
-install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.3/npmjx303.tar.gz#f3479e698f7d9288256b944cfb14842349364575a2819bd4d635ec79924c6368" jxcore_npm warn_eol
+install_package jxcore-0.3.0.3 "https://github.com/jxcore/jxcore/archive/v0.3.0.3.tar.gz#b8e4f5c791f130fb0dd51fc0489bdadf5b4dfd2ed56e050943d3269631e1ccdc" jxcore_spidermonkey standard
+install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.3/npmjx303.tar.gz#f3479e698f7d9288256b944cfb14842349364575a2819bd4d635ec79924c6368" jxcore_npm

--- a/share/node-build/jxcore+sm-0.3.0.4
+++ b/share/node-build/jxcore+sm-0.3.0.4
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 after_install_package() {
   fix_jxcore_directory_structure
 }
@@ -15,5 +19,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0304/jx_suse64sm.zip#ff724ecdce
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0304/jx_ub32sm.zip#0d44fc932924e4b5e27feae5e0f795a8075627e8e418d8f5ad2c5a533defc0f2"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0304/jx_ub64sm.zip#cec1b83501ebc39bc2109941bc7edb8826edda66282de6929ac3127978bd4d94"
 
-install_package jxcore-0.3.0.4 "https://github.com/jxcore/jxcore/archive/v0.3.0.4.tar.gz#84e67ee008abb6794940806ab2992536144d9e831643181ea0230f4e8f1aade7" jxcore_spidermonkey standard warn_eol
-install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.4/npmjx304.tar.gz#e12617fe36c58c59ee5d06e99f421f21b8a3215d5d780597e5218e2c6b63f17a" jxcore_npm warn_eol
+install_package jxcore-0.3.0.4 "https://github.com/jxcore/jxcore/archive/v0.3.0.4.tar.gz#84e67ee008abb6794940806ab2992536144d9e831643181ea0230f4e8f1aade7" jxcore_spidermonkey standard
+install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.4/npmjx304.tar.gz#e12617fe36c58c59ee5d06e99f421f21b8a3215d5d780597e5218e2c6b63f17a" jxcore_npm

--- a/share/node-build/jxcore+sm-0.3.0.5
+++ b/share/node-build/jxcore+sm-0.3.0.5
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 after_install_package() {
   fix_jxcore_directory_structure
 }
@@ -15,5 +19,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0305/jx_suse64sm.zip#04c98d4da5
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0305/jx_ub32sm.zip#a1b4166cf948e27120c9e3c85c5940716e7f649654343955e4ae659a58f29518"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0305/jx_ub64sm.zip#d254d665b42d2b4f632c73ce6afef25d8da19846cf5a9fa4eb73be9a0f9aaaa0"
 
-install_package jxcore-0.3.0.5 "https://github.com/jxcore/jxcore/archive/v0.3.0.5.tar.gz#a7c7759f66609f32bc2aed5f3674e251d66710bb742417faf5c0059319cc00b5" jxcore_spidermonkey standard warn_eol
-install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.5/npmjx305.tar.gz#fdefdb122e6ca0ea23a11730c7e032742a86b2c7e9e46421304bc6b7ce99a7fa" jxcore_npm warn_eol
+install_package jxcore-0.3.0.5 "https://github.com/jxcore/jxcore/archive/v0.3.0.5.tar.gz#a7c7759f66609f32bc2aed5f3674e251d66710bb742417faf5c0059319cc00b5" jxcore_spidermonkey standard
+install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.5/npmjx305.tar.gz#fdefdb122e6ca0ea23a11730c7e032742a86b2c7e9e46421304bc6b7ce99a7fa" jxcore_npm

--- a/share/node-build/jxcore+sm-0.3.0.6
+++ b/share/node-build/jxcore+sm-0.3.0.6
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 after_install_package() {
   fix_jxcore_directory_structure
 }
@@ -15,5 +19,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0306/jx_suse64sm.zip#1f6a6e519f
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0306/jx_ub32sm.zip#c09a3e2442126c349a802c48e2a58b8e391f0355a1ad8131b492b7e2434031ae"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0306/jx_ub64sm.zip#edc80a72aec681bfe2501be2fb89ae9deb7faf265cc208e3a82921a8dedcfb2a"
 
-install_package jxcore-0.3.0.6 "https://github.com/jxcore/jxcore/archive/v0.3.0.6.tar.gz#8e978743f126c27ba6478873013d71575af23082c1804f3cbaa911d720ef0f19" jxcore_spidermonkey standard warn_eol
-install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.6/npmjx305.tar.gz#fdefdb122e6ca0ea23a11730c7e032742a86b2c7e9e46421304bc6b7ce99a7fa" jxcore_npm warn_eol
+install_package jxcore-0.3.0.6 "https://github.com/jxcore/jxcore/archive/v0.3.0.6.tar.gz#8e978743f126c27ba6478873013d71575af23082c1804f3cbaa911d720ef0f19" jxcore_spidermonkey standard
+install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.6/npmjx305.tar.gz#fdefdb122e6ca0ea23a11730c7e032742a86b2c7e9e46421304bc6b7ce99a7fa" jxcore_npm

--- a/share/node-build/jxcore+sm-0.3.0.7
+++ b/share/node-build/jxcore+sm-0.3.0.7
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 after_install_package() {
   fix_jxcore_directory_structure
 }
@@ -15,5 +19,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0307/jx_suse64sm.zip#b412e9cd7d
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0307/jx_ub32sm.zip#21926feed8baf44c00fb002829191b55399809192f72b44f9170e7830c24fba9"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0307/jx_ub64sm.zip#35ff53927e40105bed20fa41fb00c0dfb99ff69430362874db36ba7f72feae9b"
 
-install_package jxcore-0.3.0.7 "https://github.com/jxcore/jxcore/archive/v0.3.0.7.tar.gz#a5d3daeb736981cafc41eee70c62994bdc9001a88a6a15771624c018c74463c3" jxcore_spidermonkey standard warn_eol
-install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.7/npmjx307.tar.gz#7b99397f17f5fdb592842ccd62e25806b2a05ae9997c4508b47412f194e8ba6e" jxcore_npm warn_eol
+install_package jxcore-0.3.0.7 "https://github.com/jxcore/jxcore/archive/v0.3.0.7.tar.gz#a5d3daeb736981cafc41eee70c62994bdc9001a88a6a15771624c018c74463c3" jxcore_spidermonkey standard
+install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.7/npmjx307.tar.gz#7b99397f17f5fdb592842ccd62e25806b2a05ae9997c4508b47412f194e8ba6e" jxcore_npm

--- a/share/node-build/jxcore+sm-0.3.1.0
+++ b/share/node-build/jxcore+sm-0.3.1.0
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 after_install_package() {
   fix_jxcore_directory_structure
 }
@@ -15,5 +19,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0310/jx_suse64sm.zip#c40e1a128d
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0310/jx_ub32sm.zip#ac85fe3ac35149aeb4449d6899e82a98ac5e6ebc8fc43fa6c16bdcf666979ab8"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0310/jx_ub64sm.zip#e299ee14fae34f19bb8f838b188aca36266a305950625e909e615923dd15c4be"
 
-install_package jxcore-0.3.1.0 "https://github.com/jxcore/jxcore/archive/v0.3.1.0.tar.gz#cae9dac0602667b5b5dedf2ac23445e2875c2bfb91cbdfd7b370790f8a0c96df" jxcore_spidermonkey standard warn_eol
-install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.1.0/npmjx310.tar.gz#3c8e1b1fed9be44c4ec6fd09e6978a29c3e466f684e2812f6762c0a6d28fb85c" jxcore_npm warn_eol
+install_package jxcore-0.3.1.0 "https://github.com/jxcore/jxcore/archive/v0.3.1.0.tar.gz#cae9dac0602667b5b5dedf2ac23445e2875c2bfb91cbdfd7b370790f8a0c96df" jxcore_spidermonkey standard
+install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.1.0/npmjx310.tar.gz#3c8e1b1fed9be44c4ec6fd09e6978a29c3e466f684e2812f6762c0a6d28fb85c" jxcore_npm

--- a/share/node-build/jxcore+sm-0.3.1.1
+++ b/share/node-build/jxcore+sm-0.3.1.1
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 after_install_package() {
   fix_jxcore_directory_structure
 }
@@ -15,5 +19,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0311/jx_suse64sm.zip#c10c85b6eb
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0311/jx_ub32sm.zip#cd8713e85838a59f421cba51ce488d63fe4ad50046b5d595759797360526aa61"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0311/jx_ub64sm.zip#9f8df5354fc3d7c7148a53bf307183e36f104eb66b0bfb46bfa7e276f2b927d0"
 
-install_package jxcore-0.3.1.1 "https://github.com/jxcore/jxcore/archive/v0.3.1.1.tar.gz#a1a44e0a06158245320a2aca20a7381469a453f3c5e2bc1ce36fdb470801c1f5" jxcore_spidermonkey standard warn_eol
-install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.1.1/npmjx311.tar.gz#b0a696e01db4af87c2b6978453a01e4294951dd915d4770b559cab918a20c127" jxcore_npm warn_eol
+install_package jxcore-0.3.1.1 "https://github.com/jxcore/jxcore/archive/v0.3.1.1.tar.gz#a1a44e0a06158245320a2aca20a7381469a453f3c5e2bc1ce36fdb470801c1f5" jxcore_spidermonkey standard
+install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.1.1/npmjx311.tar.gz#b0a696e01db4af87c2b6978453a01e4294951dd915d4770b559cab918a20c127" jxcore_npm

--- a/share/node-build/jxcore+sm-dev
+++ b/share/node-build/jxcore+sm-dev
@@ -1,6 +1,10 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 after_install_package() {
   fix_jxcore_directory_structure
 }
 
-install_git jxcore-dev "https://github.com/jxcore/jxcore.git" "master" jxcore_spidermonkey standard warn_eol
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx310.tar.gz#3c8e1b1fed9be44c4ec6fd09e6978a29c3e466f684e2812f6762c0a6d28fb85c" jxcore_npm warn_eol
+install_git jxcore-dev "https://github.com/jxcore/jxcore.git" "master" jxcore_spidermonkey standard
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx310.tar.gz#3c8e1b1fed9be44c4ec6fd09e6978a29c3e466f684e2812f6762c0a6d28fb85c" jxcore_npm

--- a/share/node-build/jxcore+v8-0.3.0.0
+++ b/share/node-build/jxcore+v8-0.3.0.0
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 after_install_package() {
   fix_jxcore_directory_structure
 }
@@ -13,5 +17,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0300/jx_suse64v8.zip#ce7a7ca9db
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0300/jx_ub32v8.zip#d54228a58ae658fb50e866c4236801faf1f13a26b429a8a4de9ec7c325948024"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0300/jx_ub64v8.zip#02ddb8b7fd41714927ef292c1362ca36d14afa9f04d2cc79d31e1925fc2ad6c2"
 
-install_package jxcore-0.3.0.0 "https://github.com/jxcore/jxcore/archive/v0.3.0.tar.gz#1e76648ecd012a2370354369f6161666763b4bc028544e9dc0cb27c035a90f24" warn_eol
-install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm warn_eol
+install_package jxcore-0.3.0.0 "https://github.com/jxcore/jxcore/archive/v0.3.0.tar.gz#1e76648ecd012a2370354369f6161666763b4bc028544e9dc0cb27c035a90f24"
+install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm

--- a/share/node-build/jxcore+v8-0.3.0.1
+++ b/share/node-build/jxcore+v8-0.3.0.1
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 after_install_package() {
   fix_jxcore_directory_structure
 }
@@ -15,5 +19,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0301/jx_suse64v8.zip#b454a40bb3
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0301/jx_ub32v8.zip#59bc363ab28d044a098ef42927582f87b3a9c8cad894bed0d73caae3a7539dbd"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0301/jx_ub64v8.zip#36ac32276d9fdfee9778718cbb0571ec4bc61680e91c5042a6cd8870d0308a9b"
 
-install_package jxcore-0.3.0.1 "https://github.com/jxcore/jxcore/archive/v0.3.0.1.tar.gz#fd25b575b4dd42be87f9681dbcf9812836bc6389f6d90073913092085e902a44" warn_eol
-install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.1/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm warn_eol
+install_package jxcore-0.3.0.1 "https://github.com/jxcore/jxcore/archive/v0.3.0.1.tar.gz#fd25b575b4dd42be87f9681dbcf9812836bc6389f6d90073913092085e902a44"
+install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.1/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm

--- a/share/node-build/jxcore+v8-0.3.0.2
+++ b/share/node-build/jxcore+v8-0.3.0.2
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 after_install_package() {
   fix_jxcore_directory_structure
 }
@@ -15,5 +19,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0302/jx_suse64v8.zip#12098decaf
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0302/jx_ub32v8.zip#f680e0d7f3310acbfc25929f115b24bee77e7eee3276bb0d5e3dcdce2108d0e0"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0302/jx_ub64v8.zip#c87fb4a92ae193009e646d851c89178291374a0e41f83a75bdb4ed48e129474f"
 
-install_package jxcore-0.3.0.2 "https://github.com/jxcore/jxcore/archive/v0.3.0.2.tar.gz#79baa480676ef44a93d2cf6081b4d001ecf09cb746b73143cf264e8ba8601b96" warn_eol
-install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.2/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm warn_eol
+install_package jxcore-0.3.0.2 "https://github.com/jxcore/jxcore/archive/v0.3.0.2.tar.gz#79baa480676ef44a93d2cf6081b4d001ecf09cb746b73143cf264e8ba8601b96"
+install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.2/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm

--- a/share/node-build/jxcore+v8-0.3.0.3
+++ b/share/node-build/jxcore+v8-0.3.0.3
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 after_install_package() {
   fix_jxcore_directory_structure
 }
@@ -15,5 +19,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0303/jx_suse64v8.zip#80f3ab32b6
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0303/jx_ub32v8.zip#d5f481f10aad3802ce8368b6a5a381a5557839e19da6d541d17898dcb2fd7099"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0303/jx_ub64v8.zip#257d484f2e563984b6104a3fdb4cf99e7b01bb77a289a0ade045f1e998ec584c"
 
-install_package jxcore-0.3.0.3 "https://github.com/jxcore/jxcore/archive/v0.3.0.3.tar.gz#b8e4f5c791f130fb0dd51fc0489bdadf5b4dfd2ed56e050943d3269631e1ccdc" warn_eol
-install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.3/npmjx303.tar.gz#f3479e698f7d9288256b944cfb14842349364575a2819bd4d635ec79924c6368" jxcore_npm warn_eol
+install_package jxcore-0.3.0.3 "https://github.com/jxcore/jxcore/archive/v0.3.0.3.tar.gz#b8e4f5c791f130fb0dd51fc0489bdadf5b4dfd2ed56e050943d3269631e1ccdc"
+install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.3/npmjx303.tar.gz#f3479e698f7d9288256b944cfb14842349364575a2819bd4d635ec79924c6368" jxcore_npm

--- a/share/node-build/jxcore+v8-0.3.0.4
+++ b/share/node-build/jxcore+v8-0.3.0.4
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 after_install_package() {
   fix_jxcore_directory_structure
 }
@@ -15,5 +19,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0304/jx_suse64v8.zip#0f368cb1ee
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0304/jx_ub32v8.zip#d8f33ca1544ff89213d65d733511cec6a41e9f384352a4b5310babd0b22baac4"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0304/jx_ub64v8.zip#8a268aa4a6128d214abdfec88c5a636c8ccdffa90f42a038dfb75f87493bb81e"
 
-install_package jxcore-0.3.0.4 "https://github.com/jxcore/jxcore/archive/v0.3.0.4.tar.gz#84e67ee008abb6794940806ab2992536144d9e831643181ea0230f4e8f1aade7" warn_eol
-install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.4/npmjx304.tar.gz#e12617fe36c58c59ee5d06e99f421f21b8a3215d5d780597e5218e2c6b63f17a" jxcore_npm warn_eol
+install_package jxcore-0.3.0.4 "https://github.com/jxcore/jxcore/archive/v0.3.0.4.tar.gz#84e67ee008abb6794940806ab2992536144d9e831643181ea0230f4e8f1aade7"
+install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.4/npmjx304.tar.gz#e12617fe36c58c59ee5d06e99f421f21b8a3215d5d780597e5218e2c6b63f17a" jxcore_npm

--- a/share/node-build/jxcore+v8-0.3.0.5
+++ b/share/node-build/jxcore+v8-0.3.0.5
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 after_install_package() {
   fix_jxcore_directory_structure
 }
@@ -15,5 +19,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0305/jx_suse64v8.zip#4afad1d2c1
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0305/jx_ub32v8.zip#fc893263bf8252bef52e8ba4ebab1c195fb18437db941c20168755e5e3a02685"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0305/jx_ub64v8.zip#44ffa659f01c3ea4d886a4a4bab17afaff87c5f6f447fe1ebedaa63ec4fd4990"
 
-install_package jxcore-0.3.0.5 "https://github.com/jxcore/jxcore/archive/v0.3.0.5.tar.gz#a7c7759f66609f32bc2aed5f3674e251d66710bb742417faf5c0059319cc00b5" warn_eol
-install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.5/npmjx305.tar.gz#fdefdb122e6ca0ea23a11730c7e032742a86b2c7e9e46421304bc6b7ce99a7fa" jxcore_npm warn_eol
+install_package jxcore-0.3.0.5 "https://github.com/jxcore/jxcore/archive/v0.3.0.5.tar.gz#a7c7759f66609f32bc2aed5f3674e251d66710bb742417faf5c0059319cc00b5"
+install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.5/npmjx305.tar.gz#fdefdb122e6ca0ea23a11730c7e032742a86b2c7e9e46421304bc6b7ce99a7fa" jxcore_npm

--- a/share/node-build/jxcore+v8-0.3.0.6
+++ b/share/node-build/jxcore+v8-0.3.0.6
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 after_install_package() {
   fix_jxcore_directory_structure
 }
@@ -15,5 +19,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0306/jx_suse64v8.zip#a3c1fffb47
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0306/jx_ub32v8.zip#fcdeaf029f293437ed3e2811006cb96f27ce52178abe4004a0fe48d42be71a57"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0306/jx_ub64v8.zip#675766946cc2baf8727f96cbd57223ce0f6add0fb9342445bd6a8ebcf25a3112"
 
-install_package jxcore-0.3.0.6 "https://github.com/jxcore/jxcore/archive/v0.3.0.6.tar.gz#8e978743f126c27ba6478873013d71575af23082c1804f3cbaa911d720ef0f19" warn_eol
-install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.6/npmjx305.tar.gz#fdefdb122e6ca0ea23a11730c7e032742a86b2c7e9e46421304bc6b7ce99a7fa" jxcore_npm warn_eol
+install_package jxcore-0.3.0.6 "https://github.com/jxcore/jxcore/archive/v0.3.0.6.tar.gz#8e978743f126c27ba6478873013d71575af23082c1804f3cbaa911d720ef0f19"
+install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.6/npmjx305.tar.gz#fdefdb122e6ca0ea23a11730c7e032742a86b2c7e9e46421304bc6b7ce99a7fa" jxcore_npm

--- a/share/node-build/jxcore+v8-0.3.0.7
+++ b/share/node-build/jxcore+v8-0.3.0.7
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 after_install_package() {
   fix_jxcore_directory_structure
 }
@@ -15,5 +19,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0307/jx_suse64v8.zip#139eab46f5
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0307/jx_ub32v8.zip#3b33c65c7196c1621612cb4f047abf26f81184eb172550363146a3c7e7724d37"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0307/jx_ub64v8.zip#60368d54f71d6a66bbeebabb8cabcdd81c20bf1a6daa7bdca0d98062e1087330"
 
-install_package jxcore-0.3.0.7 "https://github.com/jxcore/jxcore/archive/v0.3.0.7.tar.gz#a5d3daeb736981cafc41eee70c62994bdc9001a88a6a15771624c018c74463c3" warn_eol
-install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.7/npmjx307.tar.gz#7b99397f17f5fdb592842ccd62e25806b2a05ae9997c4508b47412f194e8ba6e" jxcore_npm warn_eol
+install_package jxcore-0.3.0.7 "https://github.com/jxcore/jxcore/archive/v0.3.0.7.tar.gz#a5d3daeb736981cafc41eee70c62994bdc9001a88a6a15771624c018c74463c3"
+install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.7/npmjx307.tar.gz#7b99397f17f5fdb592842ccd62e25806b2a05ae9997c4508b47412f194e8ba6e" jxcore_npm

--- a/share/node-build/jxcore+v8-0.3.1.0
+++ b/share/node-build/jxcore+v8-0.3.1.0
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 after_install_package() {
   fix_jxcore_directory_structure
 }
@@ -15,5 +19,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0310/jx_suse64v8.zip#a9f1303861
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0310/jx_ub32v8.zip#d533f8fe93000b3ef595cded488ae52b7817fb6cf3860d1d28e7067694ec5e85"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0310/jx_ub64v8.zip#e21abde7d6c5f7d8366c530e09de66a8fec617710988ae24b301a2dd4ea9dbcb"
 
-install_package jxcore-0.3.1.0 "https://github.com/jxcore/jxcore/archive/v0.3.1.0.tar.gz#cae9dac0602667b5b5dedf2ac23445e2875c2bfb91cbdfd7b370790f8a0c96df" warn_eol
-install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.1.0/npmjx310.tar.gz#3c8e1b1fed9be44c4ec6fd09e6978a29c3e466f684e2812f6762c0a6d28fb85c" jxcore_npm warn_eol
+install_package jxcore-0.3.1.0 "https://github.com/jxcore/jxcore/archive/v0.3.1.0.tar.gz#cae9dac0602667b5b5dedf2ac23445e2875c2bfb91cbdfd7b370790f8a0c96df"
+install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.1.0/npmjx310.tar.gz#3c8e1b1fed9be44c4ec6fd09e6978a29c3e466f684e2812f6762c0a6d28fb85c" jxcore_npm

--- a/share/node-build/jxcore+v8-0.3.1.1
+++ b/share/node-build/jxcore+v8-0.3.1.1
@@ -1,3 +1,7 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 after_install_package() {
   fix_jxcore_directory_structure
 }
@@ -15,5 +19,5 @@ binary suse-x64 "https://jxcore.s3.amazonaws.com/0311/jx_suse64v8.zip#1797be220b
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0311/jx_ub32v8.zip#392bfa35add03ede1b6d18c596d586e0551141ea88d60094241e05ab9b660db1"
 binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0311/jx_ub64v8.zip#f3bd4d58f8af6e03ad1a48c95727ed1c050c2d24f12c7974797ce7d63b3dd8f0"
 
-install_package jxcore-0.3.1.1 "https://github.com/jxcore/jxcore/archive/v0.3.1.1.tar.gz#a1a44e0a06158245320a2aca20a7381469a453f3c5e2bc1ce36fdb470801c1f5" warn_eol
-install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.1.1/npmjx311.tar.gz#b0a696e01db4af87c2b6978453a01e4294951dd915d4770b559cab918a20c127" jxcore_npm warn_eol
+install_package jxcore-0.3.1.1 "https://github.com/jxcore/jxcore/archive/v0.3.1.1.tar.gz#a1a44e0a06158245320a2aca20a7381469a453f3c5e2bc1ce36fdb470801c1f5"
+install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.1.1/npmjx311.tar.gz#b0a696e01db4af87c2b6978453a01e4294951dd915d4770b559cab918a20c127" jxcore_npm

--- a/share/node-build/jxcore+v8-dev
+++ b/share/node-build/jxcore+v8-dev
@@ -1,6 +1,10 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
 after_install_package() {
   fix_jxcore_directory_structure
 }
 
-install_git jxcore-dev "https://github.com/jxcore/jxcore.git" "master" warn_eol
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx310.tar.gz#3c8e1b1fed9be44c4ec6fd09e6978a29c3e466f684e2812f6762c0a6d28fb85c" jxcore_npm warn_eol
+install_git jxcore-dev "https://github.com/jxcore/jxcore.git" "master"
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx310.tar.gz#3c8e1b1fed9be44c4ec6fd09e6978a29c3e466f684e2812f6762c0a6d28fb85c" jxcore_npm


### PR DESCRIPTION
Updated definitions for 0.x and iojs to warn the EOL message not just for from-source builds but also for precompiled binary installs. (By using before_install hook instead of the build_package_* helper.)

Also added EOL warnings for 5.x builds.

Added EOL warnings for 0.10.x builds, as it will EOL on 10/31

Closes #177 