### PR TITLE
Adds chakracore defs for versions 8 and 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,4 @@ os:
 jobs:
   include:
     - stage: verify definitions
-      if: env(TRAVIS_COMMIT_RANGE) is present
       script: npm run verify-definitions -- $TRAVIS_COMMIT_RANGE

--- a/share/node-build/chakracore-10.0.0
+++ b/share/node-build/chakracore-10.0.0
@@ -1,0 +1,4 @@
+binary darwin-x64 "https://nodejs.org/download/chakracore-release/v10.0.0/node-v10.0.0-darwin-x64.tar.gz#223438f6001a98ba53c1ef91ddb7360963921eb17dde630394c26a0fbba10091"
+binary linux-x64 "https://nodejs.org/download/chakracore-release/v10.0.0/node-v10.0.0-linux-x64.tar.gz#b79ebc3a983c1b58d8bad7ff2828abbfa1e74a00e5ce6b8a84424b6559aad93c"
+
+install_package "node-v10.0.0" "https://nodejs.org/download/chakracore-release/v10.0.0/node-v10.0.0.tar.gz#d3d8fcc0d0319866639f3ab3ec53d21498bb9998859948acaf0fc84da3f0006b"

--- a/share/node-build/chakracore-10.1.0
+++ b/share/node-build/chakracore-10.1.0
@@ -1,0 +1,4 @@
+binary darwin-x64 "https://nodejs.org/download/chakracore-release/v10.1.0/node-v10.1.0-darwin-x64.tar.gz#0e2a1ab2531191bf7f91f5c6e54a8e9d9cc65c8561230bd4e08f07d59986b339"
+binary linux-x64 "https://nodejs.org/download/chakracore-release/v10.1.0/node-v10.1.0-linux-x64.tar.gz#0569a7ca5fde88f48fe67e04b9540daba32af237c167e65760abf6d873f3e379"
+
+install_package "node-v10.1.0" "https://nodejs.org/download/chakracore-release/v10.1.0/node-v10.1.0.tar.gz#49f24ea820e67e5787de4dc6395d624c7f0a58d37f1030807c8f03190e9aa91a"

--- a/share/node-build/chakracore-10.13.0
+++ b/share/node-build/chakracore-10.13.0
@@ -1,0 +1,4 @@
+binary darwin-x64 "https://nodejs.org/download/chakracore-release/v10.13.0/node-v10.13.0-darwin-x64.tar.gz#6bdd21c9600242556e6f61fe7713c8310c723561496668f58de802d4f8a9b3e7"
+binary linux-x64 "https://nodejs.org/download/chakracore-release/v10.13.0/node-v10.13.0-linux-x64.tar.gz#15eec5a8ecc8f7bcdf81dcacd0a690eec1b8a094b2b8e94d4b58bfad5e07ea56"
+
+install_package "node-v10.13.0" "https://nodejs.org/download/chakracore-release/v10.13.0/node-v10.13.0.tar.gz#e4b0235f8b275153126b2c334dd318039162d4361a401c950f0d6cbe9da8c714"

--- a/share/node-build/chakracore-10.6.0
+++ b/share/node-build/chakracore-10.6.0
@@ -1,0 +1,4 @@
+binary darwin-x64 "https://nodejs.org/download/chakracore-release/v10.6.0/node-v10.6.0-darwin-x64.tar.gz#1549e2fbce75d4d45bac8965ffe67072f0fcc6153b75fa75d603b49579e6c7db"
+binary linux-x64 "https://nodejs.org/download/chakracore-release/v10.6.0/node-v10.6.0-linux-x64.tar.gz#fed24f5366a97101394b53fce9f59e7763f92582d4dbf2ce941a28267379e774"
+
+install_package "node-v10.6.0" "https://nodejs.org/download/chakracore-release/v10.6.0/node-v10.6.0.tar.gz#7df930f15966badf9ed9afa61b90840b5247b8b140319f915649d487449b6b6a"

