### PR TITLE
fix: bump `bump-homebrew-formula-action` to latest to fix release issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
   homebrew:
     runs-on: ubuntu-latest
     steps:
-      - uses: mislav/bump-homebrew-formula-action@v2.3
+      - uses: mislav/bump-homebrew-formula-action@v3
         with:
           formula-name: node-build
         env:


### PR DESCRIPTION
To fix the following style issue, as it is already fixed per 2.4 release, https://github.com/mislav/bump-homebrew-formula-action/releases/tag/v2.4

```
  /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/n/node-build.rb:4:3: C: FormulaAudit/Urls: Use refs/tags/v4.9.140 or refs/heads/v4.9.140 for GitHub references (url is https://github.com/nodenv/node-build/archive/v4.9.140.tar.gz).
    url "https://github.com/nodenv/node-build/archive/v4.9.140.tar.gz"
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```


- https://github.com/Homebrew/homebrew-core/pull/167306