### PR TITLE
Restore mirror capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ You can set certain environment variables to control the build process.
   built. By default, this is a subdirectory of `TMPDIR`.
 * `NODE_BUILD_CACHE_PATH`, if set, specifies a directory to use for caching
   downloaded package files.
-* `NODE_BUILD_MIRROR_URL` overrides the default mirror URL root to one of your
-  choosing.
+* `NODE_BUILD_MIRROR_URL` select a mirror from which to download packages
+  instead of their original source URLs.
 * `NODE_BUILD_SKIP_MIRROR`, if set, forces node-build to download packages from
   their original source URLs instead of using a mirror.
 * `NODE_BUILD_ROOT` overrides the default location from where build definitions

--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ You can set certain environment variables to control the build process.
   built. By default, this is a subdirectory of `TMPDIR`.
 * `NODE_BUILD_CACHE_PATH`, if set, specifies a directory to use for caching
   downloaded package files.
+* `NODE_BUILD_MIRROR_URL` overrides the default mirror URL root to one of your
+  choosing.
+* `NODE_BUILD_SKIP_MIRROR`, if set, forces node-build to download packages from
+  their original source URLs instead of using a mirror.
 * `NODE_BUILD_ROOT` overrides the default location from where build definitions
   in `share/node-build/` are looked up.
 * `NODE_BUILD_DEFINITIONS` can be a list of colon-separated paths that get
@@ -173,6 +177,17 @@ installing it.
 
 Checksums are optional and specified as anchors on the package URL in each
 definition. (All bundled definitions include checksums.)
+
+### Package download mirrors
+
+You can point node-build to another mirror by specifying the
+`NODE_BUILD_MIRROR_URL` environment variable--useful if you'd like to run your
+own local mirror, for example. Package mirror URLs are constructed by joining
+this variable with the SHA2 checksum of the package file.
+
+If you don't have an SHA2 program installed, node-build will skip the download
+mirror and use official URLs instead. You can force node-build to bypass the
+mirror by setting the `NODE_BUILD_SKIP_MIRROR` environment variable.
 
 ### Package download caching
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ You can set certain environment variables to control the build process.
   built. By default, this is a subdirectory of `TMPDIR`.
 * `NODE_BUILD_CACHE_PATH`, if set, specifies a directory to use for caching
   downloaded package files.
+* `NODE_BUILD_MIRROR_CMD` provide a command to construct the package mirror
+  URL.
 * `NODE_BUILD_MIRROR_URL` select a mirror from which to download packages
   instead of their original source URLs.
 * `NODE_BUILD_SKIP_MIRROR`, if set, forces node-build to download packages from
@@ -182,8 +184,11 @@ definition. (All bundled definitions include checksums.)
 
 You can point node-build to another mirror by specifying the
 `NODE_BUILD_MIRROR_URL` environment variable--useful if you'd like to run your
-own local mirror, for example. Package mirror URLs are constructed by joining
-this variable with the SHA2 checksum of the package file.
+own local mirror, for example. Package mirror URLs are constructed by invoking
+`NODE_BUILD_MIRROR_CMD` with two arguments: `package_url` and `checksum`. The
+provided command should print the desired mirror's package URL. If
+`NODE_BUILD_MIRROR_CMD` is unset, package mirror URL construction defaults to
+simply replacing `https://nodejs.org/dist` with `NODE_BUILD_MIRROR_URL`.
 
 If you don't have an SHA2 program installed, node-build will skip the download
 mirror and use official URLs instead. You can force node-build to bypass the

