### PR TITLE
install hook to attempt retry without prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,16 @@ when using `--keep` with the `nodenv install` command. You should specify the
 location of the source code with the `NODE_BUILD_BUILD_PATH` environment
 variable when using `--keep` with `node-build`.
 
+#### Retry installation without v/node-/node-v prefix
+
+The nodenv-install plugin can attempt a retry if the installation failed due
+to a missing definition file. If the given node version name begins with
+'v', 'node', or 'node-v', the retry will drop the prefix and try again. For
+instance, if `nodenv install node-v11.0.0` fails because a definition file
+does not exist by the name "node-v11.0.0", it will retry as "11.0.0".
+For this retry to be attempted, the environment variable `NODENV_PREFIX_RETRY`
+must be non-empty.
+
 ## Getting Help
 
 Please see the [node-build wiki][wiki] for solutions to common problems.

--- a/etc/install/prefix-retry.bash
+++ b/etc/install/prefix-retry.bash
@@ -1,3 +1,5 @@
+[ -n "$NODENV_PREFIX_RETRY" ] || return 0
+
 retry_without_prefix() {
   [ "$STATUS" = 2 ] || return 0
 

--- a/etc/install/prefix-retry.bash
+++ b/etc/install/prefix-retry.bash
@@ -1,9 +1,10 @@
-[ -n "$NODENV_PREFIX_RETRY" ] || return 0
+[ -n "${NODENV_PREFIX_RETRY-}" ] || return 0
 
 retry_without_prefix() {
-  [ "$STATUS" = 2 ] || return 0
+  [ "${STATUS-}" = 2 ] || return 0
 
-  fallback_name=${VERSION_NAME#node-}
+  fallback_name=${VERSION_NAME-}
+  fallback_name=${fallback_name#node-}
   fallback_name=${fallback_name#v}
 
   [ "$fallback_name" != "$VERSION_NAME" ] || return 0

--- a/etc/install/prefix-retry.bash
+++ b/etc/install/prefix-retry.bash
@@ -1,0 +1,16 @@
+retry_without_prefix() {
+  [ "$STATUS" = 2 ] || return 0
+
+  fallback_name=${VERSION_NAME#node-}
+  fallback_name=${fallback_name#v}
+
+  [ "$fallback_name" != "$VERSION_NAME" ] || return 0
+
+  echo
+  echo "Attempting fallback install without \`node-/v' prefix: $fallback_name"
+  echo
+
+  exec nodenv-install ${FORCE+-f} ${SKIP_EXISTING+-s} ${SKIP_BINARY+-c} ${NODENV_BUILD_ROOT+-k} ${VERBOSE+-v} ${HAS_PATCH+-p} "$fallback_name"
+}
+
+after_install retry_without_prefix


### PR DESCRIPTION
Node versions have a couple very common forms; with v, node-, or node-v
prefix. This install hook will attempt to retry a failed installation
_without_ these common prefixes.

It only attempts a retry if:
- the prior installation failed
- and it failed specifically due to not finding the definition file
- and the version name has one of 'v', 'node-' or 'node-v' prefixes

It maintains the flags passed to the original install command; (however,
it only maintains _known_ flags. That is, if nodenv-install learns some
new flags, this hook will need to be made aware of them)

This hook _execs_ the retry; which means this hook preempts any
subsequent hooks from the initial install. Presumably, this should be
safe since _most_ install hooks only run on success. Further, the retry
command replaces the currently-running process, which means the second
attempt exit status will be the final status code of the original
invocation.

closes #307 

Potential change:
If there is significant concern around the retry being _undersirable_; or if there is evidence that this hooks' prevention of other hooks is a problem, we could guard the execution of this hook with an env var. That way the use of this hook would be opt-in by setting said env var.