### PR TITLE
Fix link to suggested build environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ and modified for node.
 [definitions]: https://github.com/nodenv/node-build/tree/master/share/node-build
 [wiki]: https://github.com/nodenv/node-build/wiki
 [ruby-build wiki]: https://github.com/rbenv/ruby-build/wiki
-[build-env]: https://github.com/rbenv/ruby-build/wiki#suggested-build-environment
+[build-env]: https://github.com/nodenv/node-build/wiki#suggested-build-environment
 [issue tracker]: https://github.com/nodenv/node-build/issues
 [node-build-update-defs]: https://github.com/nodenv/node-build-update-defs
 [Sam Stephenson]: https://github.com/sstephenson


### PR DESCRIPTION
The README points to rbenv's wiki for suggested build environment which will confuse the users (I just did a double take).

Fixing the link will send the user's to our wiki, and from then they can go to nodejs' build suggestions.