### PR TITLE
Use new GH Actions process for setting env vars

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -15,7 +15,7 @@ jobs:
       - run: |-
           npm run preversion --silent -- -o -v -- share/node-build || status=$?
           case "${status:-0}" in
-            0) echo "::set-env name=release::true" ;;
+            0) echo "release=true" >> $GITHUB_ENV;;
             1) exit 0;; # exit successfully to mask error, but don't release
             *) exit $status ;; # all other error codes are true failures
           esac


### PR DESCRIPTION
No longer possible to set-env directly:

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/