### PR TITLE
Fix graal builds on Linux

### DIFF
--- a/bin/node-build
+++ b/bin/node-build
@@ -760,7 +760,7 @@ JX
 
 build_package_graal() {
   cd "$PREFIX_PATH" || return 1
-  if is_mac; then
+  if [ -d Contents/Home ]; then
     mv -f Contents/Home/* .
     rm -rf Contents
   fi

--- a/bin/node-build
+++ b/bin/node-build
@@ -760,8 +760,11 @@ JX
 
 build_package_graal() {
   cd "$PREFIX_PATH" || return 1
-  mv -f Contents/Home/* .
-  rm -rf Contents demo sample src
+  if is_mac; then
+    mv -f Contents/Home/* .
+    rm -rf Contents
+  fi
+  rm -rf demo sample src
 }
 
 before_install_package() {


### PR DESCRIPTION
Installing graalvm builds on Linux fails because the build tries to delete directories from the download that only exist in the MacOS build image.

