### PR TITLE
Ruby build updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The build process may be configured through the following environment variables:
 | `NODE_BUILD_WGET_OPTS`   | Additional options to pass to `wget` for downloading.                                              |
 | `NODE_BUILD_MIRROR_CMD`  | A command to construct the package mirror URL.                                                     |
 | `NODE_BUILD_MIRROR_URL`  | Custom mirror URL root.                                                                            |
-| `NODE_BUILD_SKIP_MIRROR` | Always download from official sources, not mirrors. (Default: unset)                               |
+| `NODE_BUILD_SKIP_MIRROR` | Bypass the download mirror and fetch all package files from their original URLs.                   |
 | `NODE_BUILD_ROOT`        | Custom build definition directory. (Default: `share/node-build`)                                   |
 | `NODE_BUILD_DEFINITIONS` | Additional paths to search for build definitions. (Colon-separated list)                           |
 | `CC`                     | Path to the C compiler.                                                                            |
@@ -152,25 +152,32 @@ automatically verify the SHA2 checksum of each downloaded package before
 installing it.
 
 Checksums are optional and specified as anchors on the package URL in each
-definition. (All bundled definitions include checksums.)
+definition. All definitions bundled with node-build include checksums.
 
 #### Package Mirrors
 
-By default, node-build downloads package files from the official
-URL specified in the definition file.
+By default, node-build downloads package files from the official URL specified in the definition file.
 
-You can point node-build to a mirror by specifying the
-`NODE_BUILD_MIRROR_URL` environment variable--useful if you'd like to run your
-own local mirror, for example. Package mirror URLs are constructed by invoking
-`NODE_BUILD_MIRROR_CMD` with two arguments: `package_url` and `checksum`. The
-provided command should print the desired mirror's package URL. If
-`NODE_BUILD_MIRROR_CMD` is unset, package mirror URL construction defaults to
-simply replacing `https://nodejs.org/dist` with `NODE_BUILD_MIRROR_URL`.
+```sh
+ # example:
+ install_package "node-v12.0.0" "https://nodejs.org/dist/v12.0.0/node-v12.0.0.tar.gz#<SHA2>"
+```
 
-If you don't have an SHA2 program installed, node-build will skip the download
-mirror and use official URLs instead. You can force node-build to bypass the
-mirror by setting the `NODE_BUILD_SKIP_MIRROR` environment variable.
+node-build will attempt to construct a mirror url by invoking `NODE_BUILD_MIRROR_CMD` with two arguments: `package_url` and `checksum`.
+The provided command should print the desired mirror's complete package URL.
+If `NODE_BUILD_MIRROR_CMD` is unset, package mirror URL construction defaults to replacing `https://nodejs.org/dist` with `NODE_BUILD_MIRROR_URL`.
 
+node-build will first try to fetch this package from `$NODE_BUILD_MIRROR_URL/<SHA2>`
+(note: this is the complete URL), where `<SHA2>` is the checksum for the file.
+
+It will fall back to downloading the package from the original location if:
+- the package was not found on the mirror;
+- the mirror is down;
+- the download is corrupt, i.e. the file's checksum doesn't match;
+- no tool is available to calculate the checksum; or
+- `NODE_BUILD_SKIP_MIRROR` is enabled.
+
+You may specify a custom mirror by setting `NODE_BUILD_MIRROR_URL`.
 
 #### Keeping the build directory after installation
 

