### PR TITLE
Improve version list sorting

### DIFF
--- a/bin/node-build
+++ b/bin/node-build
@@ -839,8 +839,9 @@ list_definitions() {
 }
 
 sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z.\1/; s/$/.z/; G; s/\n/ /' | \
-    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+  sed -E 'h; s/[~^<>=[:space:]]//g; s/^([[:digit:]])/a.\1/g; s/[+-]/./g; s/$/.0.0.0.0/; G; s/\n/ /' \
+  | LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n \
+  | cut -d' ' -f 2-
 }
 
 

--- a/test/definitions.bats
+++ b/test/definitions.bats
@@ -76,6 +76,7 @@ NUM_DEFINITIONS="$(ls "$BATS_TEST_DIRNAME"/../share/node-build | wc -l)"
 4.0.0
 4.2.3
 4.11.1
+10.0.0
 iojs-0.12.0-dev
 iojs-1.0.0
 iojs-1.x-dev


### PR DESCRIPTION
Take sort_versions function from nodenv-versions which has been updated
from rbenv's sorting function to account for node.