### PR TITLE
Auto release

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,23 @@
+name: Version Bump
+on:
+  schedule: [{ cron:  '0 0 * * *' }] # daily: https://crontab.guru/#0_0_*_*_*
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # fetch all history
+
+      - run: |-
+          npm run preversion --silent -- -o -v -- share/node-build || status=$?
+
+          case "${status:-0}" in
+            0) echo "::set-env name=release::true" ;;
+            1) exit 0;; # exit successfully to mask error, but don't release
+            *) exit $status ;; # all other error codes are true failures
+          esac
+
+      - if: ${{ env.release }}
+        run: echo npm version patch

--- a/script/preversion
+++ b/script/preversion
@@ -34,6 +34,11 @@ if [ "${1-}" = -- ]; then
   shift
 fi
 
+abort() {
+  echo "Aborting: $*" >&2
+  exit 1
+}
+
 declare -a files
 if [ "$#" -gt 0 ]; then
   files=("$@")
@@ -47,25 +52,22 @@ git fetch --quiet --tags origin master
 
 existing="$(git tag --points-at HEAD)"
 if [ -n "$existing" ]; then
-  echo "Aborting: HEAD is already tagged as '${existing}'" >&2
-  exit 1
+  abort "HEAD is already tagged as '${existing}'"
 fi
 
 current_branch="$(git symbolic-ref --short HEAD)"
 if [ "$current_branch" != master ]; then
-  echo "Aborting: Not currently on master branch" >&2
-  exit 1
+  abort "Not currently on master branch"
 fi
 
 previous_tag="$(git describe --tags --abbrev=0)"
 if git diff --quiet "${previous_tag}..HEAD" -- "${files[@]}"; then
-  echo "Aborting: No features to release since '${previous_tag}'" >&2
-  exit 1
+  abort "No features to release since '${previous_tag}'"
 fi
 
-if [ -n "${strict-}" ] && ! git diff --quiet "${previous_tag}..HEAD" -- ":!${files[*]}"; then
-  echo "Aborting: Changes detected outside ${files[*]}"
-  exit 1
+if [ -n "${strict-}" ] &&
+  ! git diff --quiet "${previous_tag}..HEAD" -- ":!${files[*]}"; then
+  abort "Changes detected outside ${files[*]}"
 fi
 
 if [ -n "${verbose-}" ]; then

--- a/script/preversion
+++ b/script/preversion
@@ -18,6 +18,8 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+[ -n "${DEBUG-}" ] && set -x
+
 unset verbose strict
 while getopts "v" opt; do
   case "$opt" in

--- a/script/preversion
+++ b/script/preversion
@@ -35,8 +35,8 @@ if [ "${1-}" = -- ]; then
 fi
 
 abort() {
-  echo "Aborting: $*" >&2
-  exit 1
+  echo "Aborting: $1" >&2
+  exit "${2:-1}"
 }
 
 declare -a files
@@ -57,7 +57,7 @@ fi
 
 current_branch="$(git symbolic-ref --short HEAD)"
 if [ "$current_branch" != master ]; then
-  abort "Not currently on master branch"
+  abort "Not currently on master branch" 2
 fi
 
 previous_tag="$(git describe --tags --abbrev=0)"
@@ -67,7 +67,7 @@ fi
 
 if [ -n "${strict-}" ] &&
   ! git diff --quiet "${previous_tag}..HEAD" -- ":!${files[*]}"; then
-  abort "Changes detected outside '${files[*]}'"
+  abort "Changes detected outside '${files[*]}'" 2
 fi
 
 if [ -n "${verbose-}" ]; then

--- a/script/preversion
+++ b/script/preversion
@@ -67,7 +67,7 @@ fi
 
 if [ -n "${strict-}" ] &&
   ! git diff --quiet "${previous_tag}..HEAD" -- ":!${files[*]}"; then
-  abort "Changes detected outside ${files[*]}"
+  abort "Changes detected outside '${files[*]}'"
 fi
 
 if [ -n "${verbose-}" ]; then

--- a/script/preversion
+++ b/script/preversion
@@ -5,6 +5,7 @@
 # Usage: script/preversion [-v] [--] [FILES...]
 #
 # Options:
+#   -o     Detect unreleased changes in (and only in) FILES
 #   -v     Print log since last tag
 #   FILES  Files to check for changes.
 #          [default: package.json#files read via $npm_package_files_*]
@@ -17,9 +18,10 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-unset verbose
+unset verbose strict
 while getopts "v" opt; do
   case "$opt" in
+  o) strict=1 ;;
   v) verbose=1 ;;
   *) break ;;
   esac
@@ -56,6 +58,11 @@ fi
 previous_tag="$(git describe --tags --abbrev=0)"
 if git diff --quiet "${previous_tag}..HEAD" -- "${files[@]}"; then
   echo "Aborting: No features to release since '${previous_tag}'" >&2
+  exit 1
+fi
+
+if [ -n "${strict-}" ] && ! git diff --quiet "${previous_tag}..HEAD" -- ":!${files[*]}"; then
+  echo "Aborting: Changes detected outside ${files[*]}"
   exit 1
 fi
 

--- a/script/preversion
+++ b/script/preversion
@@ -21,14 +21,14 @@ IFS=$'\n\t'
 [ -n "${DEBUG-}" ] && set -x
 
 unset verbose strict
-while getopts "v" opt; do
+while getopts "ov" opt; do
   case "$opt" in
   o) strict=1 ;;
   v) verbose=1 ;;
   *) break ;;
   esac
-  shift
 done
+shift $((OPTIND-1))
 
 if [ "${1-}" = -- ]; then
   shift


### PR DESCRIPTION
Updates preversion script to support strict checking.

Presently the preversion script ensures:
- releasing from master branch
- there are valid changes to release
- not presently on a tag

Additionally, this PR adds a new option: strict checking. This allows the pathspec for release-able changes to be checked _strictly_. That is, the any changes _outside_ the pathspec will block the release.

With this option now available, we can add a workflow which will automatically trigger releases when:
- on master
- there are releaseable changes (ie to share/node-build/*)
- there are no changes _except_ definition updates (changes to bin/*, etc will require manual release).

Additionally, the preversion script reports two classes of errors now.
- Err 1: these are "silent" blockers (no releaseable changes)
- Err 2: these are "noisy" blockers:
    - on wrong branch (scheduled jobs should only run from default branch)
    - unreleaseable changes (thus requiring manual intervention)


The workflow is still in "dry run" mode: if an automatic release _would_ be kicked off, it just echos the version-patch command. Once it runs for a few weeks and operates correctly, we'll turn it on.