### PR TITLE
Fix LTS linting to work on ubuntu

### DIFF
--- a/.github/workflows/lint-checksums.yml
+++ b/.github/workflows/lint-checksums.yml
@@ -4,7 +4,7 @@ on:
     paths: 'share/node-build/**'
 
 jobs:
-  verify:
+  lint:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/lint-lts.yml
+++ b/.github/workflows/lint-lts.yml
@@ -4,7 +4,7 @@ on:
     - cron:  '0 0 * * *' # https://crontab.guru/daily
 
 jobs:
-  scrape:
+  lint:
     runs-on: ubuntu-latest
 
     steps:

--- a/script/lint/lts
+++ b/script/lint/lts
@@ -44,7 +44,7 @@ parse_json() {
 }
 
 past() {
- test "$(date -j +'%s')" -gt "$(date -j -f "%F" "$1" "+%s")"
+  [[ "$1" < "$(date -u +'%F')" ]]
 }
 
 assert_message() {


### PR DESCRIPTION
The `date` usage was BSD only.