### PR TITLE
Temporarily fix the fix-lts workflow

### DIFF
--- a/.github/workflows/fix-lts.yml
+++ b/.github/workflows/fix-lts.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   fix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
     - run: npm ci


### PR DESCRIPTION
Not sure what's causing the job to fail, but it's something to do with ubuntu 20.
Pinning to 18 for now.

https://github.com/nodenv/node-build/issues/671