### PR TITLE
Remove npm caching

### DIFF
--- a/.github/workflows/scrape-definitions.yml
+++ b/.github/workflows/scrape-definitions.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/cache@v1
       with:
-        path: node_modules
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-    - run: npm ci
+        path: ~/.npm
+        key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+    - run: npm ci --prefer-offline --no-audit
     - run: npm run scrape-definitions

--- a/.github/workflows/scrape-definitions.yml
+++ b/.github/workflows/scrape-definitions.yml
@@ -9,9 +9,5 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/cache@v1
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-    - run: npm ci --prefer-offline --no-audit
+    - run: npm ci
     - run: npm run scrape-definitions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,5 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/cache@v1
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-    - run: npm ci --prefer-offline --no-audit
+    - run: npm ci
     - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/cache@v1
       with:
-        path: node_modules
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-    - run: npm ci
+        path: ~/.npm
+        key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+    - run: npm ci --prefer-offline --no-audit
     - run: npm test

--- a/.github/workflows/verify-definitions.yml
+++ b/.github/workflows/verify-definitions.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/cache@v1
       with:
-        path: node_modules
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-    - run: npm ci
+        path: ~/.npm
+        key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+    - run: npm ci --prefer-offline --no-audit
     - run: npm run verify-definitions -- origin/${{github.base_ref}}

--- a/.github/workflows/verify-definitions.yml
+++ b/.github/workflows/verify-definitions.yml
@@ -9,9 +9,5 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/cache@v1
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-    - run: npm ci --prefer-offline --no-audit
+    - run: npm ci
     - run: npm run verify-definitions -- origin/${{github.base_ref}}


### PR DESCRIPTION
Caching node_modules is not worthwhile because npm-ci nukes that folder
immediately. However, caching npm's own cache between runs is valuable.

Unfortunately, the npm cache is frequently over the GitHub cache limit of 400mb, so the cache isn't even saved.

So this removes the caching and simplifies the configuration.