### PR TITLE
Update ubuntu image version in github actions workflows

### DIFF
--- a/.github/workflows/fix-lts.yml
+++ b/.github/workflows/fix-lts.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   fix:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - run: npm ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   lts:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - run: npm ci


### PR DESCRIPTION
[Fix LTS Warnings](https://github.com/nodenv/node-build/actions/workflows/fix-lts.yml) workflow and [Lint Definitions](https://github.com/nodenv/node-build/actions/workflows/lint.yml) workflow
uses deprecated ubuntu-18.04 image.

https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/