--- a/bin/node-build
+++ b/bin/node-build
@@ -406,7 +406,7 @@ http() {
   [ -n "$2" ] || return 1
   shift 1
 
-  NODE_BUILD_HTTP_CLIENT="${NODE_BUILD_HTTP_CLIENT:-$(detect_http_client)}"
+  NODE_BUILD_HTTP_CLIENT="${NODE_BUILD_HTTP_CLIENT:-$(detect_http_client 2>&3)}"
   [ -n "$NODE_BUILD_HTTP_CLIENT" ] || return 1
 
   "http_${method}_${NODE_BUILD_HTTP_CLIENT}" "$@"
@@ -420,7 +420,7 @@ detect_http_client() {
       return
     fi
   done
-  echo "error: please install \`aria2c\`, \`curl\`, or \`wget\` and try again" >&2
+  echo "error: install \`curl\`, \`wget\`, or \`aria2c\` to download packages" >&2
   return 1
 }
 
@@ -810,7 +810,7 @@ apply_node_patch() {
     cat "${2:--}" >"$patchfile"
 
     local striplevel=0
-    grep -q '^diff --git a/' "$patchfile" && striplevel=1
+    grep -q '^--- a/' "$patchfile" && striplevel=1
     patch -p$striplevel --force -i "$patchfile"
     ;;
   esac
@@ -980,7 +980,7 @@ NODE_BIN="${PREFIX_PATH}/bin/node"
 CWD="$(pwd)"
 
 if [ -z "$NODE_BUILD_BUILD_PATH" ]; then
-  BUILD_PATH="${TMP}/node-build.${SEED}"
+  BUILD_PATH="$(mktemp -d "${LOG_PATH%.log}.XXXXXX")"
 else
   BUILD_PATH="$NODE_BUILD_BUILD_PATH"
 fi

--- a/bin/node-build
+++ b/bin/node-build
@@ -299,7 +299,6 @@ make_package() {
   before_install_package "$package_name"
   build_package "$package_name" "$@"
   after_install_package "$package_name"
-  fix_directory_permissions
   popd >&4
 }
 
@@ -782,10 +781,6 @@ fix_jxcore_directory_structure() {
     ln -sf ../libexec/.jx/npm/bin/npm-cli.js npm
     popd
   } >&4
-}
-
-fix_directory_permissions() {
-  find "$PREFIX_PATH" -type d \( -perm -020 -o -perm -002 \) -exec chmod go-w {} \;
 }
 
 # Ensure that directories listed in LDFLAGS exist

--- a/bin/nodenv-install
+++ b/bin/nodenv-install
@@ -83,9 +83,7 @@ for option in "${OPTIONS[@]}"; do
     SKIP_BINARY="-c"
     ;;
   "l" | "list" )
-    echo "Available versions:"
-    definitions | indent
-    exit
+    exec node-build --definitions
     ;;
   "f" | "force" )
     FORCE=true

--- a/test/build.bats
+++ b/test/build.bats
@@ -64,7 +64,11 @@ assert_build_log() {
   stub_make_install
   stub patch ' : echo patch "$@" | sed -E "s/\.[[:alnum:]]+$/.XXX/" >> build.log'
 
-  TMPDIR="$BATS_TMPDIR" install_fixture --patch definitions/vanilla-node <<<""
+  TMPDIR="$BATS_TMPDIR" install_fixture --patch definitions/vanilla-node <<PATCH
+diff -pU3 align.c align.c
+--- align.c 2017-09-14 21:09:29.000000000 +0900
++++ align.c 2017-09-15 05:56:46.000000000 +0900
+PATCH
   assert_success
 
   unstub make
@@ -78,6 +82,31 @@ make install
 OUT
 }
 