--- a/share/node-build/chakracore-8.1.2
+++ b/share/node-build/chakracore-8.1.2
@@ -1,0 +1,4 @@
+binary darwin-x64 "https://nodejs.org/download/chakracore-release/v8.1.2/node-v8.1.2-darwin-x64.tar.gz#590801f43af9d682d83ec3d600d64b9e8b7bf7c353751d6cbbe224f40c46e15a"
+binary linux-x64 "https://nodejs.org/download/chakracore-release/v8.1.2/node-v8.1.2-linux-x64.tar.gz#ad175fbf56add6002659d4fba0230c21ddb52d4c2424a1624b5ee5351499794d"
+
+install_package "node-v8.1.2" "https://nodejs.org/download/chakracore-release/v8.1.2/node-v8.1.2.tar.gz#f297e3778cd712d085e754a0e64a24d776f541f22914f4721367707523d2a934"

--- a/share/node-build/chakracore-8.1.4
+++ b/share/node-build/chakracore-8.1.4
@@ -1,0 +1,4 @@
+binary darwin-x64 "https://nodejs.org/download/chakracore-release/v8.1.4/node-v8.1.4-darwin-x64.tar.gz#ba87a6db5163c54dc7c9c343e7487d65c0971cd9c16b9f79121abbf1c9876487"
+binary linux-x64 "https://nodejs.org/download/chakracore-release/v8.1.4/node-v8.1.4-linux-x64.tar.gz#6a03681714f22cdce645509093679c726d55f32f9790567e04c5a508e379717a"
+
+install_package "node-v8.1.4" "https://nodejs.org/download/chakracore-release/v8.1.4/node-v8.1.4.tar.gz#28bfea7b982a9c3c21b3ba0b500e05fee7945460b6696a7ebc0ebe28d1e46ad1"

--- a/share/node-build/chakracore-8.10.0
+++ b/share/node-build/chakracore-8.10.0
@@ -1,0 +1,4 @@
+binary darwin-x64 "https://nodejs.org/download/chakracore-release/v8.10.0/node-v8.10.0-darwin-x64.tar.gz#0f66efd367c3fd2a3488f67bb3a1c6647d41f18200df865f8a5d7afd71236134"
+binary linux-x64 "https://nodejs.org/download/chakracore-release/v8.10.0/node-v8.10.0-linux-x64.tar.gz#55d8c46dd237449d9206685b5f9a3d2ea2a7c8b9a549b74c2af3fd5ff35319f2"
+
+install_package "node-v8.10.0" "https://nodejs.org/download/chakracore-release/v8.10.0/node-v8.10.0.tar.gz#292d2b39af90d5a4f9907a309be87400ff893155613e69f0e5f0b388203f94f9"

--- a/share/node-build/chakracore-8.11.1
+++ b/share/node-build/chakracore-8.11.1
@@ -1,0 +1,4 @@
+binary darwin-x64 "https://nodejs.org/download/chakracore-release/v8.11.1/node-v8.11.1-darwin-x64.tar.gz#04d155ba4628f07bcbdd2c7285de8fb3baf55cc2b37ae4c7993324750ed6b41f"
+binary linux-x64 "https://nodejs.org/download/chakracore-release/v8.11.1/node-v8.11.1-linux-x64.tar.gz#7b4d09424a4e26dd0ec91284c238156c36571250c27c46976ed1c363bffb13a2"
+
+install_package "node-v8.11.1" "https://nodejs.org/download/chakracore-release/v8.11.1/node-v8.11.1.tar.gz#cd8cc6da8377f8d12a20512b83a38e5e40b2ab6970c86e20c858169d871dcfe3"

--- a/share/node-build/chakracore-8.2.1
+++ b/share/node-build/chakracore-8.2.1
@@ -1,0 +1,4 @@
+binary darwin-x64 "https://nodejs.org/download/chakracore-release/v8.2.1/node-v8.2.1-darwin-x64.tar.gz#452efcd519b30b83ba63257ca47bae188a7dee3ee3be3b99c23b9513d3e95015"
+binary linux-x64 "https://nodejs.org/download/chakracore-release/v8.2.1/node-v8.2.1-linux-x64.tar.gz#13f990957dab092bd88f2c372495b9728bca762a7c796ad385702712dbc77d4f"
+
+install_package "node-v8.2.1" "https://nodejs.org/download/chakracore-release/v8.2.1/node-v8.2.1.tar.gz#b0a416230be078e694584c84a451e9e4cc35a98d91d184fc1fd81e76724b5369"

