### PR TITLE
Fixed build error with 12.x-dev and 12.x-next.

### DIFF
--- a/bin/node-build
+++ b/bin/node-build
@@ -698,10 +698,10 @@ build_package_standard_build() {
       export CC=clang
     fi
     ${!PACKAGE_CONFIGURE:-./configure} --prefix="${!PACKAGE_PREFIX_PATH:-$PREFIX_PATH}" \
-      $CONFIGURE_OPTS ${!PACKAGE_CONFIGURE_OPTS} "${!PACKAGE_CONFIGURE_OPTS_ARRAY}" || return 1
+      $CONFIGURE_OPTS ${!PACKAGE_CONFIGURE_OPTS} ${!PACKAGE_CONFIGURE_OPTS_ARRAY} || return 1
   ) >&4 2>&1
 
-  "$MAKE" $MAKE_OPTS ${!PACKAGE_MAKE_OPTS} "${!PACKAGE_MAKE_OPTS_ARRAY}" >&4 2>&1
+  "$MAKE" $MAKE_OPTS ${!PACKAGE_MAKE_OPTS} ${!PACKAGE_MAKE_OPTS_ARRAY} >&4 2>&1
 }
 
 build_package_standard_install() {
@@ -712,7 +712,7 @@ build_package_standard_install() {
   local PACKAGE_MAKE_INSTALL_OPTS="${package_var_name}_MAKE_INSTALL_OPTS"
   local PACKAGE_MAKE_INSTALL_OPTS_ARRAY="${package_var_name}_MAKE_INSTALL_OPTS_ARRAY[@]"
 
-  "$MAKE" install $MAKE_INSTALL_OPTS ${!PACKAGE_MAKE_INSTALL_OPTS} "${!PACKAGE_MAKE_INSTALL_OPTS_ARRAY}" >&4 2>&1
+  "$MAKE" install $MAKE_INSTALL_OPTS ${!PACKAGE_MAKE_INSTALL_OPTS} ${!PACKAGE_MAKE_INSTALL_OPTS_ARRAY} >&4 2>&1
 }
 
 build_package_standard() {


### PR DESCRIPTION
I got the following error when I did invoke `nodenv install 12.x-next`.

```
~ > nodenv install 12.x-next
Cloning https://github.com/nodejs/node.git...

WARNING: 12.x-next is in LTS Maintenance mode and nearing its end of life.
It only receives *critical* security updates, *critical* bug fixes and documentation updates.

Installing 12.x-next...

BUILD FAILED (OS X 10.14.5 using node-build 4.6.1-6-g38db434a)

Inspect or clean up the working tree at /var/folders/jl/zgy9fk353nd6zn0xznlsdzvc6gxzs5/T/node-build.20190721190648.38928
Results logged to /var/folders/jl/zgy9fk353nd6zn0xznlsdzvc6gxzs5/T/node-build.20190721190648.38928.log

Last 10 log lines:
  File "tools/gyp/pylib/gyp/__init__.py", line 130, in Load
    params['parallel'], params['root_targets'])
  File "tools/gyp/pylib/gyp/input.py", line 2784, in Load
    variables, includes, depth, check, True)
  File "tools/gyp/pylib/gyp/input.py", line 392, in LoadTargetBuildFile
    includes, True, check)
  File "tools/gyp/pylib/gyp/input.py", line 234, in LoadOneBuildFile
    build_file_contents = open(build_file_path).read()
IOError: [Errno 21] Is a directory: '.'
make: *** empty string invalid as file name.  Stop.
```

I'm not sure why it's happened. Maybe, node uses python for configure script. I can build it removed the double quotation.