### PR TITLE
nodenv-install learns to remove common prefixes

### DIFF
--- a/bin/nodenv-install
+++ b/bin/nodenv-install
@@ -198,9 +198,19 @@ cleanup() {
 
 trap cleanup SIGINT
 
-# Invoke `node-build` and record the exit status in $STATUS.
-STATUS=0
-node-build $KEEP $VERBOSE $HAS_PATCH $SKIP_BINARY "$DEFINITION" "$PREFIX" || STATUS="$?"
+# Attempt node-build with definition as provided;
+# also try with common prefixes removed from the definition's name
+for def_prefix in "" v node- node-v; do
+  DEF_BASENAME=$(basename "$DEFINITION")
+  DEFINITION_ATTEMPT=${DEFINITION/%$DEF_BASENAME/${DEF_BASENAME/#$def_prefix}}
+
+  # Invoke `node-build` and record the exit status in $STATUS.
+  STATUS=0
+  node-build $KEEP $VERBOSE $HAS_PATCH $SKIP_BINARY "$DEFINITION_ATTEMPT" "$PREFIX" || STATUS="$?"
+
+  # Only attempt alternatives if it errored due to definition not found.
+  [ "$STATUS" == "2" ] || break
+done
 
 # Display a more helpful message if the definition wasn't found.
 if [ "$STATUS" == "2" ]; then


### PR DESCRIPTION
If nodenv-install is told to install a version,

- it will attempt node-build with that exact version name
- then fallback to removing a 'v' prefix from the name
- then fallback to removing a 'node-' prefix from the name
- then fallback to removing a 'node-v' prefix from the name

before ultimately failing.

This implementation only tries alternate _definition filenames_.
It does _not_ mutate the version name to which the node will be
installed. So if a fallback name is used and installed successfully, its
final installed version name will match the _originally attempted
name_.

A couple other caveats:

- the before/after install hooks only run once: before the first attempt
and after the final attempt; not before/after each attempt.
- the NODENV_VERSION set for the hooks matches the actually installed
name, not the variations attempted (or succeeded).
- node build prints an error message on each failure, so if all 3
fallbacks are attempted, there could be a maximum of 3 error messages
displayed (each one reporting the failure to find the definition file)

Example:

```
$ nodenv install node-v11.0.0
node-build: definition not found: node-v11.0.0
node-build: definition not found: node-v11.0.0
node-build: definition not found: v11.0.0
Installing node-v11.0.0-darwin-x64...
Installed node-v11.0.0-darwin-x64 to /usr/local/var/nodenv/versions/node-v11.0.0
```

closes #307