### PR TITLE
Don't remove prefix before installing

### DIFF
--- a/bin/node-build
+++ b/bin/node-build
@@ -725,8 +725,6 @@ build_package_autoconf() {
 }
 
 build_package_copy() {
-  # Make sure there are no leftover files in $PREFIX_PATH
-  rm -rf "$PREFIX_PATH"
   mkdir -p "$PREFIX_PATH"
   cp -fR . "$PREFIX_PATH"
 }


### PR DESCRIPTION
Back in  cda9b11733546c23db2ab70817648dcc7a48cba9, node-build started removing the prefix path before an install to prevent conflicts and hard to debug errors.

However, the operation might inadvertently delete user data (for example if they try to install to /usr/local), and is also incompatible with ruby-build, that does not clean the prefix.