--- a/bin/node-build
+++ b/bin/node-build
@@ -436,11 +436,16 @@ http_get_wget() {
 fetch_tarball() {
   local package_name="$1"
   local package_url="$2"
+  local mirror_url
   local checksum
 
   if [ "$package_url" != "${package_url/\#}" ]; then
     checksum="${package_url#*#}"
     package_url="${package_url%%#*}"
+
+    if [ -n "$NODE_BUILD_MIRROR_URL" ]; then
+      mirror_url="${NODE_BUILD_MIRROR_URL}/$checksum"
+    fi
   fi
 
   local tar="tar"
@@ -463,6 +468,8 @@ fetch_tarball() {
   if ! reuse_existing_tarball "$package_filename" "$checksum"; then
     local tarball_filename=$(basename $package_url)
     echo "Downloading ${tarball_filename}..." >&2
+    http head "$mirror_url" &&
+    download_tarball "$mirror_url" "$package_filename" "$checksum" ||
     download_tarball "$package_url" "$package_filename" "$checksum"
   fi
 
@@ -895,6 +902,16 @@ fi
 ARIA2_OPTS="${NODE_BUILD_ARIA2_OPTS} ${IPV4+--disable-ipv6=true} ${IPV6+--disable-ipv6=false}"
 CURL_OPTS="${NODE_BUILD_CURL_OPTS} ${IPV4+--ipv4} ${IPV6+--ipv6}"
 WGET_OPTS="${NODE_BUILD_WGET_OPTS} ${IPV4+--inet4-only} ${IPV6+--inet6-only}"
+
+if [ -n "$NODE_BUILD_MIRROR_URL" ]; then
+  NODE_BUILD_MIRROR_URL="${NODE_BUILD_MIRROR_URL%/}"
+else
+  unset NODE_BUILD_MIRROR_URL
+fi
+
+if [ -n "$NODE_BUILD_SKIP_MIRROR" ]; then
+  unset NODE_BUILD_MIRROR_URL
+fi
 
 SEED="$(date "+%Y%m%d%H%M%S").$$"
 LOG_PATH="${TMP}/node-build.${SEED}.log"

--- a/bin/node-build
+++ b/bin/node-build
@@ -444,7 +444,7 @@ fetch_tarball() {
     package_url="${package_url%%#*}"
 
     if [ -n "$NODE_BUILD_MIRROR_URL" ]; then
-      mirror_url="${NODE_BUILD_MIRROR_URL}/$checksum"
+      mirror_url="${package_url/https:\/\/nodejs.org\/dist/$NODE_BUILD_MIRROR_URL}"
     fi
   fi
 

--- a/bin/node-build
+++ b/bin/node-build
@@ -903,6 +903,10 @@ ARIA2_OPTS="${NODE_BUILD_ARIA2_OPTS} ${IPV4+--disable-ipv6=true} ${IPV6+--disabl
 CURL_OPTS="${NODE_BUILD_CURL_OPTS} ${IPV4+--ipv4} ${IPV6+--ipv6}"
 WGET_OPTS="${NODE_BUILD_WGET_OPTS} ${IPV4+--inet4-only} ${IPV6+--inet6-only}"
 
+if ! has_checksum_support compute_sha2; then
+  NODE_BUILD_SKIP_MIRROR=true
+fi
+
 if [ -n "$NODE_BUILD_MIRROR_URL" ]; then
   NODE_BUILD_MIRROR_URL="${NODE_BUILD_MIRROR_URL%/}"
 else

--- a/bin/node-build
+++ b/bin/node-build
@@ -903,17 +903,13 @@ ARIA2_OPTS="${NODE_BUILD_ARIA2_OPTS} ${IPV4+--disable-ipv6=true} ${IPV6+--disabl
 CURL_OPTS="${NODE_BUILD_CURL_OPTS} ${IPV4+--ipv4} ${IPV6+--ipv6}"
 WGET_OPTS="${NODE_BUILD_WGET_OPTS} ${IPV4+--inet4-only} ${IPV6+--inet6-only}"
 
+NODE_BUILD_MIRROR_URL="${NODE_BUILD_MIRROR_URL%/}"
+
 if ! has_checksum_support compute_sha2; then
   NODE_BUILD_SKIP_MIRROR=true
 fi
 
-if [ -n "$NODE_BUILD_MIRROR_URL" ]; then
-  NODE_BUILD_MIRROR_URL="${NODE_BUILD_MIRROR_URL%/}"
-else
-  unset NODE_BUILD_MIRROR_URL
-fi
-
-if [ -n "$NODE_BUILD_SKIP_MIRROR" ]; then
+if [ -n "$NODE_BUILD_SKIP_MIRROR" ] || [ -z "$NODE_BUILD_MIRROR_URL" ]; then
   unset NODE_BUILD_MIRROR_URL
 fi
 

--- a/bin/node-build
+++ b/bin/node-build
@@ -202,6 +202,13 @@ matches_platform() {
   [ "${platform[2]}-${platform[0]}" = "$match" ]
 }
 
+mirror() {
+  local package_url="$1"
+  local checksum="$2"
+
+  echo "${package_url/https:\/\/nodejs.org\/dist/$NODE_BUILD_MIRROR_URL}"
+}
+
 try_binary(){
   [ -n "$BINARY_URL" ] && [ -z "$SKIP_BINARY" ] && [ -z "$BINARY_ATTEMPT" ]
 }
@@ -443,8 +450,8 @@ fetch_tarball() {
     checksum="${package_url#*#}"
     package_url="${package_url%%#*}"
 
-    if [ -n "$NODE_BUILD_MIRROR_URL" ]; then
-      mirror_url="${package_url/https:\/\/nodejs.org\/dist/$NODE_BUILD_MIRROR_URL}"
+    if [ -z "$NODE_BUILD_SKIP_MIRROR" ]; then
+      mirror_url="$("${NODE_BUILD_MIRROR_CMD:=mirror}" $package_url $checksum 2>&4)" || unset mirror_url
     fi
   fi
 
@@ -466,9 +473,7 @@ fetch_tarball() {
   fi
 
   if ! reuse_existing_tarball "$package_filename" "$checksum"; then
-    local tarball_filename=$(basename $package_url)
-    echo "Downloading ${tarball_filename}..." >&2
-    http head "$mirror_url" &&
+    echo "Downloading $(basename $package_url)..." >&2
     download_tarball "$mirror_url" "$package_filename" "$checksum" ||
     download_tarball "$package_url" "$package_filename" "$checksum"
   fi
@@ -905,12 +910,9 @@ WGET_OPTS="${NODE_BUILD_WGET_OPTS} ${IPV4+--inet4-only} ${IPV6+--inet6-only}"
 
 NODE_BUILD_MIRROR_URL="${NODE_BUILD_MIRROR_URL%/}"
 
-if ! has_checksum_support compute_sha2; then
+if ! has_checksum_support compute_sha2 ||
+  { [ -z "$NODE_BUILD_MIRROR_URL" ] && [ -z "$NODE_BUILD_MIRROR_CMD" ]; } then
   NODE_BUILD_SKIP_MIRROR=true
-fi
-
-if [ -n "$NODE_BUILD_SKIP_MIRROR" ] || [ -z "$NODE_BUILD_MIRROR_URL" ]; then
-  unset NODE_BUILD_MIRROR_URL
 fi
 
 SEED="$(date "+%Y%m%d%H%M%S").$$"

--- a/test/cache.bats
+++ b/test/cache.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 
 load test_helper
+export NODE_BUILD_SKIP_MIRROR=1
 export NODE_BUILD_CACHE_PATH="$BATS_TMPDIR/cache"
 export NODE_BUILD_CURL_OPTS=
 
@@ -51,10 +52,11 @@ setup() {
 }
 
 
-@test "cached package with invalid checksum falls back to original URL and updates cache" {
+@test "cached package with invalid checksum falls back to mirror and updates cache" {
+  export NODE_BUILD_SKIP_MIRROR=
   local checksum="ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
   stub shasum true "echo invalid" "echo $checksum"
-  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3"
 
   touch "${NODE_BUILD_CACHE_PATH}/package-1.0.0.tar.gz"
 

--- a/test/checksum.bats
+++ b/test/checksum.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 
 load test_helper
+export NODE_BUILD_SKIP_MIRROR=1
 export NODE_BUILD_CACHE_PATH=
 export NODE_BUILD_CURL_OPTS=
 

--- a/test/fetch.bats
+++ b/test/fetch.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 
 load test_helper
+export NODE_BUILD_SKIP_MIRROR=1
 export NODE_BUILD_CACHE_PATH=
 export NODE_BUILD_ARIA2_OPTS=
 

--- a/test/mirror.bats
+++ b/test/mirror.bats
@@ -92,21 +92,3 @@ setup() {
   unstub curl
   unstub shasum
 }
-
-
-@test "default mirror URL" {
-  export NODE_BUILD_MIRROR_URL=
-  local checksum="ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
-
-  stub shasum true "echo $checksum"
-  stub curl "-*I* : true" \
-    "-q -o * -*S* https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3" \
-
-  install_fixture definitions/with-checksum
-
-  assert_success
-  assert [ -x "${INSTALL_ROOT}/bin/package" ]
-
-  unstub curl
-  unstub shasum
-}

--- a/test/mirror.bats
+++ b/test/mirror.bats
@@ -1,0 +1,102 @@
+#!/usr/bin/env bats
+
+load test_helper
+export NODE_BUILD_SKIP_MIRROR=
+export NODE_BUILD_CACHE_PATH=
+export NODE_BUILD_MIRROR_URL=http://mirror.example.com
+
+
+@test "package URL without checksum bypasses mirror" {
+  stub shasum true
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
+
+  install_fixture definitions/without-checksum
+  echo "$output" >&2
+  [ "$status" -eq 0 ]
+  [ -x "${INSTALL_ROOT}/bin/package" ]
+
+  unstub curl
+  unstub shasum
+}
+
+
+@test "package URL with checksum but no shasum support bypasses mirror" {
+  stub shasum false
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
+
+  install_fixture definitions/with-checksum
+  [ "$status" -eq 0 ]
+  [ -x "${INSTALL_ROOT}/bin/package" ]
+
+  unstub curl
+  unstub shasum
+}
+
+
+@test "package URL with checksum hits mirror first" {
+  local checksum="ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
+  local mirror_url="${NODE_BUILD_MIRROR_URL}/$checksum"
+
+  stub shasum true "echo $checksum"
+  stub curl "-*I* $mirror_url : true" \
+    "-q -o * -*S* $mirror_url : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3"
+
+  install_fixture definitions/with-checksum
+  [ "$status" -eq 0 ]
+  [ -x "${INSTALL_ROOT}/bin/package" ]
+
+  unstub curl
+  unstub shasum
+}
+
+
+@test "package is fetched from original URL if mirror download fails" {
+  local checksum="ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
+  local mirror_url="${NODE_BUILD_MIRROR_URL}/$checksum"
+
+  stub shasum true "echo $checksum"
+  stub curl "-*I* $mirror_url : false" \
+    "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
+
+  install_fixture definitions/with-checksum
+  [ "$status" -eq 0 ]
+  [ -x "${INSTALL_ROOT}/bin/package" ]
+
+  unstub curl
+  unstub shasum
+}
+
+
+@test "package is fetched from original URL if mirror download checksum is invalid" {
+  local checksum="ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
+  local mirror_url="${NODE_BUILD_MIRROR_URL}/$checksum"
+
+  stub shasum true "echo invalid" "echo $checksum"
+  stub curl "-*I* $mirror_url : true" \
+    "-q -o * -*S* $mirror_url : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3" \
+    "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
+
+  install_fixture definitions/with-checksum
+  echo "$output" >&2
+  [ "$status" -eq 0 ]
+  [ -x "${INSTALL_ROOT}/bin/package" ]
+
+  unstub curl
+  unstub shasum
+}
+
+
+@test "default mirror URL" {
+  export NODE_BUILD_MIRROR_URL=
+  local checksum="ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
+
+  stub shasum true "echo $checksum"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3"
+
+  install_fixture definitions/with-checksum
+  [ "$status" -eq 0 ]
+  [ -x "${INSTALL_ROOT}/bin/package" ]
+
+  unstub curl
+  unstub shasum
+}

--- a/test/mirror.bats
+++ b/test/mirror.bats
@@ -4,19 +4,23 @@ load test_helper
 export NODE_BUILD_SKIP_MIRROR=
 export NODE_BUILD_CACHE_PATH=
 export NODE_BUILD_MIRROR_URL=http://mirror.example.com
+export NODE_BUILD_CURL_OPTS=
+
+setup() {
+  ensure_not_found_in_path aria2c
+}
 
 
 @test "package URL without checksum bypasses mirror" {
-  stub shasum true
   stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/without-checksum
   echo "$output" >&2
-  [ "$status" -eq 0 ]
-  [ -x "${INSTALL_ROOT}/bin/package" ]
+
+  assert_success
+  assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
   unstub curl
-  unstub shasum
 }
 
 
@@ -25,8 +29,9 @@ export NODE_BUILD_MIRROR_URL=http://mirror.example.com
   stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/with-checksum
-  [ "$status" -eq 0 ]
-  [ -x "${INSTALL_ROOT}/bin/package" ]
+
+  assert_success
+  assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
   unstub curl
   unstub shasum
@@ -42,8 +47,9 @@ export NODE_BUILD_MIRROR_URL=http://mirror.example.com
     "-q -o * -*S* $mirror_url : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3"
 
   install_fixture definitions/with-checksum
-  [ "$status" -eq 0 ]
-  [ -x "${INSTALL_ROOT}/bin/package" ]
+
+  assert_success
+  assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
   unstub curl
   unstub shasum
@@ -59,8 +65,9 @@ export NODE_BUILD_MIRROR_URL=http://mirror.example.com
     "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/with-checksum
-  [ "$status" -eq 0 ]
-  [ -x "${INSTALL_ROOT}/bin/package" ]
+
+  assert_success
+  assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
   unstub curl
   unstub shasum
@@ -78,8 +85,9 @@ export NODE_BUILD_MIRROR_URL=http://mirror.example.com
 
   install_fixture definitions/with-checksum
   echo "$output" >&2
-  [ "$status" -eq 0 ]
-  [ -x "${INSTALL_ROOT}/bin/package" ]
+
+  assert_success
+  assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
   unstub curl
   unstub shasum
@@ -91,11 +99,13 @@ export NODE_BUILD_MIRROR_URL=http://mirror.example.com
   local checksum="ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
 
   stub shasum true "echo $checksum"
-  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3"
+  stub curl "-*I* : true" \
+    "-q -o * -*S* https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3" \
 
   install_fixture definitions/with-checksum
-  [ "$status" -eq 0 ]
-  [ -x "${INSTALL_ROOT}/bin/package" ]
+
+  assert_success
+  assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
   unstub curl
   unstub shasum


### PR DESCRIPTION
node-build will not provide a default mirror, but this PR at least restores the ability to select a mirror from which to download packages.

- [x] fix 2 failing tests
- [x] fix mirror_url formulation (currently follows ruby's mirror url format, which is $mirror_host/$checksum. Needs to be a regular mirror copying full url structure. see https://github.com/nodenv/node-build/pull/208#issuecomment-260416775

closes #208