### PR TITLE
Actually install etc/install/prefix-retry.bash

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,5 +18,5 @@ SHARE_PATH="${PREFIX}/share/node-build"
 mkdir -p "$BIN_PATH" "$ETC_PATH" "$SHARE_PATH"
 
 install -p bin/* "$BIN_PATH"
-install -d etc/* "$ETC_PATH"
+install -p -m 0644 etc/install/* "$ETC_PATH/install"
 install -p -m 0644 share/node-build/* "$SHARE_PATH"


### PR DESCRIPTION
In #479 I attempted to include `prefix-retry.bash` in the installation process. Turns out `install -d` didn't recursively copy as I'd hoped.

Had a spare moment so decided to tackle this again. Testing locally seems to get the right result!