### PR TITLE
Release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "scrape-definitions": "nodenv update-version-defs --destination $PWD/share/node-build/",
     "submit-definitions": "script/submit-definitions -r",
     "publish:brew": "brew-publish $npm_package_name v$npm_package_version",
-    "publish:github": "git push --follow-tags && script/release",
+    "publish:github": "git push --follow-tags && script/github_release",
     "sync-version": "perl -pi -e \"s/^(NODE_BUILD_VERSION=).*$/\\${1}${npm_package_version}/\" -- bin/node-build && git add -- bin/node-build",
     "preversion": "script/preversion",
     "version": "npm run sync-version",

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "submit-definitions": "script/submit-definitions -r",
     "publish:brew": "brew-publish $npm_package_name v$npm_package_version",
     "publish:github": "git push --follow-tags && script/github_release",
-    "sync-version": "perl -pi -e \"s/^(NODE_BUILD_VERSION=).*$/\\${1}${npm_package_version}/\" -- bin/node-build && git add -- bin/node-build",
+    "stamp-version": "perl -pi -e \"s/^(NODE_BUILD_VERSION=).*$/\\${1}${npm_package_version}/\" -- bin/node-build && git add -- bin/node-build",
     "preversion": "script/preversion",
-    "version": "npm run sync-version",
+    "version": "npm run stamp-version",
     "postversion": "npm run publish:github && npm run publish:brew"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
     "bin": "bin",
     "test": "test"
   },
-  "config": {
-    "publish": true
-  },
   "scripts": {
     "test": "bats ${CI:+--tap} test",
     "verify-definitions": "script/verify-definitions",
@@ -33,7 +30,7 @@
     "sync-version": "perl -pi -e \"s/^(NODE_BUILD_VERSION=).*$/\\${1}${npm_package_version}/\" -- bin/node-build && git add -- bin/node-build",
     "preversion": "script/release",
     "version": "npm run sync-version",
-    "postversion": "git push --follow-tags && [ \"$npm_package_config_publish\" != true ] || npm run publish:brew"
+    "postversion": "git push --follow-tags && npm run publish:brew"
   },
   "devDependencies": {
     "bats": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "scrape-definitions": "nodenv update-version-defs --destination $PWD/share/node-build/",
     "submit-definitions": "script/submit-definitions -r",
     "publish:brew": "brew-publish $npm_package_name v$npm_package_version",
-    "publish:github": "git push --follow-tags",
+    "publish:github": "git push --follow-tags && script/release",
     "sync-version": "perl -pi -e \"s/^(NODE_BUILD_VERSION=).*$/\\${1}${npm_package_version}/\" -- bin/node-build && git add -- bin/node-build",
-    "preversion": "script/release",
+    "preversion": "script/preversion",
     "version": "npm run sync-version",
     "postversion": "npm run publish:github && npm run publish:brew"
   },

--- a/package.json
+++ b/package.json
@@ -27,10 +27,11 @@
     "scrape-definitions": "nodenv update-version-defs --destination $PWD/share/node-build/",
     "submit-definitions": "script/submit-definitions -r",
     "publish:brew": "brew-publish $npm_package_name v$npm_package_version",
+    "publish:github": "git push --follow-tags",
     "sync-version": "perl -pi -e \"s/^(NODE_BUILD_VERSION=).*$/\\${1}${npm_package_version}/\" -- bin/node-build && git add -- bin/node-build",
     "preversion": "script/release",
     "version": "npm run sync-version",
-    "postversion": "git push --follow-tags && npm run publish:brew"
+    "postversion": "npm run publish:github && npm run publish:brew"
   },
   "devDependencies": {
     "bats": "^0.4.2",

--- a/script/github_release
+++ b/script/github_release
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-# Usage: script/release
+#!/usr/bin/env sh
+# Usage: script/github_release <version>
 #
 # - creates a Release on github
 

--- a/script/preversion
+++ b/script/preversion
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+# Usage: script/preversion
+#
+# - fetch from origin
+# - ensure it isn't already tagged
+# - ensure currently on master branch
+# - ensure there are bin or definition changes to release
+
+set -e
+
+git fetch --quiet --tags origin master
+
+existing="$(git tag --points-at HEAD)"
+if [ -n "$existing" ]; then
+  echo "Aborting: HEAD is already tagged as '${existing}'" >&2
+  exit 1
+fi
+
+current_branch="$(git symbolic-ref --short HEAD)"
+if [ "$current_branch" != master ]; then
+  echo "Aborting: Not currently on master branch" >&2
+  exit 1
+fi
+
+previous_tag="$(git describe --tags --abbrev=0)"
+if git diff --quiet "${previous_tag}..HEAD" -- bin share; then
+  echo "Aborting: No features to release since '${previous_tag}'" >&2
+  exit 1
+fi

--- a/script/release
+++ b/script/release
@@ -1,43 +1,22 @@
 #!/usr/bin/env bash
 # Usage: script/release
 #
-# preversion
-# - fetchs from origin
-# - ensures it isn't already tagged
-# - ensures currently on master branch
-# - ensures there are bin or definition changes to release
-# version (handled by npm and script/update-version)
-# - bumps version in package.json
-# - bumps NODE_BUILD_VERSION in bin/node-build
-# - commits and tags
-# postversion (handled by npm-script)
-# - pushes master + tag to GitHub
-# - opens pull request to update the Homebrew formula
+# - creates a Release on github
 
 set -e
 
-git fetch --quiet --tags origin master
+new_version=${1:-$npm_package_version}
 
-existing="$(git tag --points-at HEAD)"
-if [ -n "$existing" ]; then
-  echo "Aborting: HEAD is already tagged as '${existing}'" >&2
-  exit 1
-fi
+previous_tag() {
+ git describe --tags --abbrev=0
+}
 
-current_branch="$(git symbolic-ref --short HEAD)"
-if [ "$current_branch" != master ]; then
-  echo "Aborting: Not currently on master branch" >&2
-  exit 1
-fi
-
-previous_tag="$(git describe --tags --abbrev=0)"
-if git diff --quiet "${previous_tag}..HEAD" -- bin share; then
-  echo "Aborting: No features to release since '${previous_tag}'" >&2
-  exit 1
-fi
-
-{ echo "node-build ${npm_package_version:?}"
+release_message() {
+  echo "node-build $new_version"
   echo
-  git log --no-merges --format='%w(0,0,2)* %B' --reverse "${previous_tag}..HEAD" -- bin share
-} | hub release create --file=- "v${npm_package_version}" || true
-hub browse -- "releases/v${npm_package_version}"
+  git log --no-merges --format='%w(0,0,2)* %B' --reverse "$(previous_tag)..HEAD" -- bin share
+}
+
+release_message | hub release create --file=- "v$new_version" || true
+
+hub browse -- "releases/v$new_version"


### PR DESCRIPTION
This should resolve the issue with releases getting tags _after_ the commit that bumped the version.