### PR TITLE
Add upgrading message for fish shell

### DIFF
--- a/bin/nodenv-install
+++ b/bin/nodenv-install
@@ -218,7 +218,16 @@ if [ "$STATUS" == "2" ]; then
       echo "  brew update && brew upgrade node-build"
     elif [ -d "${here}/.git" ]; then
       printf ":\\n\\n"
-      echo "  cd ${here} && git pull && cd -"
+
+      shell="$(basename "${NODENV_SHELL:-$SHELL}")"
+      case "$shell" in
+      fish )
+        echo "  cd ${here}; and git pull; and cd -"
+        ;;
+      * )
+        echo "  cd ${here} && git pull && cd -"
+        ;;
+      esac
     else
       printf ".\\n"
     fi


### PR DESCRIPTION
Hello node-build maintainers.

I usually use nodenv with fish shell. In nodenv, I think the following message is output when a node version definition to need to install is not found.

```
$ nodenv install 100.13.1
node-build: definition not found: 100.13.1

See all available versions with `nodenv install --list'.

If the version you need is missing, try upgrading node-build:

  cd /Users/username/.nodenv/plugins/node-build && git pull && cd -
```

The upgrading command doesn't work in fish shell, so I think the message is unsuitable for fish users.