### PR TITLE
Use gh cli for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
-      - run: npm ci
-      - run: npm run -s relnotes | tee relnotes.txt
-      # TODO: Port to using gh-cli instead of dedicated action
-      - uses: jasonkarns/create-release@9249b73e127bea00eb6f2caa7244657983df0557
-        with: { body_path: relnotes.txt }
+      - run: gh release create --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}
 
   homebrew:
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,42 +1,77 @@
 {
   "name": "@nodenv/node-build",
   "version": "4.9.148",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@nodenv/devutil": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@nodenv/devutil/-/devutil-0.1.1.tgz",
-      "integrity": "sha512-vvwlZ+fjjhCEOnjA4M/gkm8CwzRkKLOiBH5kaEPJLLDOZs4UIPfQ24+Un3reQzF0eOQLDL0SYAieLDITUKxwuQ==",
-      "dev": true
+  "packages": {
+    "": {
+      "name": "@nodenv/node-build",
+      "version": "4.9.148",
+      "license": "MIT",
+      "bin": {
+        "node-build": "bin/node-build",
+        "nodenv-install": "bin/nodenv-install",
+        "nodenv-uninstall": "bin/nodenv-uninstall"
+      },
+      "devDependencies": {
+        "@nodenv/node-build-update-defs": "^2.11.0",
+        "bats": "^1.11.0",
+        "bats-assert": "jasonkarns/bats-assert-1",
+        "bats-mock": "^1",
+        "bats-support": "jasonkarns/bats-support"
+      }
     },
-    "@nodenv/node-build-update-defs": {
+    "node_modules/@nodenv/node-build-update-defs": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@nodenv/node-build-update-defs/-/node-build-update-defs-2.11.0.tgz",
       "integrity": "sha512-YU1GA0Jy5BWQ5cFHHFHieBGt2rQjdZquDbqYyupcRY3hv295Dor5gB+WRc03b6kWuweuwlBv6LF7yiiXwpe2WA==",
-      "dev": true
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "nodenv-prune-version-defs": "bin/nodenv-prune-version-defs",
+        "nodenv-update-version-defs": "bin/nodenv-update-version-defs"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
-    "bats": {
+    "node_modules/bats": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/bats/-/bats-1.11.0.tgz",
       "integrity": "sha512-qiKdnS4ID3bJ1MaEOKuZe12R4w+t+psJF0ICj+UdkiHBBoObPMHv8xmD3w6F4a5qwUyZUHS+413lxENBNy8xcQ==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "bats": "bin/bats"
+      }
     },
-    "bats-assert": {
-      "version": "github:jasonkarns/bats-assert-1#e2d855bc78619ee15b0c702b5c30fb074101159f",
-      "from": "github:jasonkarns/bats-assert-1",
-      "dev": true
+    "node_modules/bats-assert": {
+      "version": "2.1.0",
+      "resolved": "git+ssh://git@github.com/jasonkarns/bats-assert-1.git#e2d855bc78619ee15b0c702b5c30fb074101159f",
+      "integrity": "sha512-essBJNGadRCxpjrypamUSyJ2wzBnCAgvcO7/WS7VU1ZDrAxnWFSjx8hTNXZIcoGGcbps5eg3nS32prghhJO5aA==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "peerDependencies": {
+        "bats": "0.4 || ^1",
+        "bats-support": "^0.3"
+      }
     },
-    "bats-mock": {
+    "node_modules/bats-mock": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bats-mock/-/bats-mock-1.0.1.tgz",
-      "integrity": "sha1-+G19H84+RhU4L2PemvX/3+dN9dU=",
-      "dev": true
+      "resolved": "git+ssh://git@github.com/jasonkarns/bats-mock.git#8a230011c56bc02d2ada1bb1013fe6c470930278",
+      "dev": true,
+      "peerDependencies": {
+        "bats": "^0.4.2 || ^1"
+      }
     },
-    "bats-support": {
-      "version": "github:jasonkarns/bats-support#9bf10e876dd6b624fe44423f0b35e064225f7556",
-      "from": "github:jasonkarns/bats-support",
-      "dev": true
+    "node_modules/bats-support": {
+      "version": "0.3.0",
+      "resolved": "git+ssh://git@github.com/jasonkarns/bats-support.git#9bf10e876dd6b624fe44423f0b35e064225f7556",
+      "integrity": "sha512-Y4m/iyagkCQqX8B6tWRau6W3bc88e/ArlhcAbxuQ3h7pZjV1DO22OvwSqwdbtJl7XylWVjfovnUyqo+v63c2ig==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "peerDependencies": {
+        "bats": "0.4 || ^1"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,11 +44,10 @@
     "unmerged": "git for-each-ref refs/rbenv-tags --format='%(refname)' --merged"
   },
   "devDependencies": {
-    "@nodenv/devutil": "^0.1.1",
     "@nodenv/node-build-update-defs": "^2.11.0",
     "bats": "^1.11.0",
     "bats-assert": "jasonkarns/bats-assert-1",
-    "bats-mock": "^1.0.1",
+    "bats-mock": "^1",
     "bats-support": "jasonkarns/bats-support"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "preversion": "script/preversion",
     "version": "script/version-sync",
     "postversion": "git push --follow-tags",
-    "relnotes": "changelog -- bin etc share",
     "unmerged": "git for-each-ref refs/rbenv-tags --format='%(refname)' --merged"
   },
   "devDependencies": {


### PR DESCRIPTION
Can drop the `relnotes` npm script and the devutil package but the npm lockfile can't be upgraded at the moment.