### PR TITLE
Adds node 6.0.0-rc.0

### DIFF
--- a/share/node-build/6.0.0-rc.0
+++ b/share/node-build/6.0.0-rc.0
@@ -1,0 +1,13 @@
+binary darwin-x64 "https://nodejs.org/download/rc/v6.0.0-rc.0/node-v6.0.0-rc.0-darwin-x64.tar.gz#f1bce00d126d0ad8c87155f44ac2d1b82df80de902b505395ff4b4dd81070336"
+binary linux-arm64 "https://nodejs.org/download/rc/v6.0.0-rc.0/node-v6.0.0-rc.0-linux-arm64.tar.gz#48282b852f4bbbc87de15d1ed0c9312cdf60554afe6c37917f803aaae969be4e"
+binary linux-armv6l "https://nodejs.org/download/rc/v6.0.0-rc.0/node-v6.0.0-rc.0-linux-armv6l.tar.gz#3461cefff6d6223238272b8b0933cd73c925d2bf708738ced51aed105b32b150"
+binary linux-armv7l "https://nodejs.org/download/rc/v6.0.0-rc.0/node-v6.0.0-rc.0-linux-armv7l.tar.gz#fc35b931a71bcbc76103708b718ffa547784cc277e3cf548fbf9cec063e311cd"
+binary linux-ppc64le "https://nodejs.org/download/rc/v6.0.0-rc.0/node-v6.0.0-rc.0-linux-ppc64le.tar.gz#688debd48e614fceee38842c3009b2925c1dbca440fbae84de563f0bf3a06811"
+binary linux-x64 "https://nodejs.org/download/rc/v6.0.0-rc.0/node-v6.0.0-rc.0-linux-x64.tar.gz#21f86f0466dfea1485745d09f189cd25f2d497c204ba6ebb0582a79d423536fa"
+binary linux-x86 "https://nodejs.org/download/rc/v6.0.0-rc.0/node-v6.0.0-rc.0-linux-x86.tar.gz#8485cb56f16cb48f7556502e56c0930f2bc02d103fff0c447581865be9cf520c"
+binary sunos-x64 "https://nodejs.org/download/rc/v6.0.0-rc.0/node-v6.0.0-rc.0-sunos-x64.tar.gz#1f1dbfc638d78f4830971cd0f48656b12d09b44124032f1d7487f9146664ebb5"
+binary sunos-x86 "https://nodejs.org/download/rc/v6.0.0-rc.0/node-v6.0.0-rc.0-sunos-x86.tar.gz#689f20dbe3db1f1170442aedcbf765899933fda1c3e907baa30b35a14b8fdb7c"
+
+# FIXME: No source package available for this release; but the binaries work so this is still needed
+# see: https://github.com/nodejs/help/issues/636
+install_package "undefined" "https://nodejs.org/download/rc/v6.0.0-rc.0/undefined.tar.gz#"


### PR DESCRIPTION
This definition file is a bit weird since it's "binaries only". Which
means this build will fail if the platform doesn't match a provided
binary; or if source compile is requested.

see: https://github.com/nodejs/help/issues/636