### PR TITLE
V8 canary

### DIFF
--- a/share/node-build/chakracore-nightly
+++ b/share/node-build/chakracore-nightly
@@ -4,16 +4,16 @@
 #   mv "$PREFIX_PATH" "${prefix}/${v#v}"
 # }
 
-nightlies="https://nodejs.org/download/chakracore-nightly"
+downloads="https://nodejs.org/download/chakracore-nightly"
 
-read -ra manifest < <(http get "${nightlies}/index.tab" | grep linux-x64,osx-x64-tar | sort -rn -t $'\t' -k2,2 -k1,1 | head -1)
+read -ra manifest < <(http get "${downloads}/index.tab" | grep linux-x64,osx-x64-tar | sort -rn -t $'\t' -k2,2 -k1,1 | head -1)
 
 version="${manifest[0]}"
 date="${manifest[1]}"
 
 # warn message if more than one release for recent date
 
-latest="$(http get "${nightlies}/index.tab" | grep "$date")"
+latest="$(http get "${downloads}/index.tab" | grep "$date")"
 if [ $(wc -l <<<"$latest") -gt 1 ]; then
   {
     echo "More than one nightly release; installing first of:"
@@ -30,7 +30,7 @@ for file in "${files[@]}"; do
     osx-x64-tar ) file="darwin-x64";;
   esac
 
-  binary "$file" "${nightlies}/${version}/node-${version}-${file}.tar.gz"
+  binary "$file" "${downloads}/${version}/node-${version}-${file}.tar.gz"
 done
 
-install_package "$version" "${nightlies}/${version}/node-${version}.tar.gz"
+install_package "$version" "${downloads}/${version}/node-${version}.tar.gz"

--- a/share/node-build/nightly
+++ b/share/node-build/nightly
@@ -1,13 +1,13 @@
-nightlies="https://nodejs.org/download/nightly"
+downloads="https://nodejs.org/download/nightly"
 
-read -ra manifest < <(http get "${nightlies}/index.tab" | grep src | sort -rn -t $'\t' -k2,2 -k1,1 | head -1)
+read -ra manifest < <(http get "${downloads}/index.tab" | grep src | sort -rn -t $'\t' -k2,2 -k1,1 | head -1)
 
 version="${manifest[0]}"
 date="${manifest[1]}"
 
 # warn message if more than one release for recent date
 
-latest="$(http get "${nightlies}/index.tab" | grep "$date")"
+latest="$(http get "${downloads}/index.tab" | grep "$date")"
 if [ $(wc -l <<<"$latest") -gt 1 ]; then
   {
     echo "More than one nightly release; installing first of:"
@@ -24,7 +24,7 @@ for file in "${files[@]}"; do
     osx-x64-tar ) file="darwin-x64";;
   esac
 
-  binary "$file" "${nightlies}/${version}/node-${version}-${file}.tar.gz"
+  binary "$file" "${downloads}/${version}/node-${version}-${file}.tar.gz"
 done
 
-install_package "$version" "${nightlies}/${version}/node-${version}.tar.gz"
+install_package "$version" "${downloads}/${version}/node-${version}.tar.gz"

--- a/share/node-build/rc
+++ b/share/node-build/rc
@@ -1,0 +1,30 @@
+downloads="https://nodejs.org/download/rc"
+
+read -ra manifest < <(http get "${downloads}/index.tab" | grep src | sort -rn -t $'\t' -k2,2 -k1,1 | head -1)
+
+version="${manifest[0]}"
+date="${manifest[1]}"
+
+# warn message if more than one release for recent date
+
+latest="$(http get "${downloads}/index.tab" | grep "$date")"
+if [ $(wc -l <<<"$latest") -gt 1 ]; then
+  {
+    echo "More than one v8-canary release; installing first of:"
+    echo "$latest"
+  } >&2
+fi
+
+# do platform matching of binaries
+
+IFS=',' read -ra files <<< "${manifest[2]}"
+for file in "${files[@]}"; do
+  case "$file" in
+    headers | src | osx-*-pkg | win-* ) continue;;
+    osx-x64-tar ) file="darwin-x64";;
+  esac
+
+  binary "$file" "${downloads}/${version}/node-${version}-${file}.tar.gz"
+done
+
+install_package "$version" "${downloads}/${version}/node-${version}.tar.gz"

--- a/share/node-build/v8-canary
+++ b/share/node-build/v8-canary
@@ -1,0 +1,30 @@
+downloads="https://nodejs.org/download/v8-canary"
+
+read -ra manifest < <(http get "${downloads}/index.tab" | grep src | sort -rn -t $'\t' -k2,2 -k1,1 | head -1)
+
+version="${manifest[0]}"
+date="${manifest[1]}"
+
+# warn message if more than one release for recent date
+
+latest="$(http get "${downloads}/index.tab" | grep "$date")"
+if [ $(wc -l <<<"$latest") -gt 1 ]; then
+  {
+    echo "More than one v8-canary release; installing first of:"
+    echo "$latest"
+  } >&2
+fi
+
+# do platform matching of binaries
+
+IFS=',' read -ra files <<< "${manifest[2]}"
+for file in "${files[@]}"; do
+  case "$file" in
+    headers | src | osx-*-pkg | win-* ) continue;;
+    osx-x64-tar ) file="darwin-x64";;
+  esac
+
+  binary "$file" "${downloads}/${version}/node-${version}-${file}.tar.gz"
+done
+
+install_package "$version" "${downloads}/${version}/node-${version}.tar.gz"


### PR DESCRIPTION
Adds dynamic build definitions (build defs that pull their packages from latest on nodejs.org) for v8-canary and rc.

Still need to figure out postinstall-renaming.