### PR TITLE
Improve LTS schedule linting

### DIFF
--- a/.github/workflows/validate-lts-schedule.yml
+++ b/.github/workflows/validate-lts-schedule.yml
@@ -1,0 +1,13 @@
+name: Validate LTS Schedule
+on:
+  schedule:
+    - cron:  '0 0 * * *' # https://crontab.guru/daily
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - run: npm ci
+    - run: npm run lint:lts

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "verify-definitions": "scripty",
     "test": "bats ${CI:+--tap} test",
     "lint": "git ls-files bin script **/*.*sh | xargs shellcheck",
+    "lint:lts": "test/helpers/warning_messages share/node-build/",
     "preversion": "scripty",
     "version": "script/version-sync",
     "postversion": "git push --follow-tags"

--- a/test/eol-lts.bats
+++ b/test/eol-lts.bats
@@ -2,11 +2,7 @@
 
 load test_helper
 
-setup() {
-  cd "$BATS_TEST_DIRNAME/../share/node-build"
-}
-
 @test "definitions have EOL and LTS warnings" {
-  run echo "$("$BATS_TEST_DIRNAME/helpers/warning_messages" 2>/dev/null)"
+  run echo "$("$BATS_TEST_DIRNAME/helpers/warning_messages" "$BATS_TEST_DIRNAME/../share/node-build" 2>/dev/null)"
   assert_output ""
 }

--- a/test/helpers/warning_messages
+++ b/test/helpers/warning_messages
@@ -6,8 +6,13 @@
 # Prints status messages to STDERR
 # Prints failing definition filenames to STDOUT
 
+# Expects CWD to be share/node-build
+# or to be given the directory as first arg.
+
 set -euo pipefail
 IFS=$'\n\t'
+
+[ $# = 0 ] || cd "$1"
 
 schedule_json() {
   curl -qsSfJL https://raw.githubusercontent.com/nodejs/Release/master/schedule.json
@@ -65,8 +70,6 @@ assert_warnings() {
 }
 
 declare -a versions
-
-
 eval "$(schedule_json | parse_json)"
 
 status=0


### PR DESCRIPTION
- Allow the linter helper to change directories such that it can be
  invoked from anywhere.
- Add npm script to run the linter.
- Add a daily scheduled workflow to run the linter.