### PR TITLE
Always use gmake on FreeBSD 11

### DIFF
--- a/bin/node-build
+++ b/bin/node-build
@@ -895,7 +895,7 @@ if [ -n "$noexec" ]; then
 fi
 
 if [ -z "$MAKE" ]; then
-  if [ "FreeBSD" = "$(uname -s)" ] && [ "$(uname -r | sed 's/[^[:digit:]].*//')" -lt 10 ]; then
+  if [ "FreeBSD" = "$(uname -s)" ] && [ "$(uname -r | sed 's/[^[:digit:]].*//')" -ne 10 ]; then
     export MAKE="gmake"
   else
     export MAKE="make"

--- a/test/build.bats
+++ b/test/build.bats
@@ -245,15 +245,16 @@ OUT
   unstub uname
 }
 
-@test "make on FreeBSD 11" {
+@test "make on FreeBSD 11 defaults to gmake" {
   cached_tarball "node-v4.0.0"
 
   stub uname "-s : echo FreeBSD" "-r : echo 11.0-RELEASE"
-  stub_make_install
+  MAKE=gmake stub_make_install
 
   MAKE= install_fixture definitions/vanilla-node
   assert_success
 
+  unstub gmake
   unstub uname
 }
 


### PR DESCRIPTION
Node.js's BSDmakefile requires use of `gmake`, and calling `make`, which will just spawn gmake, is both useless, and does not function properly on FreeBSD 11, due to spaces between `-j` and the count in `MAKE_OPTS`.