+@test "striplevel node patch before building" {
+  cached_tarball "node-v4.0.0"
+
+  stub brew false
+  stub_make_install
+  stub patch ' : echo patch "$@" | sed -E "s/\.[[:alnum:]]+$/.XXX/" >> build.log'
+
+  TMPDIR="$BATS_TMPDIR" install_fixture --patch definitions/vanilla-node <<PATCH
+diff -pU3 a/configure b/configure
+--- a/configure 2017-09-14 21:09:29.000000000 +0900
++++ b/configure 2017-09-15 05:56:46.000000000 +0900
+PATCH
+  assert_success
+
+  unstub make
+  unstub patch
+
+  assert_build_log <<OUT
+patch -p1 --force -i $BATS_TMPDIR/node-patch.XXX
+node-v4.0.0: --prefix=$INSTALL_ROOT
+make -j 2
+make install
+OUT
+}
+
 @test "apply node patch from git diff before building" {
   cached_tarball "node-v4.0.0"
 
@@ -85,7 +114,12 @@ OUT
   stub_make_install
   stub patch ' : echo patch "$@" | sed -E "s/\.[[:alnum:]]+$/.XXX/" >> build.log'
 
-  TMPDIR="$BATS_TMPDIR" install_fixture --patch definitions/vanilla-node <<<"diff --git a/script.rb"
+  TMPDIR="$BATS_TMPDIR" install_fixture --patch definitions/vanilla-node <<PATCH
+diff --git a/test/build.bats b/test/build.bats
+index 4760c31..66a237a 100755
+--- a/test/build.bats
++++ b/test/build.bats
+PATCH
   assert_success
 
   unstub make

--- a/test/fetch.bats
+++ b/test/fetch.bats
@@ -18,6 +18,15 @@ setup() {
   assert_output --partial "error: failed to download package-1.0.0.tar.gz"
 }
 
+@test "no download tool" {
+  export -n NODE_BUILD_HTTP_CLIENT
+  clean_path="$(remove_commands_from_path curl wget aria2c)"
+
+  PATH="$clean_path" install_fixture definitions/without-checksum
+  assert_failure
+  assert_output --partial 'error: install `curl`, `wget`, or `aria2c` to download packages'
+}
+
 @test "using aria2c if available" {
   export NODE_BUILD_ARIA2_OPTS=
   export -n NODE_BUILD_HTTP_CLIENT

--- a/test/nodenv.bats
+++ b/test/nodenv.bats
@@ -43,12 +43,11 @@ stub_node_build() {
   run nodenv-install --list
   assert_success
   assert_output - <<OUT
-Available versions:
-  0.8.7
-  0.10.4
-  0.11.0
-  1.0.0
-  4.1.2
+0.8.7
+0.10.4
+0.11.0
+1.0.0
+4.1.2
 OUT
 
   unstub node-build
@@ -130,10 +129,9 @@ OUT
   run nodenv-install --list
   assert_success
   assert_output - <<OUT
-Available versions:
-  
-  ${NODENV_ROOT}/plugins/bar/share/node-build
-  ${NODENV_ROOT}/plugins/foo/share/node-build
+
+${NODENV_ROOT}/plugins/bar/share/node-build
+${NODENV_ROOT}/plugins/foo/share/node-build
 OUT
 }
 

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -20,6 +20,19 @@ if [ "$FIXTURE_ROOT" != "$BATS_TEST_DIRNAME/fixtures" ]; then
   export PATH
 fi
 
+remove_commands_from_path() {
+  local path cmd
+  local paths=( $(command -v "$@" | sed 's!/[^/]*$!!' | sort -u) )
+  local NEWPATH=":$PATH:"
+  for path in "${paths[@]}"; do
+    local tmp_path="$(mktemp -d "$TMP/path.XXXXX")"
+    ln -fs "$path"/* "$tmp_path/"
+    for cmd; do rm -f "$tmp_path/$cmd"; done
+    NEWPATH="${NEWPATH/:$path:/:$tmp_path:}"
+  done
+  echo "${NEWPATH#:}"
+}
+
 teardown() {
   rm -fr "${BATS_TMPDIR:?}"/*
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -17,6 +17,7 @@ if [ "$FIXTURE_ROOT" != "$BATS_TEST_DIRNAME/fixtures" ]; then
   fi
   PATH="$BATS_TEST_DIRNAME/../bin:$PATH"
   PATH="$BATS_MOCK_BINDIR:$PATH"
+  PATH="$BATS_TMPDIR/bin:$PATH"
   export PATH
 fi
 
@@ -25,7 +26,7 @@ remove_commands_from_path() {
   local paths=( $(command -v "$@" | sed 's!/[^/]*$!!' | sort -u) )
   local NEWPATH=":$PATH:"
   for path in "${paths[@]}"; do
-    local tmp_path="$(mktemp -d "$TMP/path.XXXXX")"
+    local tmp_path="$(mktemp -d "$BATS_TMPDIR/path.XXXXX")"
     ln -fs "$path"/* "$tmp_path/"
     for cmd; do rm -f "$tmp_path/$cmd"; done
     NEWPATH="${NEWPATH/:$path:/:$tmp_path:}"


### PR DESCRIPTION

- Handle non-git patches a59672a
- Improve documentation for mirror urls. 0dc5ad7 dafe705 a963078
- Remove overzealous permission change post-install 3a10951
- Have `nodenv install --list` output match `node-build --definitions` 9e41ff4
- Use `mktemp` to securely initialize the build directory c660cfc
- Improve error shown when curl, wget, & aria2c are unavailable e2b1da8
- Ensure missing curl/wget/aria2c error message is shown on Linux 0d3e3b8