### PR TITLE
lowjs 20200402+1028ffb (binaries only)

### DIFF
--- a/share/node-build/lowjs-20200402+1028ffb
+++ b/share/node-build/lowjs-20200402+1028ffb
@@ -1,0 +1,10 @@
+echo "This package only contains compiled binaries."
+echo "If no binary matches your platform, source compilation will not be attempted."
+
+binary darwin-x64 "https://www.neonious.com/lowjs/downloads/lowjs-darwin-x86_64-20200402_1028ffb.tar.gz#4e724b9820cab4fce90fb8c03acfe58a1de4be88f2263d8ac079e19201cbf293"
+binary linux-arm64 "https://www.neonious.com/lowjs/downloads/lowjs-linux-aarch64-20200402_1028ffb.tar.gz#ddab0d38d8e23d476baa23f2faa3ef81f7fe7455045bcdc611f7327d74598de7"
+binary linux-armv6l "https://www.neonious.com/lowjs/downloads/lowjs-linux-armv6l-20200402_1028ffb.tar.gz#7477868b1b10bf037a96ae8c7c7714c19f2a271897cccf158b053306e1faf3ee"
+binary linux-x86 "https://www.neonious.com/lowjs/downloads/lowjs-linux-i686-20200402_1028ffb.tar.gz#2c19e2fe458d0d53a9ceac6389c2615b3b3d1f3703a020cf6a82f33d39f0f77b"
+binary linux-x64 "https://www.neonious.com/lowjs/downloads/lowjs-linux-x86_64-20200402_1028ffb.tar.gz#938040787cd047de1d709fcf4d3e65cfe980f87cc4d6f147492206ac2af1d3aa"
+
+install_package "lowjs-20200402+1028ffb" "#"


### PR DESCRIPTION
Pinging @neoniousTR as maintainer of lowjs...

This adds a binaries-only definition file for lowjs. Subsequent PRs will start to add the ability to compile lowjs from source.

Questions for Thomas Rogg:

1. This build is named `20200402+1028ffb` but based on the sha, it looks like it's actually `v1.4.9`. Is this correct? Should this be published within nodenv as `v1.4.9` or `20200402+1028ffb`? Which version naming scheme will be used moving forward.  Is it expected that binary dists are typically only published for tagged releases? If so, will these binaries eventually be uploaded as assets with each GitHub Release?
(I'm concerned about consistent releases since it looks like the last release tag of v1.4.9 is at sha 93cc895 but the binary is from sha 1028ffb.)

1. I see that the tarball doesn't contain a bin named 'node'. Is it common for lowjs users to want their `low` bin to be symlinked as `node`? For a similar example, in ruby-build, the jruby definition symlinks `jruby` as `ruby`. So when a jruby is activated, invoking `ruby` gives one the jruby runtime. Similarly in nodenv, graalvm's definition symlinks node to its graalvm node runtime. Alternatively, is it frequently necessary for "standard" node to still be available alongside lowjs such that symlinking lowjs as node is specifically _undesirable_?

1. Does npm work for lowjs or is there a package manager that should be bundled with low or installed automatically when lowjs is installed by nodenv? Can node packages be installed "globally" under lowjs' `lib/node_modules` directory similar to npm installing packages under nodejs' `lib/node_modules` directory?

Anything else that would be useful for lowjs builds? I'd like to eventually get source compilation definitions added for lowjs, so nodenv can be used to compile releases and nightlies in addition to downloading binary dists.

Thanks! Hopefully nodenv can provide some helpful utility to lowjs users!

#457 