### PR TITLE
Restore uname stubbings

### DIFF
--- a/test/build.bats
+++ b/test/build.bats
@@ -60,7 +60,6 @@ assert_build_log() {
 @test "apply node patch before building" {
   cached_tarball "node-v4.0.0"
 
-  stub uname '-s : echo Linux'
   stub brew false
   stub_make_install
   stub patch ' : echo patch "$@" | sed -E "s/\.[[:alnum:]]+$/.XXX/" >> build.log'
@@ -68,7 +67,6 @@ assert_build_log() {
   TMPDIR="$BATS_TMPDIR" install_fixture --patch definitions/vanilla-node <<<""
   assert_success
 
-  unstub uname
   unstub make
   unstub patch
 
@@ -83,7 +81,6 @@ OUT
 @test "apply node patch from git diff before building" {
   cached_tarball "node-v4.0.0"
 
-  stub uname '-s : echo Linux'
   stub brew false
   stub_make_install
   stub patch ' : echo patch "$@" | sed -E "s/\.[[:alnum:]]+$/.XXX/" >> build.log'
@@ -91,7 +88,6 @@ OUT
   TMPDIR="$BATS_TMPDIR" install_fixture --patch definitions/vanilla-node <<<"diff --git a/script.rb"
   assert_success
 
-  unstub uname
   unstub make
   unstub patch
 
@@ -177,7 +173,6 @@ OUT
 @test "setting NODE_MAKE_INSTALL_OPTS to a multi-word string" {
   cached_tarball "node-v4.0.0"
 
-  stub uname '-s : echo Linux'
   stub_make_install
 
   export NODE_MAKE_INSTALL_OPTS="DOGE=\"such wow\""
@@ -186,7 +181,6 @@ install_package "node-v4.0.0" "http://nodejs.org/dist/v4.0.0/node-v4.0.0.tar.gz"
 DEF
   assert_success
 
-  unstub uname
   unstub make
 
   assert_build_log <<OUT
@@ -199,7 +193,6 @@ OUT
 @test "setting MAKE_INSTALL_OPTS to a multi-word string" {
   cached_tarball "node-v4.0.0"
 
-  stub uname '-s : echo Linux'
   stub_make_install
 
   export MAKE_INSTALL_OPTS="DOGE=\"such wow\""
@@ -208,7 +201,6 @@ install_package "node-v4.0.0" "http://nodejs.org/dist/v4.0.0/node-v4.0.0.tar.gz"
 DEF
   assert_success
 
-  unstub uname
   unstub make
 
   assert_build_log <<OUT
@@ -273,7 +265,6 @@ apply -p1 -i /my/patch.diff
 exec ./configure "\$@"
 CONF
 
-  stub uname '-s : echo Linux'
   stub apply 'echo apply "$@" >> build.log'
   stub_make_install
 
@@ -283,7 +274,6 @@ install_package "node-v4.0.0" "http://nodejs.org/dist/v4.0.0/node-v4.0.0.tar.gz"
 DEF
   assert_success
 
-  unstub uname
   unstub make
   unstub apply
 

--- a/test/build.bats
+++ b/test/build.bats
@@ -60,6 +60,7 @@ assert_build_log() {
 @test "apply node patch before building" {
   cached_tarball "node-v4.0.0"
 
+  stub uname '-s : echo Linux'
   stub brew false
   stub_make_install
   stub patch ' : echo patch "$@" | sed -E "s/\.[[:alnum:]]+$/.XXX/" >> build.log'
@@ -67,6 +68,7 @@ assert_build_log() {
   TMPDIR="$BATS_TMPDIR" install_fixture --patch definitions/vanilla-node <<<""
   assert_success
 
+  unstub uname
   unstub make
   unstub patch
 
@@ -81,6 +83,7 @@ OUT
 @test "apply node patch from git diff before building" {
   cached_tarball "node-v4.0.0"
 
+  stub uname '-s : echo Linux'
   stub brew false
   stub_make_install
   stub patch ' : echo patch "$@" | sed -E "s/\.[[:alnum:]]+$/.XXX/" >> build.log'
@@ -88,6 +91,7 @@ OUT
   TMPDIR="$BATS_TMPDIR" install_fixture --patch definitions/vanilla-node <<<"diff --git a/script.rb"
   assert_success
 
+  unstub uname
   unstub make
   unstub patch
 
@@ -173,6 +177,7 @@ OUT
 @test "setting NODE_MAKE_INSTALL_OPTS to a multi-word string" {
   cached_tarball "node-v4.0.0"
 
+  stub uname '-s : echo Linux'
   stub_make_install
 
   export NODE_MAKE_INSTALL_OPTS="DOGE=\"such wow\""
@@ -181,6 +186,7 @@ install_package "node-v4.0.0" "http://nodejs.org/dist/v4.0.0/node-v4.0.0.tar.gz"
 DEF
   assert_success
 
+  unstub uname
   unstub make
 
   assert_build_log <<OUT
@@ -193,6 +199,7 @@ OUT
 @test "setting MAKE_INSTALL_OPTS to a multi-word string" {
   cached_tarball "node-v4.0.0"
 
+  stub uname '-s : echo Linux'
   stub_make_install
 
   export MAKE_INSTALL_OPTS="DOGE=\"such wow\""
@@ -201,6 +208,7 @@ install_package "node-v4.0.0" "http://nodejs.org/dist/v4.0.0/node-v4.0.0.tar.gz"
 DEF
   assert_success
 
+  unstub uname
   unstub make
 
   assert_build_log <<OUT
@@ -265,6 +273,7 @@ apply -p1 -i /my/patch.diff
 exec ./configure "\$@"
 CONF
 
+  stub uname '-s : echo Linux'
   stub apply 'echo apply "$@" >> build.log'
   stub_make_install
 
@@ -274,6 +283,7 @@ install_package "node-v4.0.0" "http://nodejs.org/dist/v4.0.0/node-v4.0.0.tar.gz"
 DEF
   assert_success
 
+  unstub uname
   unstub make
   unstub apply
 

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -8,7 +8,10 @@ load ../node_modules/bats-mock/stub
 if [ "$FIXTURE_ROOT" != "$BATS_TEST_DIRNAME/fixtures" ]; then
   export FIXTURE_ROOT="$BATS_TEST_DIRNAME/fixtures"
   export INSTALL_ROOT="$BATS_TMPDIR/install"
-  PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+  if [ "FreeBSD" = "$(uname -s)" ]; then
+    PATH="/usr/local/bin:$PATH"
+  fi
   PATH="$BATS_TEST_DIRNAME/../bin:$PATH"
   PATH="$BATS_MOCK_BINDIR:$PATH"
   export PATH


### PR DESCRIPTION
https://github.com/rbenv/ruby-build/pull/1038 broke the test suite on OS X with 0a347a45374eed0b44a6e2273ce24919b7568217.
This breakage was reverted when ruby-build updates were pulled into node-build with #230.
However, the revert breaks tests on freebsd (presumably).

We need to find a fix that passes on Linux, FreeBSD and OSX.