### PR TITLE
Open a PR for any auto-fixed lint issues.

### DIFF
--- a/.github/workflows/lint-lts.yml
+++ b/.github/workflows/lint-lts.yml
@@ -28,3 +28,19 @@ jobs:
       with:
         commit_message: 'Include warning message per LTS schedule'
         file_pattern: share/node-build
+
+  pr:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: npm ci
+    - run: npm run lint:lts -- --fix
+    - if: failure()
+      uses: peter-evans/create-pull-request@v2
+      with:
+        token: ${{ secrets.REPO_TOKEN }}
+        branch: lts-warning-message
+        title: 'Update warning messages per LTS Schedule'
+        author: '${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>'
+        commit-message: 'Prepend warning message per LTS schedule'


### PR DESCRIPTION
Adds a job to the lts-linter which will run on the cron schedule. If the linter finds an error, it will fix it, and a PR will be opened with the changes.

This will hopefully be the same type of scheduled action that will start auto-generated the definitions.