### PR TITLE
Separate commit per scraped node

### DIFF
--- a/.github/workflows/scrape-definitions.yml
+++ b/.github/workflows/scrape-definitions.yml
@@ -11,17 +11,21 @@ jobs:
     - run: npm ci
     - run: npm run scrape-definitions
     - id: scraped
+      name: Commit new definitions
       run: |
+        git config user.name 'GitHub Actions'
+        git config user.email 'noreply@github.com'
         nodes=$(git ls-files --others --exclude-standard -- share/node-build |
-            while read -r node; do echo "- ${node##*/}"; done)
+            while read -r node_def; do
+              node_name=${node_def##*/}
+              git add "$node_def"
+              git commit -q -m "$node_name" -m 'Created with `npm run submit-definitions`.'
+              echo "- $node_name"
+            done)
         echo "::set-output name=nodes::${nodes//$'\n'/'%0A'}"
     - uses: peter-evans/create-pull-request@v2
       with:
         token: ${{ secrets.REPO_TOKEN }}
         branch: latest-scraped-definitions
-        title: 'Scraped latest node definitions'
+        title: 'Scraped latest definitions'
         body: ${{ steps.scraped.outputs.nodes }}
-        commit-message: |
-          Created definitions with `npm run scrape-definitions`
-
-          ${{ steps.scraped.outputs.nodes }}


### PR DESCRIPTION
This makes subsequent release notes generation a bit cleaner since each commit summary will be added to the release notes.