### PR TITLE
sync-master workflow

### DIFF
--- a/.github/workflows/sync-master.yml
+++ b/.github/workflows/sync-master.yml
@@ -1,0 +1,9 @@
+name: Sync Master
+on:
+  push: { branches: main }
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  sync:
+    uses: nodenv/.github/.github/workflows/sync-master.yml@v1


### PR DESCRIPTION
node-build's default branch has been renamed from `master` to `main`.

Because git is not just used by contributors to node-build, but as an _installation_ mechanism, we want to keep the `master` branch around so as to not break folks' existing installations.

This workflow will force-sync every `main` commit over to the `master` ref. This way `master` continues to exist and be updated, whereas new installs of `node-build` will use `main` as the default branch.