### PR TITLE
initial upstream script

### DIFF
--- a/script/merge-next-upstream
+++ b/script/merge-next-upstream
@@ -1,0 +1,73 @@
+#! /usr/bin/env bash
+
+# This is intended to help automate the process of pull changes down from
+# ruby-build upstream. It depends on customized rbenv-tags refspec for
+# namespacing ruby-build's tags (that way ruby-builds tags don't pollute
+# node-build's tags). It re-uses a staging branch where ruby-build's tags
+# will be merged into. It finds only the very "next" un-merged ruby-build
+# tag; diffs against that and merges it. Then removes the ruby-build defs
+# and known scripts that don't apply to node-build. Should leave the 
+# working copy in a MERGING state.
+
+set -euo pipefail
+
+trace() { (set -x; "$@"); }
+
+clean_branch() {
+  br=${1:-ruby-build-upstream}
+  start=${2:-origin/main}
+
+  # TODO: explicitly use the rbenv-tags refspec
+  git fetch --all
+  git checkout --no-track -b "$br" "$start" ||
+  [ "$br" = "$(git rev-parse --abbrev-ref HEAD)" ]
+
+  # TODO: check clean WC here
+}
+
+# FIXME: this is brittle; based on chronological listing of revs
+rbenv_tag(){
+  merged=$1
+  main=${2:-HEAD}
+
+  only=$(test "$merged" = --merged && echo tail || echo head)
+
+  trace git for-each-ref 'refs/rbenv-tags/' \
+  --format '%(refname)' --sort=refname "$merged" "$main" | $only -1
+}
+
+prepare(){
+  {
+    upstream=${1:-ruby-build/master}
+    main=${2:-HEAD}
+
+    trace git describe --all --exact-match \
+      "$(trace git merge-base "$main" "$upstream")"
+
+    vlast=$(rbenv_tag --merged)
+    vnext=$(rbenv_tag --no-merged)
+
+    trace git diff "${vlast:?}"..."${vnext:?}" \
+      -- ':!share/' ':!script/*ruby*'
+  } >&2
+
+  echo "$vnext"
+}
+
+merge(){
+  ref=${1:?}
+
+  # FIXME: find better way to handle the expected errexit
+  # TODO: improve commit message
+  git merge --no-commit --quiet "$ref" || true
+
+  # TODO: this stuff should be a custom merge-driver
+  git rm -rf share/ruby-build
+  git rm -rf script/update-*ruby
+}
+
+# clean_branch ruby-build-update origin/main
+
+rbenv_tag=$(prepare ruby-build/master)
+
+merge "$rbenv_tag"


### PR DESCRIPTION
This is very much WIP:

    This is intended to help automate the process of pull changes down from
    ruby-build upstream. It depends on customized rbenv-tags refspec for
    namespacing ruby-build's tags (that way ruby-builds tags don't pollute
    node-build's tags). It re-uses a staging branch where ruby-build's tags
    will be merged into. It finds only the very "next" un-merged ruby-build
    tag; diffs against that and merges it. Then removes the ruby-build defs
    and known scripts that don't apply to node-build. Should leave the 
    working copy in a MERGING state.