### PR TITLE
Always use gmake on FreeBSD

### DIFF
--- a/bin/node-build
+++ b/bin/node-build
@@ -895,7 +895,7 @@ if [ -n "$noexec" ]; then
 fi
 
 if [ -z "$MAKE" ]; then
-  if [ "FreeBSD" = "$(uname -s)" ] && [ "$(uname -r | sed 's/[^[:digit:]].*//')" -lt 10 ]; then
+  if [ "FreeBSD" = "$(uname -s)" ] && [ "$(uname -r | sed 's/[^[:digit:]].*//')" -ne 10 ]; then
     export MAKE="gmake"
   else
     export MAKE="make"

--- a/bin/node-build
+++ b/bin/node-build
@@ -895,7 +895,8 @@ if [ -n "$noexec" ]; then
 fi
 
 if [ -z "$MAKE" ]; then
-  if [ "FreeBSD" = "$(uname -s)" ] && [ "$(uname -r | sed 's/[^[:digit:]].*//')" -ne 10 ]; then
+  if [ "FreeBSD" = "$(uname -s)" ]; then
+    # node needs gmake on FreeBSD : https://github.com/nodejs/node/blob/0229e378e80948428cf7baa7b176939e879497cc/BSDmakefile#L7
     export MAKE="gmake"
   else
     export MAKE="make"

--- a/test/build.bats
+++ b/test/build.bats
@@ -220,35 +220,10 @@ OUT
   assert [ -x ./here/bin/package ]
 }
 
-@test "make on FreeBSD 9 defaults to gmake" {
+@test "make on FreeBSD defaults to gmake" {
   cached_tarball "node-v4.0.0"
 
-  stub uname "-s : echo FreeBSD" "-r : echo 9.1"
-  MAKE=gmake stub_make_install
-
-  MAKE= install_fixture definitions/vanilla-node
-  assert_success
-
-  unstub gmake
-  unstub uname
-}
-
-@test "make on FreeBSD 10" {
-  cached_tarball "node-v4.0.0"
-
-  stub uname "-s : echo FreeBSD" "-r : echo 10.0-RELEASE"
-  stub_make_install
-
-  MAKE= install_fixture definitions/vanilla-node
-  assert_success
-
-  unstub uname
-}
-
-@test "make on FreeBSD 11 defaults to gmake" {
-  cached_tarball "node-v4.0.0"
-
-  stub uname "-s : echo FreeBSD" "-r : echo 11.0-RELEASE"
+  stub uname "-s : echo FreeBSD"
   MAKE=gmake stub_make_install
 
   MAKE= install_fixture definitions/vanilla-node

--- a/test/build.bats
+++ b/test/build.bats
@@ -245,15 +245,16 @@ OUT
   unstub uname
 }
 
-@test "make on FreeBSD 11" {
+@test "make on FreeBSD 11 defaults to gmake" {
   cached_tarball "node-v4.0.0"
 
   stub uname "-s : echo FreeBSD" "-r : echo 11.0-RELEASE"
-  stub_make_install
+  MAKE=gmake stub_make_install
 
   MAKE= install_fixture definitions/vanilla-node
   assert_success
 
+  unstub gmake
   unstub uname
 }
 


### PR DESCRIPTION
It was an inheritance from ruby-build that was allowing regular make for 
   FreeBSD 10. However, node itself requires gmake for all versions of FreeBSD
   (indeed, the BSDmakefile just calls through to gmake)

   So let's simplify the logic and just default to gmake for all versions of
   FreeBSD.

Includes neersighted's initial patch to work on FreeBSD 11. Closes #377