--- a/share/node-build/chakracore-8.3.0
+++ b/share/node-build/chakracore-8.3.0
@@ -1,0 +1,4 @@
+binary darwin-x64 "https://nodejs.org/download/chakracore-release/v8.3.0/node-v8.3.0-darwin-x64.tar.gz#3d0796d0b5c85eefd3a7f5bdadffadbec799b7e626f51e10bd44601298e74c12"
+binary linux-x64 "https://nodejs.org/download/chakracore-release/v8.3.0/node-v8.3.0-linux-x64.tar.gz#cf78ae4622be5e82cb538cde9b6e0bcea47e9ef431e305fae4f80698c3658d7a"
+
+install_package "node-v8.3.0" "https://nodejs.org/download/chakracore-release/v8.3.0/node-v8.3.0.tar.gz#3c3b24b61b8776fa663183eb37ce00752d21e891548d7ddfb6a37bdac454a1d0"

--- a/share/node-build/chakracore-8.4.0
+++ b/share/node-build/chakracore-8.4.0
@@ -1,0 +1,4 @@
+binary darwin-x64 "https://nodejs.org/download/chakracore-release/v8.4.0/node-v8.4.0-darwin-x64.tar.gz#7a04b1f1dab5d6daf5bca9b0864fed34307315d8d705aa14b94b13848f1816c1"
+binary linux-x64 "https://nodejs.org/download/chakracore-release/v8.4.0/node-v8.4.0-linux-x64.tar.gz#db07893293def67380ef160125513fa8fb74351a08086099debab3a792b55558"
+
+install_package "node-v8.4.0" "https://nodejs.org/download/chakracore-release/v8.4.0/node-v8.4.0.tar.gz#79bbf497873afdf4c94f4e94285019d771712226a7956673c38541d682389f89"

--- a/share/node-build/chakracore-8.6.0
+++ b/share/node-build/chakracore-8.6.0
@@ -1,0 +1,4 @@
+binary darwin-x64 "https://nodejs.org/download/chakracore-release/v8.6.0/node-v8.6.0-darwin-x64.tar.gz#76d565a85d0a5078a16585011a3ad37dd119ca772ef1a07e16063274f88dfc63"
+binary linux-x64 "https://nodejs.org/download/chakracore-release/v8.6.0/node-v8.6.0-linux-x64.tar.gz#baa00c6267ee2d9363d333d956a4870500ac78ed9ef3ca10da4836e012aecee1"
+
+install_package "node-v8.6.0" "https://nodejs.org/download/chakracore-release/v8.6.0/node-v8.6.0.tar.gz#84e76d937ee964f3305f37af41a31eeddc6954a7d5fda14e0df4ca96a09b1f60"

--- a/share/node-build/chakracore-8.9.4
+++ b/share/node-build/chakracore-8.9.4
@@ -1,0 +1,4 @@
+binary darwin-x64 "https://nodejs.org/download/chakracore-release/v8.9.4/node-v8.9.4-darwin-x64.tar.gz#e47559d95117f9a096d77250f10865b8c7d842b96ebfcc0c87be07ec3bc99da8"
+binary linux-x64 "https://nodejs.org/download/chakracore-release/v8.9.4/node-v8.9.4-linux-x64.tar.gz#de8a93b070ba1a15b1f7755ceb4121fffdb144dbff9fa0c411f7ef04a9da5b49"
+
+install_package "node-v8.9.4" "https://nodejs.org/download/chakracore-release/v8.9.4/node-v8.9.4.tar.gz#010b63e2ee3eff86a610a3aee78cf328f0debbf46612be2e0ae953b8f39a8372"


### PR DESCRIPTION
Source builds haven't been officially confirmed to work.
Need to support the options available here: https://github.com/Microsoft/ChakraCore/wiki/Building-ChakraCore

Particularly for --static (embed JSRT as a static library), custom
--icu, --debug or --test-build, and -n to use ninja instead of cmake.

(indeed, confirming make works instead of cmake needs to happen)

Lots of other options available:

https://github.com/Microsoft/ChakraCore/blob/master/build.sh#L37-L84