### PR TITLE
Uninstall multiple nodes at once

### DIFF
--- a/bin/nodenv-uninstall
+++ b/bin/nodenv-uninstall
@@ -2,7 +2,7 @@
 #
 # Summary: Uninstall a specific Node version
 #
-# Usage: nodenv uninstall [-f|--force] <version>
+# Usage: nodenv uninstall [-f|--force] <version>...
 #
 #    -f  Attempt to remove the specified version without prompting
 #        for confirmation. If the version does not exist, do not
@@ -33,14 +33,15 @@ if [ "$1" = "-f" ] || [ "$1" = "--force" ]; then
   shift
 fi
 
-[ "$#" -eq 1 ] || usage 1 >&2
+[ "$#" -gt 0 ] || usage 1 >&2
 
-DEFINITION="$1"
-case "$DEFINITION" in
-"" | -* )
-  usage 1 >&2
-  ;;
-esac
+DEFINITIONS=("$@")
+
+for DEFINITION in "${DEFINITIONS[@]}"; do
+  case "$DEFINITION" in
+  "" | -* ) usage 1 >&2 ;;
+  esac
+done
 
 declare -a before_hooks after_hooks
 
@@ -60,28 +61,31 @@ done < <(nodenv-hooks uninstall)
 # shellcheck disable=SC1090
 for script in "${scripts[@]}"; do source "$script"; done
 
+for DEFINITION in "${DEFINITIONS[@]}"; do
 
-VERSION_NAME="${DEFINITION##*/}"
-PREFIX="${NODENV_ROOT}/versions/${VERSION_NAME}"
+  VERSION_NAME="${DEFINITION##*/}"
+  PREFIX="${NODENV_ROOT}/versions/${VERSION_NAME}"
 
-if [ -z "$FORCE" ]; then
-  if [ ! -d "$PREFIX" ]; then
-    echo "nodenv: version \`$VERSION_NAME' not installed" >&2
-    exit 1
+  if [ -z "$FORCE" ]; then
+    if [ ! -d "$PREFIX" ]; then
+      echo "nodenv: version \`$VERSION_NAME' not installed" >&2
+      exit 1
+    fi
+
+    read -rp "nodenv: remove $PREFIX? [yN] "
+    case "$REPLY" in
+    y* | Y* ) ;;
+    * ) exit 1 ;;
+    esac
   fi
 
-  read -rp "nodenv: remove $PREFIX? [yN] "
-  case "$REPLY" in
-  y* | Y* ) ;;
-  * ) exit 1 ;;
-  esac
-fi
+  for hook in "${before_hooks[@]}"; do eval "$hook"; done
 
-for hook in "${before_hooks[@]}"; do eval "$hook"; done
+  if [ -d "$PREFIX" ]; then
+    rm -rf "$PREFIX"
+    nodenv-rehash
+  fi
 
-if [ -d "$PREFIX" ]; then
-  rm -rf "$PREFIX"
-  nodenv-rehash
-fi
+  for hook in "${after_hooks[@]}"; do eval "$hook"; done
 
-for hook in "${after_hooks[@]}"; do eval "$hook"; done
+done

--- a/bin/nodenv-uninstall
+++ b/bin/nodenv-uninstall
@@ -14,8 +14,9 @@ set -e
 
 # Provide nodenv completions
 if [ "$1" = "--complete" ]; then
-  echo --force
-  exec nodenv versions --bare
+  exec comm -23 \
+  <({ echo --force; nodenv versions --bare;} | sort) \
+  <(printf "%s\n" "${@:1}" | sort)
 fi
 
 usage() {

--- a/bin/nodenv-uninstall
+++ b/bin/nodenv-uninstall
@@ -61,6 +61,8 @@ done < <(nodenv-hooks uninstall)
 # shellcheck disable=SC1090
 for script in "${scripts[@]}"; do source "$script"; done
 
+STATUS=0
+
 for DEFINITION in "${DEFINITIONS[@]}"; do
 
   VERSION_NAME="${DEFINITION##*/}"
@@ -69,13 +71,14 @@ for DEFINITION in "${DEFINITIONS[@]}"; do
   if [ -z "$FORCE" ]; then
     if [ ! -d "$PREFIX" ]; then
       echo "nodenv: version \`$VERSION_NAME' not installed" >&2
-      exit 1
+      STATUS=1
+      continue
     fi
 
     read -rp "nodenv: remove $PREFIX? [yN] "
     case "$REPLY" in
     y* | Y* ) ;;
-    * ) exit 1 ;;
+    * ) STATUS=1; continue ;;
     esac
   fi
 
@@ -89,3 +92,5 @@ for DEFINITION in "${DEFINITIONS[@]}"; do
   for hook in "${after_hooks[@]}"; do eval "$hook"; done
 
 done
+
+exit $STATUS

--- a/test/nodenv.bats
+++ b/test/nodenv.bats
@@ -199,12 +199,18 @@ OUT
   unstub nodenv-help
 }
 
-@test "too many arguments for nodenv-uninstall" {
-  stub nodenv-help 'uninstall : true'
+@test "nodenv-uninstall can uninstall multiple nodes at once" {
+  mkdir -p "${NODENV_ROOT}/versions/4.0.0"
+  mkdir -p "${NODENV_ROOT}/versions/4.1.1"
+  mkdir -p "${NODENV_ROOT}/versions/4.2.2"
 
-  run nodenv-uninstall 4.1.1 4.1.2
-  assert_failure
-  unstub nodenv-help
+  run nodenv-uninstall -f 4.1.1 4.2.2
+
+  assert_success
+  refute_output
+  assert [ -d "${NODENV_ROOT}/versions/4.0.0" ]
+  refute [ -d "${NODENV_ROOT}/versions/4.1.1" ]
+  refute [ -d "${NODENV_ROOT}/versions/4.2.2" ]
 }
 
 @test "show help for nodenv-uninstall" {


### PR DESCRIPTION
Iterates over all versions passed to nodenv-uninstall and removes (as well as invokes before/after hooks) for each node version.

Uninstalls continue past a failure (though messages are printed as per usual) and exit status is 0 if _all_ were uninstalled successfully. 1 otherwise.

A nice improvement would be for the completion invocation to not complete any nodes not already provided. But that's left for later.

closes #92