### PR TITLE
Revert "After install, rename nightly to the actual version string"

### DIFF
--- a/share/node-build/nightly
+++ b/share/node-build/nightly
@@ -1,9 +1,3 @@
-after_install_package() {
-  local v="$("${PREFIX_PATH}/bin/node" -v)"
-  local prefix="$(dirname "$PREFIX_PATH")"
-  mv "$PREFIX_PATH" "${prefix}/${v#v}"
-}
-
 nightlies="https://nodejs.org/download/nightly"
 
 read -ra manifest < <(http get "${nightlies}/index.tab" | grep src | sort -rn -t $'\t' -k2,2 -k1,1 | head -1)


### PR DESCRIPTION
Unsure how this was missed, but `after_install_package` can't simply mv the installed version from 'nightly' to the versioned path. It causes any subsequent code which relies on `$PREFIX_PATH` (like fix_directory_permissions and any other registered hooks) to fail.

Naive attempt to just modify `PREFIX_PATH` as part of the after install hook was unsuccessful. It seemed to apply to fix_directory_permissions, but not any other registered after-install hooks.

More work should be done to investigate options, but for now we need to at least allow nightlies to be installed as `nightly`.

fixes #235 