### PR TITLE
Don't autofix PRs

### DIFF
--- a/.github/workflows/autofix-lts.yml
+++ b/.github/workflows/autofix-lts.yml
@@ -1,0 +1,20 @@
+name: Fix LTS Warnings
+on:
+  schedule: [{ cron:  '0 0 * * *' }] # daily: https://crontab.guru/#0_0_*_*_*
+
+jobs:
+  fix:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: npm ci
+    - run: npm run lint:lts -- --fix
+    - if: failure()
+      uses: peter-evans/create-pull-request@v2
+      with:
+        token: ${{ secrets.REPO_TOKEN }}
+        branch: lts-warning-message
+        title: 'Update warning messages per LTS Schedule'
+        author: '${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>'
+        commit-message: 'Prepend warning message per LTS schedule'

--- a/.github/workflows/lint-lts.yml
+++ b/.github/workflows/lint-lts.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   lint:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -14,21 +14,6 @@ jobs:
     - run: npm run lint:lts
 
   fix:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        ref: ${{ github.head_ref }}
-    - run: npm ci
-    - run: npm run lint:lts -- --fix
-    - if: failure()
-      uses: stefanzweifel/git-auto-commit-action@v4.1.1
-      with:
-        commit_message: 'Include warning message per LTS schedule'
-        file_pattern: share/node-build
-
-  pr:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint-lts.yml
+++ b/.github/workflows/lint-lts.yml
@@ -2,29 +2,11 @@ name: Lint LTS Warnings
 on:
   pull_request:
   push: { branches: master }
-  schedule: [{ cron:  '0 0 * * *' }] # daily: https://crontab.guru/#0_0_*_*_*
 
 jobs:
   lint:
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - run: npm ci
     - run: npm run lint:lts
-
-  fix:
-    if: github.event_name == 'schedule'
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - run: npm ci
-    - run: npm run lint:lts -- --fix
-    - if: failure()
-      uses: peter-evans/create-pull-request@v2
-      with:
-        token: ${{ secrets.REPO_TOKEN }}
-        branch: lts-warning-message
-        title: 'Update warning messages per LTS Schedule'
-        author: '${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>'
-        commit-message: 'Prepend warning message per LTS schedule'


### PR DESCRIPTION
Since PRs would be opened by collaborators, then Actions doesn't make
the token available. And without the token available, the subsequent
commit won't trigger the Test actions. And without the test actions, the
green checkmark for the commit incorrectly implies the commit (and the
PR) is good to merge.