### PR TITLE
Also install etc directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,9 +12,11 @@ if [ -z "${PREFIX}" ]; then
 fi
 
 BIN_PATH="${PREFIX}/bin"
+ETC_PATH="${PREFIX}/etc"
 SHARE_PATH="${PREFIX}/share/node-build"
 
-mkdir -p "$BIN_PATH" "$SHARE_PATH"
+mkdir -p "$BIN_PATH" "$ETC_PATH" "$SHARE_PATH"
 
 install -p bin/* "$BIN_PATH"
+install -d etc/* "$ETC_PATH"
 install -p -m 0644 share/node-build/* "$SHARE_PATH"


### PR DESCRIPTION
When installing **nodenv** via Homebrew I noticed that **node-build** dependency didn't include the install hook added by https://github.com/nodenv/node-build/pull/455. 

This PR attempts to rectify this. 

Not sure if the convention is correct but I took a stab at it and included the  `etc` folder in the install script because it's used by the Homebrew formulae:

https://github.com/Homebrew/homebrew-core/blob/4516ee029aac77079a6b1368d8d5402ed573a94b/Formula/node-build.rb#L14-L17