### PR TITLE
Test definition warning messages based on nodejs schedule.json

### DIFF
--- a/test/eol-lts.bats
+++ b/test/eol-lts.bats
@@ -6,54 +6,7 @@ setup() {
   cd "$BATS_TEST_DIRNAME/../share/node-build"
 }
 
-assert_eol() {
-  run grep -e "warn_eol" --files-without-match "$@"
+@test "definitions have EOL and LTS warnings" {
+  run echo "$("$BATS_TEST_DIRNAME/helpers/warning_messages" 2>/dev/null)"
   assert_output ""
-}
-
-assert_lts() {
-  run grep -e "warn_lts" --files-without-match "$@"
-  assert_output ""
-}
-
-assert_warning() {
-  state=$1
-  date=$2
-
-  if [ "$(date -j +'%s')" -gt $(date -j -f "%F" "$date" "+%s") ]; then
-    "assert_$state" "${@:3}"
-  fi
-}
-
-@test "EOL nodes have warnings" {
-  assert_eol 0.*
-  assert_eol 4.*
-  assert_eol 5.*
-  assert_eol 7.*
-  assert_eol 9.*
-  assert_eol iojs-*
-}
-
-@test "Node 6 is in LTS Maintenace April 2018 - April 2019" {
-  assert_warning eol '2019-04-01' 6.*
-  assert_warning lts '2018-04-30' 6.*
-}
-
-@test "Node 8 is in LTS Maintenace April 2019 - Dec 2019" {
-  assert_warning eol '2019-12-01' 8.*
-  assert_warning lts '2019-04-01' 8.*
-}
-
-@test "Node 10 is LTS Maintenance April 2020 - April 2021" {
-  assert_warning eol '2021-04-01' 10.*
-  assert_warning lts '2020-04-01' 10.*
-}
-
-@test "Node 11 is EOL June 2019" {
-  assert_warning eol '2019-06-01' 11.*
-}
-
-@test "Node 12 is LTS Maintenance April 2021 - April 2022" {
-  assert_warning eol '2022-04-01' 12.*
-  assert_warning lts '2021-04-01' 12.*
 }

--- a/test/helpers/warning_messages
+++ b/test/helpers/warning_messages
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# Scrapes LTS/EOL schedule from https://github.com/nodejs/Release/blob/master/schedule.json
+# Asserts that all definitions for a given version include the EOL or LTS Maintenance warning message,
+# as appropriate.
+# Prints status messages to STDERR
+# Prints failing definition filenames to STDOUT
+
+set -euo pipefail
+IFS=$'\n\t'
+
+schedule_json() {
+  curl -qsSfJL https://raw.githubusercontent.com/nodejs/Release/master/schedule.json
+}
+
+parse_json() {
+  awk '
+  /"v[[:digit:]]+":/ {
+    gsub(/[^[:digit:].]/, "")
+    version = $0
+    print "versions+=(" version ")"
+    next
+  }
+
+  /".*":/ && version {
+    gsub(/[ "]/, "")
+    gsub(/,$/, "")
+    split($0, v, /:/)
+
+    print "v" version "_" v[1] "=\"" v[2] "\""
+    next
+  }
+
+  /}/ {
+    version = 0
+    next
+  }
+'
+}
+
+past() {
+ test "$(date -j +'%s')" -gt "$(date -j -f "%F" "$1" "+%s")"
+}
+
+assert_message() {
+  local msg=$1
+  local v=$2
+  local files_missing_messages
+
+  echo "asserting $msg message for v$v" >&2
+
+  files_missing_messages="$(grep -e "warn_$msg" --files-without-match "$v".*)"
+
+  test -z "$files_missing_messages" || ( echo "$files_missing_messages" && return 1 )
+}
+
+assert_warnings() {
+  local v=$1
+  local maint=$2
+  local eol=$3
+
+  if past "$eol"; then assert_message eol "$v"
+  elif past "$maint"; then assert_message lts "$v"
+  fi
+}
+
+declare -a versions
+
+
+eval "$(schedule_json | parse_json)"
+
+status=0
+
+for v in "${versions[@]}"; do
+  maint="v${v}_maintenance"
+  eol="v${v}_end"
+
+  echo "v$v maint: ${!maint} eol: ${!eol}" >&2
+  assert_warnings "$v" "${!maint}" "${!eol}" || status=$?
+done
+
+exit $status


### PR DESCRIPTION
Scrape and parse the schedule.json from nodejs' Release repo.

Print the definition files that are missing the EOL or LTS-maintenance
warning, per the current date.

closes #427 