### PR TITLE
Learn how to rename a node after installation

### DIFF
--- a/bin/node-build
+++ b/bin/node-build
@@ -713,6 +713,17 @@ after_install_package() {
   local stub=1
 }
 
+rename_node() {
+  local name=${1:-$(./bin/node --version)}
+  local prefix=$(dirname "$PREFIX_PATH")
+  local new_path=${prefix:?not set}/${name#v}
+
+  #TODO check for preexisting
+  mv -f "$PREFIX_PATH" "$new_path"
+  ln -s "$(basename $new_path)" "$PREFIX_PATH"
+  PREFIX_PATH=$new_path
+}
+
 fix_jxcore_directory_structure() {
   {
     mkdir -p "$PREFIX_PATH/bin"

--- a/share/node-build/nightly
+++ b/share/node-build/nightly
@@ -1,3 +1,7 @@
+after_install_package() {
+  rename_node
+}
+
 downloads="https://nodejs.org/download/nightly"
 
 read -ra manifest < <(http get "${downloads}/index.tab" | grep src | sort -rn -t $'\t' -k2,2 -k1,1 | head -1)


### PR DESCRIPTION
The rename_node function is part of node-build that way the build
definitions simply need to define their after_install_package function
to invoke rename_node.

The function accepts a specific name as the new name, but defaults the
name to the actual response from `node --version`.

PREFIX_PATH must be updated after the move such that the rest of
node-build knows about the new location.

After moving the installed node, a symlink is created at the original
location pointing to the new location. This allows end users to set
their selected node using the same name as the build definition.
Further, this "hack" allows any other plugins that hook into
after-install to continue operating unchanged. Without the symlink,
`PREFIX` and `NODENV_VERSION` would be incorrect for all after-install
hooks. However, as they now refer to an existing directory (symlink),
the hooks will operate on the newly installed node correctly.

Fixes #237 
Unblocks #145 

## todo
- [ ] handle the "new name" already existing