### PR TITLE
Chakracore build defs

### DIFF
--- a/share/node-build/chakracore-dev
+++ b/share/node-build/chakracore-dev
@@ -1,0 +1,1 @@
+install_git chakracore "https://github.com/nodejs/node-chakracore.git" xplat standard

--- a/share/node-build/chakracore-nightly
+++ b/share/node-build/chakracore-nightly
@@ -1,0 +1,36 @@
+# after_install_package() {
+#   local v="$("${PREFIX_PATH}/bin/node" -v)"
+#   local prefix="$(dirname "$PREFIX_PATH")"
+#   mv "$PREFIX_PATH" "${prefix}/${v#v}"
+# }
+
+nightlies="https://nodejs.org/download/chakracore-nightly"
+
+read -ra manifest < <(http get "${nightlies}/index.tab" | grep linux-x64,osx-x64-tar | sort -rn -t $'\t' -k2,2 -k1,1 | head -1)
+
+version="${manifest[0]}"
+date="${manifest[1]}"
+
+# warn message if more than one release for recent date
+
+latest="$(http get "${nightlies}/index.tab" | grep "$date")"
+if [ $(wc -l <<<"$latest") -gt 1 ]; then
+  {
+    echo "More than one nightly release; installing first of:"
+    echo "$latest"
+  } >&2
+fi
+
+# do platform matching of binaries
+
+IFS=',' read -ra files <<< "${manifest[2]}"
+for file in "${files[@]}"; do
+  case "$file" in
+    headers | src | osx-*-pkg | win-* ) continue;;
+    osx-x64-tar ) file="darwin-x64";;
+  esac
+
+  binary "$file" "${nightlies}/${version}/node-${version}-${file}.tar.gz"
+done
+
+install_package "$version" "${nightlies}/${version}/node-${version}.tar.gz"


### PR DESCRIPTION
version rename (to match exact build version) is currently failing ( #235 )

Currently rename behavior is disabled.

See also: from-source build steps https://github.com/nodejs/node-chakracore//#mac-os

Currently not doing anything special for icu4c. May need further investigation.