### PR TITLE
Exit early with better message if missing pkg_url

### DIFF
--- a/bin/node-build
+++ b/bin/node-build
@@ -461,6 +461,11 @@ fetch_tarball() {
   local checksum
   local extracted_dir
 
+  if [ -z "$package_url" ]; then
+    echo "error: failed to download $package_name (missing package url)" >&2
+    return 1
+  fi
+
   if [ "$package_url" != "${package_url/\#}" ]; then
     checksum="${package_url#*#}"
     package_url="${package_url%%#*}"


### PR DESCRIPTION
Instead of silently proceeding until the download fails for an empty
URL, mark the parameter as required so we get an early (and useful)
error message.

closes #259