### PR TITLE
Revert "bump lockfile"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,88 +1,42 @@
 {
   "name": "@nodenv/node-build",
   "version": "4.9.147",
-  "lockfileVersion": 3,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "@nodenv/node-build",
-      "version": "4.9.147",
-      "license": "MIT",
-      "bin": {
-        "node-build": "bin/node-build",
-        "nodenv-install": "bin/nodenv-install",
-        "nodenv-uninstall": "bin/nodenv-uninstall"
-      },
-      "devDependencies": {
-        "@nodenv/devutil": "^0.1.1",
-        "@nodenv/node-build-update-defs": "^2.11.0",
-        "bats": "^1.11.0",
-        "bats-assert": "jasonkarns/bats-assert-1",
-        "bats-mock": "^1.0.1",
-        "bats-support": "jasonkarns/bats-support"
-      }
-    },
-    "node_modules/@nodenv/devutil": {
+  "dependencies": {
+    "@nodenv/devutil": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@nodenv/devutil/-/devutil-0.1.1.tgz",
       "integrity": "sha512-vvwlZ+fjjhCEOnjA4M/gkm8CwzRkKLOiBH5kaEPJLLDOZs4UIPfQ24+Un3reQzF0eOQLDL0SYAieLDITUKxwuQ==",
-      "dev": true,
-      "bin": {
-        "changelog": "bin/changelog"
-      }
+      "dev": true
     },
-    "node_modules/@nodenv/node-build-update-defs": {
+    "@nodenv/node-build-update-defs": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@nodenv/node-build-update-defs/-/node-build-update-defs-2.11.0.tgz",
       "integrity": "sha512-YU1GA0Jy5BWQ5cFHHFHieBGt2rQjdZquDbqYyupcRY3hv295Dor5gB+WRc03b6kWuweuwlBv6LF7yiiXwpe2WA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "nodenv-prune-version-defs": "bin/nodenv-prune-version-defs",
-        "nodenv-update-version-defs": "bin/nodenv-update-version-defs"
-      },
-      "engines": {
-        "node": ">=6"
-      }
+      "dev": true
     },
-    "node_modules/bats": {
+    "bats": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/bats/-/bats-1.11.0.tgz",
       "integrity": "sha512-qiKdnS4ID3bJ1MaEOKuZe12R4w+t+psJF0ICj+UdkiHBBoObPMHv8xmD3w6F4a5qwUyZUHS+413lxENBNy8xcQ==",
-      "dev": true,
-      "bin": {
-        "bats": "bin/bats"
-      }
+      "dev": true
     },
-    "node_modules/bats-assert": {
-      "version": "2.1.0",
-      "resolved": "git+ssh://git@github.com/jasonkarns/bats-assert-1.git#e2d855bc78619ee15b0c702b5c30fb074101159f",
-      "integrity": "sha512-essBJNGadRCxpjrypamUSyJ2wzBnCAgvcO7/WS7VU1ZDrAxnWFSjx8hTNXZIcoGGcbps5eg3nS32prghhJO5aA==",
-      "dev": true,
-      "license": "CC0-1.0",
-      "peerDependencies": {
-        "bats": "0.4 || ^1",
-        "bats-support": "^0.3"
-      }
+    "bats-assert": {
+      "version": "github:jasonkarns/bats-assert-1#e2d855bc78619ee15b0c702b5c30fb074101159f",
+      "from": "github:jasonkarns/bats-assert-1",
+      "dev": true
     },
-    "node_modules/bats-mock": {
+    "bats-mock": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bats-mock/-/bats-mock-1.0.1.tgz",
       "integrity": "sha1-+G19H84+RhU4L2PemvX/3+dN9dU=",
-      "dev": true,
-      "peerDependencies": {
-        "bats": "^0.4.2"
-      }
+      "dev": true
     },
-    "node_modules/bats-support": {
-      "version": "0.3.0",
-      "resolved": "git+ssh://git@github.com/jasonkarns/bats-support.git#9bf10e876dd6b624fe44423f0b35e064225f7556",
-      "integrity": "sha512-Y4m/iyagkCQqX8B6tWRau6W3bc88e/ArlhcAbxuQ3h7pZjV1DO22OvwSqwdbtJl7XylWVjfovnUyqo+v63c2ig==",
-      "dev": true,
-      "license": "CC0-1.0",
-      "peerDependencies": {
-        "bats": "0.4 || ^1"
-      }
+    "bats-support": {
+      "version": "github:jasonkarns/bats-support#9bf10e876dd6b624fe44423f0b35e064225f7556",
+      "from": "github:jasonkarns/bats-support",
+      "dev": true
     }
   }
 }


### PR DESCRIPTION
This reverts commit 851b628e42030b24f7930fd577db2e4bde575eac.


How is npm still this buggy?

```
$ npm i
npm warn old lockfile
npm warn old lockfile The package-lock.json file was created with an old version of npm,
npm warn old lockfile so supplemental metadata must be fetched from the registry.
npm warn old lockfile
npm warn old lockfile This is a one-time fix-up, please be patient...
npm warn old lockfile

changed 2 packages, and audited 7 packages in 1s

found 0 vulnerabilities
```

and very next command:

```
$ npm i
npm error code ERESOLVE
npm error ERESOLVE could not resolve
npm error
[...]
```