### PR TITLE
remove maintenance warning from EOL builds

### DIFF
--- a/share/node-build/10.0.0
+++ b/share/node-build/10.0.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.0.0/node-v10.0.0-aix-ppc64.tar.gz#1b9849a20b335229bcdbea04db213846553c87f50002b6457a5c9c4b299411b5"
 binary darwin-x64 "https://nodejs.org/dist/v10.0.0/node-v10.0.0-darwin-x64.tar.gz#37447fdb5f5cbcf1307ca1661ed67e6e911e0e988c0cb6d15f92eebb211dce88"
 binary linux-arm64 "https://nodejs.org/dist/v10.0.0/node-v10.0.0-linux-arm64.tar.gz#36adc17e9cceab32179d3314da9cb9c737ffb11f0de4e688f407ad6d9ca32201"

--- a/share/node-build/10.1.0
+++ b/share/node-build/10.1.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.1.0/node-v10.1.0-aix-ppc64.tar.gz#f4f96c3180f9fd8113632e499d5129709d52d8206e250924ff4c2d7d07ba5715"
 binary darwin-x64 "https://nodejs.org/dist/v10.1.0/node-v10.1.0-darwin-x64.tar.gz#383ef526e27b92113f8dc0dad406b771f6ecaf9e3fddd4f5357590a3cf543d7b"
 binary linux-arm64 "https://nodejs.org/dist/v10.1.0/node-v10.1.0-linux-arm64.tar.gz#62c395fd3ffca1671dd0b7a84e7250485e484e7d62f9be13fd45879e9ef45290"

--- a/share/node-build/10.10.0
+++ b/share/node-build/10.10.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.10.0/node-v10.10.0-aix-ppc64.tar.gz#d37fa6cb6ac55ae8b3529492a3fd0a0c3210b22a8acb6b6a7228907ae941cbb1"
 binary darwin-x64 "https://nodejs.org/dist/v10.10.0/node-v10.10.0-darwin-x64.tar.gz#00b7a8426e076e9bf9d12ba2d571312e833fe962c70afafd10ad3682fdeeaa5e"
 binary linux-arm64 "https://nodejs.org/dist/v10.10.0/node-v10.10.0-linux-arm64.tar.gz#0b83a3e427d076947b1deca943a48fba0258772f9c037de19d8b1261632d1385"

--- a/share/node-build/10.11.0
+++ b/share/node-build/10.11.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.11.0/node-v10.11.0-aix-ppc64.tar.gz#af6ade952ad083d2db9d21db9e5a6ecb87deb1a28d55d63376e96fd35ee527a4"
 binary darwin-x64 "https://nodejs.org/dist/v10.11.0/node-v10.11.0-darwin-x64.tar.gz#32ad850a0e5cfdefc32d4267707abad05bd5c9eabb047e8ed9bf97faeffc52b6"
 binary linux-arm64 "https://nodejs.org/dist/v10.11.0/node-v10.11.0-linux-arm64.tar.gz#d9a5072e0bbb90793ce9e90b9b0b12d9955806dd19cbdeba97cfc978b8c87e5d"

--- a/share/node-build/10.12.0
+++ b/share/node-build/10.12.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.12.0/node-v10.12.0-aix-ppc64.tar.gz#eb8cb1aa1f3ee9bc376d3654ce6410980e9c42b5d09eddca73f5d624bec22861"
 binary darwin-x64 "https://nodejs.org/dist/v10.12.0/node-v10.12.0-darwin-x64.tar.gz#f275c901b9aeaacea2bf22648329c2e9ade5e1ff63a446b83446d5d4e19464cc"
 binary linux-arm64 "https://nodejs.org/dist/v10.12.0/node-v10.12.0-linux-arm64.tar.gz#35108e762de4d449ae012c69c5927023806b2e447070d712630e78ab1f1d2cd5"

--- a/share/node-build/10.13.0
+++ b/share/node-build/10.13.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.13.0/node-v10.13.0-aix-ppc64.tar.gz#9e8d0b86ef67ea2bf660a50f560ba8eb5b91665af7489c5ba8475708624dbd30"
 binary darwin-x64 "https://nodejs.org/dist/v10.13.0/node-v10.13.0-darwin-x64.tar.gz#815a5d18516934a3963ace9f0574f7d41f0c0ce9186a19be3d89e039e57598c5"
 binary linux-arm64 "https://nodejs.org/dist/v10.13.0/node-v10.13.0-linux-arm64.tar.gz#de4e92103d228f5a5d0e67f8a681b1bce63036776bb7a46e014fae072d188036"

--- a/share/node-build/10.14.0
+++ b/share/node-build/10.14.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.14.0/node-v10.14.0-aix-ppc64.tar.gz#d089875efec9b79a248a23ed7da86250b639fbca1572dba19323eb16321e58e1"
 binary darwin-x64 "https://nodejs.org/dist/v10.14.0/node-v10.14.0-darwin-x64.tar.gz#dd044aa0ddeb5e32fefa80a13b33bafe3f7e0536e15fe93c1e81b052c2f1965c"
 binary linux-arm64 "https://nodejs.org/dist/v10.14.0/node-v10.14.0-linux-arm64.tar.gz#848868d24f1b237afd2d71b1749a21bdabafda2346bf404b1d4fa941d3d35982"

--- a/share/node-build/10.14.1
+++ b/share/node-build/10.14.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.14.1/node-v10.14.1-aix-ppc64.tar.gz#81cc429d9c5d50d36f7912ec927ff271e0608c501db7aa3375aad0043558e6f7"
 binary darwin-x64 "https://nodejs.org/dist/v10.14.1/node-v10.14.1-darwin-x64.tar.gz#91ebe7d6da8a40c72618ac9d0b0a8e224ae01febd3f5595b43b1a58190dcacb1"
 binary linux-arm64 "https://nodejs.org/dist/v10.14.1/node-v10.14.1-linux-arm64.tar.gz#87ecffc9fc643de85ca821f87c150a98596eaa3092a7f9469555e2a8625b6c92"

--- a/share/node-build/10.14.2
+++ b/share/node-build/10.14.2
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.14.2/node-v10.14.2-aix-ppc64.tar.gz#c5df726d847b7b2744b7a2cd7dcb687a5dbac4ab5920d6e93cc8a1b85b7055d8"
 binary darwin-x64 "https://nodejs.org/dist/v10.14.2/node-v10.14.2-darwin-x64.tar.gz#5306da5db576d9c984167b4693600a2e3074cc5a701961279837753fa2139baa"
 binary linux-arm64 "https://nodejs.org/dist/v10.14.2/node-v10.14.2-linux-arm64.tar.gz#23c82e8a3569bb463a0ed40602195c4280041a30a68858fd84ede7cd532e555e"

--- a/share/node-build/10.15.0
+++ b/share/node-build/10.15.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.15.0/node-v10.15.0-aix-ppc64.tar.gz#5a0eac2db2dc6114a9095190a0e9e835e210d5cdf5c0042607bb50331c32313f"
 binary darwin-x64 "https://nodejs.org/dist/v10.15.0/node-v10.15.0-darwin-x64.tar.gz#353402461c898c569658d0a963790476f4d9828cc6c9286d81617ee8afcba4e8"
 binary linux-arm64 "https://nodejs.org/dist/v10.15.0/node-v10.15.0-linux-arm64.tar.gz#69a86c71df32320dc8dfccd1aca124c73dc2b274c7ce50104dad733a06dc26f3"

--- a/share/node-build/10.15.1
+++ b/share/node-build/10.15.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.15.1/node-v10.15.1-aix-ppc64.tar.gz#5085537ad9d6a6adc24bbfbb5c40711be61222378b37202fa189b69135aa5503"
 binary darwin-x64 "https://nodejs.org/dist/v10.15.1/node-v10.15.1-darwin-x64.tar.gz#327dcef4b61dead1ae04d2743d3390a2b7e6cc6c389c62cfcfeb0486c5a9f181"
 binary linux-arm64 "https://nodejs.org/dist/v10.15.1/node-v10.15.1-linux-arm64.tar.gz#d1cc9b84befd7b001e61bb40c96b8b9d0776f186ebc4e7993fcc0d5c2631b24c"

--- a/share/node-build/10.15.2
+++ b/share/node-build/10.15.2
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.15.2/node-v10.15.2-aix-ppc64.tar.gz#04b06a4904442887939603d1e34fb9d9230d5660c8d7d6ad7c0a0c708f8baacf"
 binary darwin-x64 "https://nodejs.org/dist/v10.15.2/node-v10.15.2-darwin-x64.tar.gz#8bbb6c15a0572f493d33ef044d06ccd0ff7ead8daa67f9a32df3e863277568e8"
 binary linux-arm64 "https://nodejs.org/dist/v10.15.2/node-v10.15.2-linux-arm64.tar.gz#2988f31a07f54a80442166574b01ecfa92f2c6a8094ca4c2d820f464df0b5ce1"

--- a/share/node-build/10.15.3
+++ b/share/node-build/10.15.3
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.15.3/node-v10.15.3-aix-ppc64.tar.gz#f2f018418b6bfa263ec981f04f3fa5337724edae8d77fc3951cd36667ee720ea"
 binary darwin-x64 "https://nodejs.org/dist/v10.15.3/node-v10.15.3-darwin-x64.tar.gz#7a5eaa1f69614375a695ccb62017248e5dcc15b0b8edffa7db5b52997cf992ba"
 binary linux-arm64 "https://nodejs.org/dist/v10.15.3/node-v10.15.3-linux-arm64.tar.gz#c82cd99e01f6e26830f0b3e0465f12f92957ebd69a68c91c03228c2669104359"

--- a/share/node-build/10.16.0
+++ b/share/node-build/10.16.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.16.0/node-v10.16.0-aix-ppc64.tar.gz#6aa026be2dcda26c3a5dd6f492bf517431787ba52e7a82db1d0a37c16031b841"
 binary darwin-x64 "https://nodejs.org/dist/v10.16.0/node-v10.16.0-darwin-x64.tar.gz#6c009df1b724026d84ae9a838c5b382662e30f6c5563a0995532f2bece39fa9c"
 binary linux-arm64 "https://nodejs.org/dist/v10.16.0/node-v10.16.0-linux-arm64.tar.gz#2d84a777318bc95dd2a201ab8d700aea7e20641b3ece0c048399398dc645cbd7"

--- a/share/node-build/10.16.1
+++ b/share/node-build/10.16.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.16.1/node-v10.16.1-aix-ppc64.tar.gz#f9afd5285438e2f6b72c5c529a9f28a80f0fcd9cdc003e477d6e95177d89fdc2"
 binary darwin-x64 "https://nodejs.org/dist/v10.16.1/node-v10.16.1-darwin-x64.tar.gz#328e61fdacfe2f6f1a049d57e248b3eafc0345747831323a14fe1edf98d9b3bb"
 binary linux-arm64 "https://nodejs.org/dist/v10.16.1/node-v10.16.1-linux-arm64.tar.gz#c5f1df1ae559a9e40fc7216f4c82379d4e8ce64a96921ab0bed216c82cf9a1f3"

--- a/share/node-build/10.16.2
+++ b/share/node-build/10.16.2
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.16.2/node-v10.16.2-aix-ppc64.tar.gz#0b78f2bb3281090dd8f389aa57e692cf548f993d8108032c24793bcb9c3ed440"
 binary darwin-x64 "https://nodejs.org/dist/v10.16.2/node-v10.16.2-darwin-x64.tar.gz#21ee8bdb04909f553e97af7c6e41009e15d06b886dd3e2ca8a92ce3e0a148a09"
 binary linux-arm64 "https://nodejs.org/dist/v10.16.2/node-v10.16.2-linux-arm64.tar.gz#5c496fc4392f34d9f2515212f58088448e121cbe9b732a64e9757f021b6b675f"

--- a/share/node-build/10.16.3
+++ b/share/node-build/10.16.3
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.16.3/node-v10.16.3-aix-ppc64.tar.gz#1e246436e177d69354b5e3ea47579a03b68d7b61a2565972c18c3a4cb5d8ee33"
 binary darwin-x64 "https://nodejs.org/dist/v10.16.3/node-v10.16.3-darwin-x64.tar.gz#6febc571e1543c2845fa919c6d06b36a24e4e142c91aedbe28b6ff7d296119e4"
 binary linux-arm64 "https://nodejs.org/dist/v10.16.3/node-v10.16.3-linux-arm64.tar.gz#3bab16e7107092e43426e082ee9fd88ef0a43a35816f662f14563bcc5152600d"

--- a/share/node-build/10.17.0
+++ b/share/node-build/10.17.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.17.0/node-v10.17.0-aix-ppc64.tar.gz#0e6237b642ce93704395a61468990fb1156df33c0b60a83bfebb42aaeee272f5"
 binary darwin-x64 "https://nodejs.org/dist/v10.17.0/node-v10.17.0-darwin-x64.tar.gz#9b96140ad74b217f216c83ddf50d1f70a4296576f6edbbbfb65d0f478015d9df"
 binary linux-arm64 "https://nodejs.org/dist/v10.17.0/node-v10.17.0-linux-arm64.tar.gz#fca7862a435c48d634fd74464057edef0e6ed854678c4b1fee3f21f126f2d7c7"

--- a/share/node-build/10.18.0
+++ b/share/node-build/10.18.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.18.0/node-v10.18.0-aix-ppc64.tar.gz#1e8604a930d732eef94362c8e5b204cb7272bbd14171582043ee8436caeb7fd4"
 binary darwin-x64 "https://nodejs.org/dist/v10.18.0/node-v10.18.0-darwin-x64.tar.gz#a7af53e3363e8ab654b97387bc7cf352dddb324562404c1d35fe10cba3f27e0f"
 binary linux-arm64 "https://nodejs.org/dist/v10.18.0/node-v10.18.0-linux-arm64.tar.gz#3f9d6c5e7f5781518fb46e9f86081c03e97fb052ff397345be1acc658997174a"

--- a/share/node-build/10.18.1
+++ b/share/node-build/10.18.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.18.1/node-v10.18.1-aix-ppc64.tar.gz#07d8baf00e4456d678c4828bc597808f0789abfbc91e81172bed650f1b72477d"
 binary darwin-x64 "https://nodejs.org/dist/v10.18.1/node-v10.18.1-darwin-x64.tar.gz#2b2d3379420e626eee393cabf1c90bc55957ff5bb067b82a74eb2f92147d6757"
 binary linux-arm64 "https://nodejs.org/dist/v10.18.1/node-v10.18.1-linux-arm64.tar.gz#554b42da76877a9c5ab0054b492fef0d5847b06217e466728b1e73547e55c7da"

--- a/share/node-build/10.19.0
+++ b/share/node-build/10.19.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.19.0/node-v10.19.0-aix-ppc64.tar.gz#9040615d614cf4039f4abbd62c799877c3c2efd517e4100d6f13064d368a25a0"
 binary darwin-x64 "https://nodejs.org/dist/v10.19.0/node-v10.19.0-darwin-x64.tar.gz#b16328570651be44213a2303c1f9515fc506e0a96a273806f71ed000e3ca3cb3"
 binary linux-arm64 "https://nodejs.org/dist/v10.19.0/node-v10.19.0-linux-arm64.tar.gz#3510172797b63bb6a7247f62a241bdfcf51fef8b1134eb7d3a27973e2008e482"

--- a/share/node-build/10.2.0
+++ b/share/node-build/10.2.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.2.0/node-v10.2.0-aix-ppc64.tar.gz#bc1e5b26ddd18f494036682fda957199210b4c88b382f61eb45ec55a70601546"
 binary darwin-x64 "https://nodejs.org/dist/v10.2.0/node-v10.2.0-darwin-x64.tar.gz#35fcc482d07218119ce5fde62620994324f03f8c4426dd680886c6844b62232a"
 binary linux-arm64 "https://nodejs.org/dist/v10.2.0/node-v10.2.0-linux-arm64.tar.gz#77a9e159c303faa12c85a0cffd3cf8a3a1134ef781a7bc52787f49e97116540f"

--- a/share/node-build/10.2.1
+++ b/share/node-build/10.2.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.2.1/node-v10.2.1-aix-ppc64.tar.gz#e71c30c2f723d95b421bf6744acac6db1cf1abc1e6da626e410381f8565409eb"
 binary darwin-x64 "https://nodejs.org/dist/v10.2.1/node-v10.2.1-darwin-x64.tar.gz#6ffa149f67e8bd68d291d62591b6573146a65682affd99eefe2835a9c048d3ef"
 binary linux-arm64 "https://nodejs.org/dist/v10.2.1/node-v10.2.1-linux-arm64.tar.gz#2af75c6f14f27b1ff8d5c4f31f380a1be7f22cf56577826a1cc40178c7d4e4ea"

--- a/share/node-build/10.20.0
+++ b/share/node-build/10.20.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.20.0/node-v10.20.0-aix-ppc64.tar.gz#392432f73ec56ad420bd505d9d4e0e15435138aef45c27106d0f15de4975790b"
 binary darwin-x64 "https://nodejs.org/dist/v10.20.0/node-v10.20.0-darwin-x64.tar.gz#c153832774afcae89a82efb55ed80557d1a41e1880638ad57128a9a3762d212f"
 binary linux-arm64 "https://nodejs.org/dist/v10.20.0/node-v10.20.0-linux-arm64.tar.gz#96a26b897d120806c80115bb484160daae3e86944d0c1ffecf1b4be0a8e09501"

--- a/share/node-build/10.20.1
+++ b/share/node-build/10.20.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.20.1/node-v10.20.1-aix-ppc64.tar.gz#d25e795554942f467d6c3c3e22d3cd420aa3beac03adc71055c50c6cc41e79cf"
 binary darwin-x64 "https://nodejs.org/dist/v10.20.1/node-v10.20.1-darwin-x64.tar.gz#6437e364cd93be246ffb67dd40775cbb467bb8d28d8af4413123f478bb6234b9"
 binary linux-arm64 "https://nodejs.org/dist/v10.20.1/node-v10.20.1-linux-arm64.tar.gz#e0073e46fe85e389e7ddca990c99b27fbc1e833d00b1ee32561f0d104ab277f9"

--- a/share/node-build/10.21.0
+++ b/share/node-build/10.21.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.21.0/node-v10.21.0-aix-ppc64.tar.gz#73f0bc9348b2f70f2deed898843f7212f494b085ee3022ff67967005852130fa"
 binary darwin-x64 "https://nodejs.org/dist/v10.21.0/node-v10.21.0-darwin-x64.tar.gz#596900700c4a0de0303bb4c378a1abcd63f31efc848704c5fbc1230de628577a"
 binary linux-arm64 "https://nodejs.org/dist/v10.21.0/node-v10.21.0-linux-arm64.tar.gz#43f821147c18367c227ea63ce173ee3acfd3da1fa3ea0581f6de1a27ca5b7d4e"

--- a/share/node-build/10.22.0
+++ b/share/node-build/10.22.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.22.0/node-v10.22.0-aix-ppc64.tar.gz#15fc4672df24d28e606acb9f4d0c5dd72e11cefca880107167d661b6c7a6a455"
 binary darwin-x64 "https://nodejs.org/dist/v10.22.0/node-v10.22.0-darwin-x64.tar.gz#c7583a297ba9c6cfc03688a32776155d02fabf9ff45847c63b12a68d400f1dc1"
 binary linux-arm64 "https://nodejs.org/dist/v10.22.0/node-v10.22.0-linux-arm64.tar.gz#8e59eb6865f704785a9aa53ccf9f4cb10412caaf778cee617241a0d0684e008d"

--- a/share/node-build/10.22.1
+++ b/share/node-build/10.22.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.22.1/node-v10.22.1-aix-ppc64.tar.gz#358d266878b8a728dfdcb93a7d6d1d1a9d489026bca4a1bece6fc839984dc3d8"
 binary darwin-x64 "https://nodejs.org/dist/v10.22.1/node-v10.22.1-darwin-x64.tar.gz#c87251c952e791d37b289947bea9f450a9beb541078cd47f77c0c4ef1cad9675"
 binary linux-arm64 "https://nodejs.org/dist/v10.22.1/node-v10.22.1-linux-arm64.tar.gz#f38e3e8cd00fe480a3b6a4a78d381f6880f755af08f0566df2bdf26006e44812"

--- a/share/node-build/10.23.0
+++ b/share/node-build/10.23.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.23.0/node-v10.23.0-aix-ppc64.tar.gz#b7967e12fc50c73e9b70be8fd744539bb90f845b05947e93715c55f00e09d484"
 binary darwin-x64 "https://nodejs.org/dist/v10.23.0/node-v10.23.0-darwin-x64.tar.gz#c4dcaee7806b1fa1a2e832abd817bdd9b31a9c84181e7686067fd4eb5e3b12c3"
 binary linux-arm64 "https://nodejs.org/dist/v10.23.0/node-v10.23.0-linux-arm64.tar.gz#d66f4912a0cb84678124d9a311bee7b204665fc62f83b0fc0d10b2f385feb524"

--- a/share/node-build/10.23.1
+++ b/share/node-build/10.23.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.23.1/node-v10.23.1-aix-ppc64.tar.gz#33bf67ad4a5843b0c1a5a9f3800ccbe1f30b068889177049bd6faca4a843c64a"
 binary darwin-x64 "https://nodejs.org/dist/v10.23.1/node-v10.23.1-darwin-x64.tar.gz#07da39e4c122d1cee744f3a3ace904edf23c3256879adedafcca6a1da4ca4681"
 binary linux-arm64 "https://nodejs.org/dist/v10.23.1/node-v10.23.1-linux-arm64.tar.gz#e7d0476b1e9add7b21297698517356bb7c7d7f10e75f5abad6ab5806518a6cd6"

--- a/share/node-build/10.23.2
+++ b/share/node-build/10.23.2
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.23.2/node-v10.23.2-aix-ppc64.tar.gz#a0b595a3c0da4e8cd8cf30786f505241d339b58e24de9de2e37114b519236b59"
 binary darwin-x64 "https://nodejs.org/dist/v10.23.2/node-v10.23.2-darwin-x64.tar.gz#27f714657720b566690e5612cd7faffba63a5c0c9ba47834997e2658c8f533d9"
 binary linux-arm64 "https://nodejs.org/dist/v10.23.2/node-v10.23.2-linux-arm64.tar.gz#83a15dc442916c55fc033c4395fb72d27d27c16fdea05fc23f952cba88023d81"

--- a/share/node-build/10.23.3
+++ b/share/node-build/10.23.3
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.23.3/node-v10.23.3-aix-ppc64.tar.gz#b9ad6ba0f7377fc5010b7aa3bb852385e3a54d6a910d294a76b23419a3eeb297"
 binary darwin-x64 "https://nodejs.org/dist/v10.23.3/node-v10.23.3-darwin-x64.tar.gz#f33d88fe2bf93c1b1f6312cb849a56185d3c8371517119d48245fa322b82d96e"
 binary linux-arm64 "https://nodejs.org/dist/v10.23.3/node-v10.23.3-linux-arm64.tar.gz#483a4b609fe406b87da290bc0aa582b863e725321d71c6207f050ebe06baec8d"

--- a/share/node-build/10.24.0
+++ b/share/node-build/10.24.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.24.0/node-v10.24.0-aix-ppc64.tar.gz#59bdb393035c605627bf4ba64ad8edcc74f067043790c7edc545333cca8630c4"
 binary darwin-x64 "https://nodejs.org/dist/v10.24.0/node-v10.24.0-darwin-x64.tar.gz#265ccad26fdfdcd86d6571b0bf5f1815b55f6a4a9b367816ad0369790501f55e"
 binary linux-arm64 "https://nodejs.org/dist/v10.24.0/node-v10.24.0-linux-arm64.tar.gz#65e6255c6f95b6dcf87f13c21994bc80205b4bd7c7d9a3fe1f8f2a18daec576d"

--- a/share/node-build/10.24.1
+++ b/share/node-build/10.24.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.24.1/node-v10.24.1-aix-ppc64.tar.gz#fc9ba4f3ba0be4a4495dd4fc7aa1e608f74a1440264518da760b246417077c3f"
 binary darwin-x64 "https://nodejs.org/dist/v10.24.1/node-v10.24.1-darwin-x64.tar.gz#8088968a896e17c21b98187f8083291df9c88d0baa100a6cb9553e53c4fb17f8"
 binary linux-arm64 "https://nodejs.org/dist/v10.24.1/node-v10.24.1-linux-arm64.tar.gz#0ae4931d0ea779ecb237c1fc9f4a27271b0054b1efabc783863478913fe6caa6"

--- a/share/node-build/10.3.0
+++ b/share/node-build/10.3.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.3.0/node-v10.3.0-aix-ppc64.tar.gz#53f5d2b14f4fe2f66a4c4063f7870af978a81559e7d0b608a9b483673e6d0b56"
 binary darwin-x64 "https://nodejs.org/dist/v10.3.0/node-v10.3.0-darwin-x64.tar.gz#0bb5b7e3fe8cccda2abda958d1eb0408f1518a8b0cb58b75ade5d507cd5d6053"
 binary linux-arm64 "https://nodejs.org/dist/v10.3.0/node-v10.3.0-linux-arm64.tar.gz#a4e8be9d186e6f0506088bf5121c1d0fb72b5d9eb5add6a75b466c140d6eb476"

--- a/share/node-build/10.4.0
+++ b/share/node-build/10.4.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.4.0/node-v10.4.0-aix-ppc64.tar.gz#cc90b3662a6e479b42f71091fe8ffd155d520cf81c96b3012d9126568e7fc03b"
 binary darwin-x64 "https://nodejs.org/dist/v10.4.0/node-v10.4.0-darwin-x64.tar.gz#82b27983c990a6860e8d729e0b15acf9643ffca0eff282a926268849dfd2c3d2"
 binary linux-arm64 "https://nodejs.org/dist/v10.4.0/node-v10.4.0-linux-arm64.tar.gz#e54af0d3046c45fa45ce3f207a8f652969489c17b8328110e626aab19d8ab430"

--- a/share/node-build/10.4.1
+++ b/share/node-build/10.4.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.4.1/node-v10.4.1-aix-ppc64.tar.gz#7b35df9310cf11c2c9b2ff27de5acb19ac2f75fc0f8d670da0d05d2a83b84bb2"
 binary darwin-x64 "https://nodejs.org/dist/v10.4.1/node-v10.4.1-darwin-x64.tar.gz#c232241c97e1f4659186205d50b44132e62b61cdc517f1fb86905a21d03e9189"
 binary linux-arm64 "https://nodejs.org/dist/v10.4.1/node-v10.4.1-linux-arm64.tar.gz#f61110447544b5ada4b5523b4ccd8a2f5000709e2f9dc6f1f3594f556a068627"

--- a/share/node-build/10.5.0
+++ b/share/node-build/10.5.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.5.0/node-v10.5.0-aix-ppc64.tar.gz#a4008530bf54dc760206e71d7548977137d488e83081e3153a2ffead9bd9549e"
 binary darwin-x64 "https://nodejs.org/dist/v10.5.0/node-v10.5.0-darwin-x64.tar.gz#a85bda6ab91da8595e71736944cbd77c61afe05092217defd0fb74d9f77109f0"
 binary linux-arm64 "https://nodejs.org/dist/v10.5.0/node-v10.5.0-linux-arm64.tar.gz#2708f77f12966cdf13046c7ac8513fc430be5cbeacc02711d242d65044580d91"

--- a/share/node-build/10.6.0
+++ b/share/node-build/10.6.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.6.0/node-v10.6.0-aix-ppc64.tar.gz#ad6c4cc2be5b5427a1d48c61e86778b1f085d74a9c7e140bf5769ef025cf3b3b"
 binary darwin-x64 "https://nodejs.org/dist/v10.6.0/node-v10.6.0-darwin-x64.tar.gz#537efef0c6fd998502fa10baf82ee21edf513256cc73575991354e19442d0b69"
 binary linux-arm64 "https://nodejs.org/dist/v10.6.0/node-v10.6.0-linux-arm64.tar.gz#354dc8b855faf57c7561633538a63224aeb19e109144396fae466f570feeb69e"

--- a/share/node-build/10.7.0
+++ b/share/node-build/10.7.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.7.0/node-v10.7.0-aix-ppc64.tar.gz#fb5d42f64655bf21ffee921a1b1ecad3a7bcbe11d709db054a7f26073ec28e8b"
 binary darwin-x64 "https://nodejs.org/dist/v10.7.0/node-v10.7.0-darwin-x64.tar.gz#913473055605c8ae92f46923e6ac400133895aafe7766574fd46899bc6b0c5a4"
 binary linux-arm64 "https://nodejs.org/dist/v10.7.0/node-v10.7.0-linux-arm64.tar.gz#98211277500f39c10f71417bfb77e422190ff9aa46707cc5d2fd18a8a8b50691"

--- a/share/node-build/10.8.0
+++ b/share/node-build/10.8.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.8.0/node-v10.8.0-aix-ppc64.tar.gz#b167433b33bddd5839c7ce2a703137b22a888f22a12d5a32b3eca6f78819f557"
 binary darwin-x64 "https://nodejs.org/dist/v10.8.0/node-v10.8.0-darwin-x64.tar.gz#b800d8b55c234b1f7d972e9464b00328a1caea5f86f94fdb5fc88ebbed7852b7"
 binary linux-arm64 "https://nodejs.org/dist/v10.8.0/node-v10.8.0-linux-arm64.tar.gz#c0af4dfb2eb2b0abf45a0c96bbf00ffc059e4afe7feb9a8611ecfd2442847323"

--- a/share/node-build/10.9.0
+++ b/share/node-build/10.9.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v10.9.0/node-v10.9.0-aix-ppc64.tar.gz#238afcb7b047691db3883b01a97f1ec458824d6d7d8412840319aeb82f3a3d5c"
 binary darwin-x64 "https://nodejs.org/dist/v10.9.0/node-v10.9.0-darwin-x64.tar.gz#3c4fe75dacfcc495a432a7ba2dec9045cff359af2a5d7d0429c84a424ef686fc"
 binary linux-arm64 "https://nodejs.org/dist/v10.9.0/node-v10.9.0-linux-arm64.tar.gz#de3f9625fd15acefce6123e7ac7e51f26b965315f0f64f00aef359d68677ec82"

--- a/share/node-build/10.x-dev
+++ b/share/node-build/10.x-dev
@@ -2,10 +2,4 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 install_git "10.x-dev" "https://github.com/nodejs/node.git" "v10.x-staging" standard

--- a/share/node-build/10.x-next
+++ b/share/node-build/10.x-next
@@ -2,10 +2,4 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 install_git "10.x-next" "https://github.com/nodejs/node.git" "v10.x" standard

--- a/share/node-build/12.0.0
+++ b/share/node-build/12.0.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.0.0/node-v12.0.0-aix-ppc64.tar.gz#84e9f3f274a89ff82f9f5890bc009a2d697bfca0312fb3dbc248212844bb7e20"
 binary darwin-x64 "https://nodejs.org/dist/v12.0.0/node-v12.0.0-darwin-x64.tar.gz#92c81a284e909424b50dd01e175260b75bbbdb487fdfe1885229817187ea76bc"
 binary linux-arm64 "https://nodejs.org/dist/v12.0.0/node-v12.0.0-linux-arm64.tar.gz#835265539497708b4daf68175614fbe57ed21374f3717b4754971551a06c5efb"

--- a/share/node-build/12.1.0
+++ b/share/node-build/12.1.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.1.0/node-v12.1.0-aix-ppc64.tar.gz#dfedd5f7f31284b4b1c4cabc07c1f8619e998ebeac8183ea4c4b8cb1e1a61611"
 binary darwin-x64 "https://nodejs.org/dist/v12.1.0/node-v12.1.0-darwin-x64.tar.gz#57c592b13940aa44611aec08e7b425f35565a2c95c51736f433cb36eb65105b7"
 binary linux-arm64 "https://nodejs.org/dist/v12.1.0/node-v12.1.0-linux-arm64.tar.gz#e0ca3fe82c35d7e03b6a4c9983cf6797677f797148777b61c2bb3c01257026f2"

--- a/share/node-build/12.10.0
+++ b/share/node-build/12.10.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.10.0/node-v12.10.0-aix-ppc64.tar.gz#c5058a0fcbd0c9f8d49b64aa573ef151460f9de142a94479b2eda7d077d9de37"
 binary darwin-x64 "https://nodejs.org/dist/v12.10.0/node-v12.10.0-darwin-x64.tar.gz#4c16d1f6454f5dc3977ad00cea123792b8d4e1d6d1bf42bbc82a4202039a5971"
 binary linux-arm64 "https://nodejs.org/dist/v12.10.0/node-v12.10.0-linux-arm64.tar.gz#fd117a6ed22f493900fabdc7881fee50c7661c0eed88ae10c1139fa0d6c72535"

--- a/share/node-build/12.11.0
+++ b/share/node-build/12.11.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.11.0/node-v12.11.0-aix-ppc64.tar.gz#e6016150756787756e019d86f3cc677ae26348abc1cae48c7faaa393b5be7b08"
 binary darwin-x64 "https://nodejs.org/dist/v12.11.0/node-v12.11.0-darwin-x64.tar.gz#a0fd5c1c9e67099f52b73c732aa52a878c6ff67f50ff0e94c2c5628a87455130"
 binary linux-arm64 "https://nodejs.org/dist/v12.11.0/node-v12.11.0-linux-arm64.tar.gz#8988bf487317766b3d84f9b9075c302eaa2a35c768640c99d1f7b0c4ba10bbda"

--- a/share/node-build/12.11.1
+++ b/share/node-build/12.11.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.11.1/node-v12.11.1-aix-ppc64.tar.gz#5242f490a320584dbfb21a7009fe6c316d43cffc9fa661ee852bdbb0875e27f4"
 binary darwin-x64 "https://nodejs.org/dist/v12.11.1/node-v12.11.1-darwin-x64.tar.gz#7dd24ee6d81668e65ce1b77b4bb4cdaf517d8f80bb19740d286606028506970b"
 binary linux-arm64 "https://nodejs.org/dist/v12.11.1/node-v12.11.1-linux-arm64.tar.gz#a9973aeb9f942b4ffa8fe40149dfb3e0ddf9377049fc3cc7e789c5dfdc22ffd0"

--- a/share/node-build/12.12.0
+++ b/share/node-build/12.12.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.12.0/node-v12.12.0-aix-ppc64.tar.gz#b9ccb43e955656ad9c1653428890ce74a7a7ac25dad0218e9b4a259e57fc0d6f"
 binary darwin-x64 "https://nodejs.org/dist/v12.12.0/node-v12.12.0-darwin-x64.tar.gz#14a98237e8859bc22695719dbc2e9db5529a33ada0c6c377df4dc27b5622ffbb"
 binary linux-arm64 "https://nodejs.org/dist/v12.12.0/node-v12.12.0-linux-arm64.tar.gz#9c6ff84ad3be0fc79188cfa68b3fab9aedadf219ffb3821d4bf6d01308ed6621"

--- a/share/node-build/12.13.0
+++ b/share/node-build/12.13.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.13.0/node-v12.13.0-aix-ppc64.tar.gz#c5a07d2915a787e8f73c987e8263bb33b453a854f7fba3c8873421be5b4d53b6"
 binary darwin-x64 "https://nodejs.org/dist/v12.13.0/node-v12.13.0-darwin-x64.tar.gz#49a7374670a111b033ce16611b20fd1aafd3296bbc662b184fe8fb26a29c22cc"
 binary linux-arm64 "https://nodejs.org/dist/v12.13.0/node-v12.13.0-linux-arm64.tar.gz#92371c7f1edd384a8acb0d2b9f2deac76e911588669b71de9f6453012196c970"

--- a/share/node-build/12.13.1
+++ b/share/node-build/12.13.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.13.1/node-v12.13.1-aix-ppc64.tar.gz#81a5eed8c2215816aad4551683189a48953a11cb669f2e942a903e2cd5a5e4d7"
 binary darwin-x64 "https://nodejs.org/dist/v12.13.1/node-v12.13.1-darwin-x64.tar.gz#12d14c7fbd98876a163a2b7e0aeb13657dc3e967e993efaf2dcacbe475a285e8"
 binary linux-arm64 "https://nodejs.org/dist/v12.13.1/node-v12.13.1-linux-arm64.tar.gz#a1c183f175344f492188543fa789576ed266b7542763ad07d880f9819d9f23d3"

--- a/share/node-build/12.14.0
+++ b/share/node-build/12.14.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.14.0/node-v12.14.0-aix-ppc64.tar.gz#b1c4db193ac9981d671a8b267d4d836dcdb20d9d0a9fa1b69150c349a5ac5b39"
 binary darwin-x64 "https://nodejs.org/dist/v12.14.0/node-v12.14.0-darwin-x64.tar.gz#5f3170b346b29e6902c0ca7e0993e3d1b4b650615348aa866de17ad965377048"
 binary linux-arm64 "https://nodejs.org/dist/v12.14.0/node-v12.14.0-linux-arm64.tar.gz#63e9c96712868addef76a694852f54ea279479949669275dab506aa8ce4e0b73"

--- a/share/node-build/12.14.1
+++ b/share/node-build/12.14.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.14.1/node-v12.14.1-aix-ppc64.tar.gz#7d7621ff0c037ea556284e382f3c5c98af0dad146786fef133a71cea1bd661fc"
 binary darwin-x64 "https://nodejs.org/dist/v12.14.1/node-v12.14.1-darwin-x64.tar.gz#0be10a28737527a1e5e3784d3ad844d742fe8b0718acd701fd48f718fd3af78f"
 binary linux-arm64 "https://nodejs.org/dist/v12.14.1/node-v12.14.1-linux-arm64.tar.gz#fb1a20f37ef918033b0f2f9436b4a82e15128ce61e0de2378a4306ba7667cf4a"

--- a/share/node-build/12.15.0
+++ b/share/node-build/12.15.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.15.0/node-v12.15.0-aix-ppc64.tar.gz#4674d94402b8c0d79a9e20d4320652830032f0a7171cea2c815858b76d3d2ee9"
 binary darwin-x64 "https://nodejs.org/dist/v12.15.0/node-v12.15.0-darwin-x64.tar.gz#b6449cec39ac15b37abe4e59ef0eae50dcdfbf060c5276a01cc590f2a3372b7d"
 binary linux-arm64 "https://nodejs.org/dist/v12.15.0/node-v12.15.0-linux-arm64.tar.gz#9349bb00a522da9ecd0d2f9453b500904ccd56e271852ab2defb51a8c77a1aca"

--- a/share/node-build/12.16.0
+++ b/share/node-build/12.16.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.16.0/node-v12.16.0-aix-ppc64.tar.gz#62495024587778856d800021203b67c1c306b451146c2418614810ebd8666f5e"
 binary darwin-x64 "https://nodejs.org/dist/v12.16.0/node-v12.16.0-darwin-x64.tar.gz#af3b9bbfdd9ae1b46390e7deeb77a2c1d8dbc6fb4171bbb0cfe8686fc1ecef1d"
 binary linux-arm64 "https://nodejs.org/dist/v12.16.0/node-v12.16.0-linux-arm64.tar.gz#d899593fc516357bf1ad9e28fbb5b2beb5ade25c81a45c1f5499b9320709793f"

--- a/share/node-build/12.16.1
+++ b/share/node-build/12.16.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.16.1/node-v12.16.1-aix-ppc64.tar.gz#d928dd3dc4a79c39e45aa8f1f00c33117eb6145001427cb4dd838340932d8f2d"
 binary darwin-x64 "https://nodejs.org/dist/v12.16.1/node-v12.16.1-darwin-x64.tar.gz#34895bce210ca4b3cf19cd480e6563588880dd7f5d798f3782e3650580d35920"
 binary linux-arm64 "https://nodejs.org/dist/v12.16.1/node-v12.16.1-linux-arm64.tar.gz#22750695d432e22f2a1faadfcd534a88a18933ffd658d45b08a5afa61acbc24a"

--- a/share/node-build/12.16.2
+++ b/share/node-build/12.16.2
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.16.2/node-v12.16.2-aix-ppc64.tar.gz#6beb0d9583b33d6ff7cab78cb89f61c861fe57d2fff6474317aa2613eaf1634f"
 binary darwin-x64 "https://nodejs.org/dist/v12.16.2/node-v12.16.2-darwin-x64.tar.gz#483954e311a5ff649ddf32b473f635a58890790d284b5788bdd8d7ff850c6db2"
 binary linux-arm64 "https://nodejs.org/dist/v12.16.2/node-v12.16.2-linux-arm64.tar.gz#0beb78161a02eed9fc2a97e9cf95e1aecfdff61da6a695a26a66880528f1f53f"

--- a/share/node-build/12.16.3
+++ b/share/node-build/12.16.3
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.16.3/node-v12.16.3-aix-ppc64.tar.gz#7d16447943c66dda607420e798ddc9c7d59f8849aa739e061b6cab63e7c10dd1"
 binary darwin-x64 "https://nodejs.org/dist/v12.16.3/node-v12.16.3-darwin-x64.tar.gz#0718812b3ab8e77e8d1354f4d10428ae99d78f721bdcceee527c4b592ea7fed0"
 binary linux-arm64 "https://nodejs.org/dist/v12.16.3/node-v12.16.3-linux-arm64.tar.gz#f91f92bd690f457ced9faa81bef8eeb8706abea33a349358299e30f1c2522f30"

--- a/share/node-build/12.17.0
+++ b/share/node-build/12.17.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.17.0/node-v12.17.0-aix-ppc64.tar.gz#a775eb37dd9bd020b5d96673390e2aa43e59953f50fda59acf1f56f3dde01716"
 binary darwin-x64 "https://nodejs.org/dist/v12.17.0/node-v12.17.0-darwin-x64.tar.gz#8c3b9459462b8adaa10549f4da6a5ff5cdfaf7140a8a8020a87cc96d79022cc0"
 binary linux-arm64 "https://nodejs.org/dist/v12.17.0/node-v12.17.0-linux-arm64.tar.gz#498eda4d6089544ec7be795fd43cb5e9ff5e7f25fc10f0ce81646990ff3163b7"

--- a/share/node-build/12.18.0
+++ b/share/node-build/12.18.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.18.0/node-v12.18.0-aix-ppc64.tar.gz#78581e043e6d33c2d793c24990424b1c3e8ac276e440d38184ba1af25b5a7aeb"
 binary darwin-x64 "https://nodejs.org/dist/v12.18.0/node-v12.18.0-darwin-x64.tar.gz#11fe50e670315d2d3c46317d23f7a019f46a3d08b534fbadee9a1bc3d4f81852"
 binary linux-arm64 "https://nodejs.org/dist/v12.18.0/node-v12.18.0-linux-arm64.tar.gz#11860778b886b9771980ba04774d18496fe6bd1f4a6181189f7b6be61b1e7c79"

--- a/share/node-build/12.18.1
+++ b/share/node-build/12.18.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.18.1/node-v12.18.1-aix-ppc64.tar.gz#ff5ff4f96630cff7c7aa8fe54f42bdae6ada43ac8043badb4fb4ed3ae3e5b3e9"
 binary darwin-x64 "https://nodejs.org/dist/v12.18.1/node-v12.18.1-darwin-x64.tar.gz#80e1d644fe78838da47cd16de234b612c20e06ffe14447125db9622e381ed1ba"
 binary linux-arm64 "https://nodejs.org/dist/v12.18.1/node-v12.18.1-linux-arm64.tar.gz#b78fc542858b83a96d712d6a2f493ae87e1af55040bc55fb68671af191016d19"

--- a/share/node-build/12.18.2
+++ b/share/node-build/12.18.2
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.18.2/node-v12.18.2-aix-ppc64.tar.gz#3b7026487c93871c8d7817c008cf2a04a04094873f198a605c7386d7054d2c06"
 binary darwin-x64 "https://nodejs.org/dist/v12.18.2/node-v12.18.2-darwin-x64.tar.gz#6e6e7311943e4f3880db5038b8b8034a30469342fe436c8aaacf2997dfa305a6"
 binary linux-arm64 "https://nodejs.org/dist/v12.18.2/node-v12.18.2-linux-arm64.tar.gz#f6413c83c3a5ab0935f0ca8653a81b9b180462db078ea49478fa4e843b074eff"

--- a/share/node-build/12.18.3
+++ b/share/node-build/12.18.3
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.18.3/node-v12.18.3-aix-ppc64.tar.gz#9b62fcc3138eaadfc4ea90776c5e02f508a1d7df8c0b1692734cd9d07a7d82dd"
 binary darwin-x64 "https://nodejs.org/dist/v12.18.3/node-v12.18.3-darwin-x64.tar.gz#af376caf114bdd5d7e566dbf7590e9077ffc01f9b2692eb2651f31d7219a30bb"
 binary linux-arm64 "https://nodejs.org/dist/v12.18.3/node-v12.18.3-linux-arm64.tar.gz#f2b8b7f34966a03f03fcd89fa4924fb97ea680eae4c4e02ff1aafd9ea89ecad8"

--- a/share/node-build/12.18.4
+++ b/share/node-build/12.18.4
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.18.4/node-v12.18.4-aix-ppc64.tar.gz#ddba15a6b544df32c242d761ffc66b7f5d841fe9fdf78ec1e11aa4ae9f4ac452"
 binary darwin-x64 "https://nodejs.org/dist/v12.18.4/node-v12.18.4-darwin-x64.tar.gz#1bd2c367dc6b33f46c90c0a13fc83a890ced0a2e278f80c3e3b6aab8843189be"
 binary linux-arm64 "https://nodejs.org/dist/v12.18.4/node-v12.18.4-linux-arm64.tar.gz#69a419a08b6e2d0dffc5b0659e16adfd315074fc0e93e382ee6052546ad789ff"

--- a/share/node-build/12.19.0
+++ b/share/node-build/12.19.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.19.0/node-v12.19.0-aix-ppc64.tar.gz#256ce45b2aad4f4d7da6e282f94f1c8cfdef20cd0c4e346c9a158116fc944825"
 binary darwin-x64 "https://nodejs.org/dist/v12.19.0/node-v12.19.0-darwin-x64.tar.gz#751482c5060c2b705bd63739300a8d06bb33bcfacaf616eec78bbc20c55a627b"
 binary linux-arm64 "https://nodejs.org/dist/v12.19.0/node-v12.19.0-linux-arm64.tar.gz#09f2a675f209f7af8d346b2a0ceb2cb9248515a50207276cef13038ec103d552"

--- a/share/node-build/12.19.1
+++ b/share/node-build/12.19.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.19.1/node-v12.19.1-aix-ppc64.tar.gz#b89a4c9ca331fd8ded9ea8d97e70461f7b90bc71a29b6845b4703cd3f2294a24"
 binary darwin-x64 "https://nodejs.org/dist/v12.19.1/node-v12.19.1-darwin-x64.tar.gz#3cb491abc1f643bb71ef40722291c2fee0b75ed52b333ea71aa67de005757251"
 binary linux-arm64 "https://nodejs.org/dist/v12.19.1/node-v12.19.1-linux-arm64.tar.gz#a716fca03eb7ba6e07c6a05595e152e177ad3435e58df8120cf615836bcd00b4"

--- a/share/node-build/12.2.0
+++ b/share/node-build/12.2.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.2.0/node-v12.2.0-aix-ppc64.tar.gz#94533317caae6c62ba0d139641e3d873cd678cc9a1105c96f89c423fdea46b76"
 binary darwin-x64 "https://nodejs.org/dist/v12.2.0/node-v12.2.0-darwin-x64.tar.gz#c72ae8a2b989138c6e6e9b393812502df8c28546a016cf24e7a82dd27e3838af"
 binary linux-arm64 "https://nodejs.org/dist/v12.2.0/node-v12.2.0-linux-arm64.tar.gz#abc9adedbbbd48f46163399c0f7a7948c14df184cb500b925c6980c921988d13"

--- a/share/node-build/12.20.0
+++ b/share/node-build/12.20.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.20.0/node-v12.20.0-aix-ppc64.tar.gz#e31578c5fad164c2b292d3e13a8eded6aefd094e2abe3c9f4d9d0bf94743cc84"
 binary darwin-x64 "https://nodejs.org/dist/v12.20.0/node-v12.20.0-darwin-x64.tar.gz#6a8f4a0f1060552386181e10aa8db5f4b7771f7a28b3d367d7ac246d52654e6e"
 binary linux-arm64 "https://nodejs.org/dist/v12.20.0/node-v12.20.0-linux-arm64.tar.gz#4c44beb80f08bd815c813a2acd3a8736593022b5a1d53ec779be0e9df0ab32ff"

--- a/share/node-build/12.20.1
+++ b/share/node-build/12.20.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.20.1/node-v12.20.1-aix-ppc64.tar.gz#85d6b2fb4517fdc2540eba89a70a6256541f89cb9970aa5176c10294c2d595ee"
 binary darwin-x64 "https://nodejs.org/dist/v12.20.1/node-v12.20.1-darwin-x64.tar.gz#da5d32de2e0f3e82b4bc4a33754a9ceedb3c031f8804e984de89d82074897795"
 binary linux-arm64 "https://nodejs.org/dist/v12.20.1/node-v12.20.1-linux-arm64.tar.gz#3154628c02f2c920fed77e8dce1a8ae32333260666ebaaa7a3cd230f45d13e42"

--- a/share/node-build/12.20.2
+++ b/share/node-build/12.20.2
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.20.2/node-v12.20.2-aix-ppc64.tar.gz#663510979b18d0cde123156f4fe78569716559cebe798390db4f2fd5e1940206"
 binary darwin-x64 "https://nodejs.org/dist/v12.20.2/node-v12.20.2-darwin-x64.tar.gz#c226e98116c169d230dd71d9adbab0fc8cc696af914de8cb80cedaa496af54cc"
 binary linux-arm64 "https://nodejs.org/dist/v12.20.2/node-v12.20.2-linux-arm64.tar.gz#cd7a83dd8d9e00953079b09520647d474431f5aaad1a67200005ddff9166d55d"

--- a/share/node-build/12.21.0
+++ b/share/node-build/12.21.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.21.0/node-v12.21.0-aix-ppc64.tar.gz#10a487471ebd720f0d643c9e8e919db580baf852b812788f00db736d2e634d77"
 binary darwin-x64 "https://nodejs.org/dist/v12.21.0/node-v12.21.0-darwin-x64.tar.gz#4d0b5d07d41a16909fdeb41c3158c27bcdccf16231cccf76d5eb6835e2076e90"
 binary linux-arm64 "https://nodejs.org/dist/v12.21.0/node-v12.21.0-linux-arm64.tar.gz#5748bfc5bbf7d9c1c8e79bd4f71d8f049c7fc7bc5b52e04685633319843c4f93"

--- a/share/node-build/12.22.0
+++ b/share/node-build/12.22.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.22.0/node-v12.22.0-aix-ppc64.tar.gz#64482b90fb13ca4be3a40386c958a41e49f6c915d3807d14d797bf101d363621"
 binary darwin-x64 "https://nodejs.org/dist/v12.22.0/node-v12.22.0-darwin-x64.tar.gz#7f72fd468cd00cf562c8fe2ea8b5e7a3b68027e8454e432db9ffbdd967bf420c"
 binary linux-arm64 "https://nodejs.org/dist/v12.22.0/node-v12.22.0-linux-arm64.tar.gz#844d0ea80f0b71b015800d2089fe13a0dee1dd46b2957c458d06a5231bf6ac0b"

--- a/share/node-build/12.22.1
+++ b/share/node-build/12.22.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.22.1/node-v12.22.1-aix-ppc64.tar.gz#696f48b080915eb08e2ae24349a32ce56520483ac982fb51cce4876b82ab1bf5"
 binary darwin-x64 "https://nodejs.org/dist/v12.22.1/node-v12.22.1-darwin-x64.tar.gz#9cbade90e2e89feba674b1841573e6f0329e6ba4bd3ecc1f5e0c5c6785db6dc0"
 binary linux-arm64 "https://nodejs.org/dist/v12.22.1/node-v12.22.1-linux-arm64.tar.gz#917c582b7f7ae5ff8b2d97e05d00598011f9fbfcc4f76952da3ed477405c9c1a"

--- a/share/node-build/12.22.10
+++ b/share/node-build/12.22.10
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.22.10/node-v12.22.10-aix-ppc64.tar.gz#2f60e225dd0c50a4e43e08ddaa822d60e59b0ebe77140a7ded284133ce5fab78"
 binary darwin-x64 "https://nodejs.org/dist/v12.22.10/node-v12.22.10-darwin-x64.tar.gz#4d37ce205cc95affda3f275e98c5aee4568b06103e9bcb5714c14e2fdb634b0b"
 binary linux-arm64 "https://nodejs.org/dist/v12.22.10/node-v12.22.10-linux-arm64.tar.gz#1c2e82099a7b1e2c43327f2e5d2ced22b69738870272a2cbc8c92dea4299980a"

--- a/share/node-build/12.22.11
+++ b/share/node-build/12.22.11
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.22.11/node-v12.22.11-aix-ppc64.tar.gz#66d54fbdc98ed93cc54524d8e515301a6954daabcfb1507c57c258e20095a12f"
 binary darwin-x64 "https://nodejs.org/dist/v12.22.11/node-v12.22.11-darwin-x64.tar.gz#858fd52204fa48799105019e73347dfd6b0371621b01beecfe2264f2d64d1b30"
 binary linux-arm64 "https://nodejs.org/dist/v12.22.11/node-v12.22.11-linux-arm64.tar.gz#6efd2770a6d73ef631d1b7a8aecf50361c5cf1858080dbc29e56c8ddf0a981af"

--- a/share/node-build/12.22.12
+++ b/share/node-build/12.22.12
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.22.12/node-v12.22.12-aix-ppc64.tar.gz#c360131f03422105d59c84d164e3cbb8fa23d6c1a7d7b80fc594ec331e13a466"
 binary darwin-x64 "https://nodejs.org/dist/v12.22.12/node-v12.22.12-darwin-x64.tar.gz#32927913ed549ce01685a6f9f4697567a64592c7fd1e9a845ac8a10efa1475e6"
 binary linux-arm64 "https://nodejs.org/dist/v12.22.12/node-v12.22.12-linux-arm64.tar.gz#91aefa690914b7f24250f3c0b560b42c6d306315d40009c96b5a6940115895fe"

--- a/share/node-build/12.22.2
+++ b/share/node-build/12.22.2
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.22.2/node-v12.22.2-aix-ppc64.tar.gz#6e55248464241a1a2e025872c02becf49ab4a989576a5a40fdabc7c11c2cb449"
 binary darwin-x64 "https://nodejs.org/dist/v12.22.2/node-v12.22.2-darwin-x64.tar.gz#293156b4ab199ed2775e4b4c69dbd6d3730fe0a099be8c354d5628652ff0ec3a"
 binary linux-arm64 "https://nodejs.org/dist/v12.22.2/node-v12.22.2-linux-arm64.tar.gz#40f4a6a887e3ab8675e71bdc544353e078775074ec9f7911cfe3827ad68007fb"

--- a/share/node-build/12.22.3
+++ b/share/node-build/12.22.3
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.22.3/node-v12.22.3-aix-ppc64.tar.gz#84755fb1e0d8c87b7da168f5d29b53427275c3899f9542d64a56b188d19305fc"
 binary darwin-x64 "https://nodejs.org/dist/v12.22.3/node-v12.22.3-darwin-x64.tar.gz#c223e375567804efa312c3c04d78b1c27901dd671210d5bc588ae1e3439dd3e5"
 binary linux-arm64 "https://nodejs.org/dist/v12.22.3/node-v12.22.3-linux-arm64.tar.gz#fea8d7801dbea6aa45d8fe58351f758a9262e187b8e86eaf500bbe01c7f02362"

--- a/share/node-build/12.22.4
+++ b/share/node-build/12.22.4
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.22.4/node-v12.22.4-aix-ppc64.tar.gz#efc0252457e8bbc4d703a672e2f58a4da9ebc14eb07e7a16c9dab2fbc732f6a5"
 binary darwin-x64 "https://nodejs.org/dist/v12.22.4/node-v12.22.4-darwin-x64.tar.gz#6e6842468ff8b50562098e41f9fb6af7c3acbefbd018696f4ac7c2d9b7faac48"
 binary linux-arm64 "https://nodejs.org/dist/v12.22.4/node-v12.22.4-linux-arm64.tar.gz#c104dff52409d27836f7c4529c7f3cce6c76a521b8b834e338bcbf6eed4abc18"

--- a/share/node-build/12.22.5
+++ b/share/node-build/12.22.5
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.22.5/node-v12.22.5-aix-ppc64.tar.gz#88ec315734db12686d1ee8cc24c7590f125231b64159b23e8aae3c42083d5480"
 binary darwin-x64 "https://nodejs.org/dist/v12.22.5/node-v12.22.5-darwin-x64.tar.gz#7944aa8bcc25842cac70d7e5454fce3eed1a01867968a3734765a3d6d15a5050"
 binary linux-arm64 "https://nodejs.org/dist/v12.22.5/node-v12.22.5-linux-arm64.tar.gz#bfb436a87142e9dc73ed675c81c267490e575f9abfbbc7fa5db227a2ab6b555c"

--- a/share/node-build/12.22.6
+++ b/share/node-build/12.22.6
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.22.6/node-v12.22.6-aix-ppc64.tar.gz#eb2fc7741587f5149178265cbc5b244d9a9cffb6a5fe62e20ee966d57ec9217a"
 binary darwin-x64 "https://nodejs.org/dist/v12.22.6/node-v12.22.6-darwin-x64.tar.gz#2124e9e17bf6b81ad579223f8efff537238c9cace17721e60614c5091f00e2d1"
 binary linux-arm64 "https://nodejs.org/dist/v12.22.6/node-v12.22.6-linux-arm64.tar.gz#f65bf376b6b074b78240ea84d0ab7ca6cacb34c1c066b6653d76045a38565bc2"

--- a/share/node-build/12.22.7
+++ b/share/node-build/12.22.7
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.22.7/node-v12.22.7-aix-ppc64.tar.gz#32a88bed33b22ac4c7c0a11a66857748f1d2ba8f409527d87d0045e5edb11ea9"
 binary darwin-x64 "https://nodejs.org/dist/v12.22.7/node-v12.22.7-darwin-x64.tar.gz#4fa5bdee2ac420f8043b800c4789929b09e4a5226dfd5fa7162e53939c594eae"
 binary linux-arm64 "https://nodejs.org/dist/v12.22.7/node-v12.22.7-linux-arm64.tar.gz#76fa99531cc57982e9a469babb03a7bd1c47d9392cb6d4b0d55f55858c4ed5a0"

--- a/share/node-build/12.22.8
+++ b/share/node-build/12.22.8
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.22.8/node-v12.22.8-aix-ppc64.tar.gz#e96e6df9a493c60e8d95ce9affb0b7404ea646050236995fc42ba3226e6f80a1"
 binary darwin-x64 "https://nodejs.org/dist/v12.22.8/node-v12.22.8-darwin-x64.tar.gz#53478fac030a1fc6f6044ba46b6cc194c8b9b33c9a5f68cdd05f98bd644bc50c"
 binary linux-arm64 "https://nodejs.org/dist/v12.22.8/node-v12.22.8-linux-arm64.tar.gz#64b9d84cf202ce73f5a87d3dbbc56791f65ec31f3f77c7210713eeffb58d5dd5"

--- a/share/node-build/12.22.9
+++ b/share/node-build/12.22.9
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.22.9/node-v12.22.9-aix-ppc64.tar.gz#bb1de3edd4aef85ed7a9581f8bab579cace8c3a5a4909e6aabc412c9fdb636ee"
 binary darwin-x64 "https://nodejs.org/dist/v12.22.9/node-v12.22.9-darwin-x64.tar.gz#92cc54a86e7a52016c1cd0bbda5d3c857b37795340292d9c547b1c5f4373a2a5"
 binary linux-arm64 "https://nodejs.org/dist/v12.22.9/node-v12.22.9-linux-arm64.tar.gz#307aa26c68600e2f73d699e58a15c59ea06928e4a348cd5a216278d9f2ee0d6c"

--- a/share/node-build/12.3.0
+++ b/share/node-build/12.3.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.3.0/node-v12.3.0-aix-ppc64.tar.gz#ad994e17d12427dfb96b796c8a390af14541499edea9cc4b7349305ae650597c"
 binary darwin-x64 "https://nodejs.org/dist/v12.3.0/node-v12.3.0-darwin-x64.tar.gz#4a9faa038fb4e6e930a0fecd9818a4820b4ca91d1c45a1c1279fe49cdbd28160"
 binary linux-arm64 "https://nodejs.org/dist/v12.3.0/node-v12.3.0-linux-arm64.tar.gz#ffb57ec86f4f279e75e755515fb74149702f3467c4841c47c18cfb5d89e67c6d"

--- a/share/node-build/12.3.1
+++ b/share/node-build/12.3.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.3.1/node-v12.3.1-aix-ppc64.tar.gz#3ab8ed94704c6d74bbf6553a3481352cbeb51dc267d8bf32390398984cb9add3"
 binary darwin-x64 "https://nodejs.org/dist/v12.3.1/node-v12.3.1-darwin-x64.tar.gz#b9c979f63a356090d8ff88ed141fd856ad853165c73633794a9d3a060334378e"
 binary linux-arm64 "https://nodejs.org/dist/v12.3.1/node-v12.3.1-linux-arm64.tar.gz#5926be88109c8efe048eedd875487041174fadd470fed4fe6ffb5eadfa50cb6b"

--- a/share/node-build/12.4.0
+++ b/share/node-build/12.4.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.4.0/node-v12.4.0-aix-ppc64.tar.gz#b5fbeca9b72725a9825cad0a73af3f804ec01f8a7bac335fc9547c89443ad7f6"
 binary darwin-x64 "https://nodejs.org/dist/v12.4.0/node-v12.4.0-darwin-x64.tar.gz#aaff97d59cda775165ef966ae74e70f55f3267e86d735ed3740ae9bf1d40531e"
 binary linux-arm64 "https://nodejs.org/dist/v12.4.0/node-v12.4.0-linux-arm64.tar.gz#312a7942f5fbd0aa83d6e624a06681275db2cb3c3eeaf3e452ad04aac17b6de5"

--- a/share/node-build/12.5.0
+++ b/share/node-build/12.5.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.5.0/node-v12.5.0-aix-ppc64.tar.gz#45f3d0ea287d5f091da5c71cf6e77f36a98348e13972c6397bbc374d12257ef3"
 binary darwin-x64 "https://nodejs.org/dist/v12.5.0/node-v12.5.0-darwin-x64.tar.gz#a9ba9f584f015f1705063c10dd8d84d43f5b09dc7ecf4ee3968ab1ff1fe5d2b5"
 binary linux-arm64 "https://nodejs.org/dist/v12.5.0/node-v12.5.0-linux-arm64.tar.gz#a6d226bf486453d2f58df14ec71dd08f18383af582e2fc992fa8cc96cd7925b4"

--- a/share/node-build/12.6.0
+++ b/share/node-build/12.6.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.6.0/node-v12.6.0-aix-ppc64.tar.gz#26bbcb162932a8d04008c65b19c5056c871a7c3af38b4a4efaba316751a81f59"
 binary darwin-x64 "https://nodejs.org/dist/v12.6.0/node-v12.6.0-darwin-x64.tar.gz#004b7992a2621eb35a47c94d258510ca5744b5a8072364f235dc7e3d4bff7457"
 binary linux-arm64 "https://nodejs.org/dist/v12.6.0/node-v12.6.0-linux-arm64.tar.gz#966951924e08c6e1107a46396dd661a827d9473d2b503fe9e6383bbfa68881b3"

--- a/share/node-build/12.7.0
+++ b/share/node-build/12.7.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.7.0/node-v12.7.0-aix-ppc64.tar.gz#48d199a653952aee81ba31a7cc04da45ccf4f20d9b74172ea19a1cd4f507a836"
 binary darwin-x64 "https://nodejs.org/dist/v12.7.0/node-v12.7.0-darwin-x64.tar.gz#1a76bea7f7ed8c5c921852269ddd1300c9baba2f1e3f0377200a22c22cdea177"
 binary linux-arm64 "https://nodejs.org/dist/v12.7.0/node-v12.7.0-linux-arm64.tar.gz#4eb18db42c36ac535ab306894f0bd6bf1058e61ef9702108b11fca7c1b44a484"

--- a/share/node-build/12.8.0
+++ b/share/node-build/12.8.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.8.0/node-v12.8.0-aix-ppc64.tar.gz#c90a01b8480e2f820649924f9814023b2cb1ddda439d8f2d1f64e7917774459d"
 binary darwin-x64 "https://nodejs.org/dist/v12.8.0/node-v12.8.0-darwin-x64.tar.gz#5229571a1736befd6426dc0a6907be416e9f5c24695e3ef275ed2ba70f496499"
 binary linux-arm64 "https://nodejs.org/dist/v12.8.0/node-v12.8.0-linux-arm64.tar.gz#9eb01fe3ff86210f19d03929d0a7c59713a05fd686334ecc8843c8f0d0321de6"

--- a/share/node-build/12.8.1
+++ b/share/node-build/12.8.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.8.1/node-v12.8.1-aix-ppc64.tar.gz#a140e9c84fdb5c40328dc1ea6425954e08cec722ab4e1ab4521b0523bd7b2fa0"
 binary darwin-x64 "https://nodejs.org/dist/v12.8.1/node-v12.8.1-darwin-x64.tar.gz#caccf8b409af342e35672cc766430587664f88d01dab622a5de44c8be1336e44"
 binary linux-arm64 "https://nodejs.org/dist/v12.8.1/node-v12.8.1-linux-arm64.tar.gz#3ad6e53bcf8a3b92b10504fa70d83f69eab85a8603c2fbe210121278dd19920b"

--- a/share/node-build/12.9.0
+++ b/share/node-build/12.9.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.9.0/node-v12.9.0-aix-ppc64.tar.gz#c690810b11e286778c0eacb8f1f56af1973d71b1788c54040f25380fc3ff6bcd"
 binary darwin-x64 "https://nodejs.org/dist/v12.9.0/node-v12.9.0-darwin-x64.tar.gz#24c1f0c93e485961446814662db942f1b309d843fb4ecbe50466d9857a51b343"
 binary linux-arm64 "https://nodejs.org/dist/v12.9.0/node-v12.9.0-linux-arm64.tar.gz#703134352854e3501023cda8eba68f1f992a426f1cda649dc6b38e248b07fcf1"

--- a/share/node-build/12.9.1
+++ b/share/node-build/12.9.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v12.9.1/node-v12.9.1-aix-ppc64.tar.gz#76c66b55bd2a923579333c2d24429e10d50f4e259170cdd6e413214febb9df55"
 binary darwin-x64 "https://nodejs.org/dist/v12.9.1/node-v12.9.1-darwin-x64.tar.gz#9aaf29d30056e2233fd15dfac56eec12e8342d91bb6c13d54fb5e599383dddb9"
 binary linux-arm64 "https://nodejs.org/dist/v12.9.1/node-v12.9.1-linux-arm64.tar.gz#a09e7c54f05036ddf260f9a6762d72669e428810f814ad189519fe5adad0bd2d"

--- a/share/node-build/12.x-dev
+++ b/share/node-build/12.x-dev
@@ -2,9 +2,3 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-install_git "12.x-dev" "https://github.com/nodejs/node.git" "v12.x-staging" standard

--- a/share/node-build/12.x-next
+++ b/share/node-build/12.x-next
@@ -2,9 +2,3 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-install_git "12.x-next" "https://github.com/nodejs/node.git" "v12.x" standard

--- a/share/node-build/13.0.0
+++ b/share/node-build/13.0.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-binary aix-ppc64 "https://nodejs.org/dist/v13.0.0/node-v13.0.0-aix-ppc64.tar.gz#9164c8b7eb9f2acccf8fe2d783122bfe967774a400ba7551695b4252181ffbcf"
 binary darwin-x64 "https://nodejs.org/dist/v13.0.0/node-v13.0.0-darwin-x64.tar.gz#612556a8c7e6b4cd08f6134b8afe5a05bf84c0121225fa9c542be1c98af04a35"
 binary linux-arm64 "https://nodejs.org/dist/v13.0.0/node-v13.0.0-linux-arm64.tar.gz#18e28a5ed3a474e8d0619c5b17c14b88c72a55630e637d4547485d88863dc1a9"
 binary linux-armv7l "https://nodejs.org/dist/v13.0.0/node-v13.0.0-linux-armv7l.tar.gz#dbbe30ba285c012a456a33b0ea5d6c7bdd0ce9a5095bcd1f2fd130109023e132"

--- a/share/node-build/13.0.1
+++ b/share/node-build/13.0.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-binary aix-ppc64 "https://nodejs.org/dist/v13.0.1/node-v13.0.1-aix-ppc64.tar.gz#86d3a93abc03aeb43c9a56db56eac591276a66f0723cd3c32f20d427b21fb3b9"
 binary darwin-x64 "https://nodejs.org/dist/v13.0.1/node-v13.0.1-darwin-x64.tar.gz#25621359a51ff218ecf4bb2ffc657815154230a967224f22b722840a2b9ad061"
 binary linux-arm64 "https://nodejs.org/dist/v13.0.1/node-v13.0.1-linux-arm64.tar.gz#437dc656d94e295d9200425b0d0dd000eed67fbc090334a5da51c77a8895b136"
 binary linux-armv7l "https://nodejs.org/dist/v13.0.1/node-v13.0.1-linux-armv7l.tar.gz#1ac9b16adf01069170bf685dc0497d83d7f690492f83cc29a1c6a5950b914661"

--- a/share/node-build/13.1.0
+++ b/share/node-build/13.1.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-binary aix-ppc64 "https://nodejs.org/dist/v13.1.0/node-v13.1.0-aix-ppc64.tar.gz#5faec026afe9052f277402500236dd9ec4d58e0e8de93f66989fc337c65e33c8"
 binary darwin-x64 "https://nodejs.org/dist/v13.1.0/node-v13.1.0-darwin-x64.tar.gz#6501c1bcf2babb5b9c81dcff8b52021f726da8f6ee28df1637acade1a16c7d39"
 binary linux-arm64 "https://nodejs.org/dist/v13.1.0/node-v13.1.0-linux-arm64.tar.gz#dd36c7846f7713b6e55baf0b6ab7882c18b129d83a3d0f7ef62790d181461d22"
 binary linux-armv7l "https://nodejs.org/dist/v13.1.0/node-v13.1.0-linux-armv7l.tar.gz#88450bc38dac0be15c9bd09bfccf4ce79f1911930f37658c730c151b26c5aa97"

--- a/share/node-build/13.10.0
+++ b/share/node-build/13.10.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-binary aix-ppc64 "https://nodejs.org/dist/v13.10.0/node-v13.10.0-aix-ppc64.tar.gz#a5037e8b3ace4ece087fdd89bf7a652b3e9dc8bda9579f2e1cbbcbd5d58b11c9"
 binary darwin-x64 "https://nodejs.org/dist/v13.10.0/node-v13.10.0-darwin-x64.tar.gz#67269fb9061402e446bb61776be2e5d0ec330b5274326df77979698d05f503da"
 binary linux-arm64 "https://nodejs.org/dist/v13.10.0/node-v13.10.0-linux-arm64.tar.gz#48b18003d75abb10acee432a9bfa2de8bc8e2ec4c8a3cf08a69ff7f9c2afc1ea"
 binary linux-armv7l "https://nodejs.org/dist/v13.10.0/node-v13.10.0-linux-armv7l.tar.gz#75e17612b8b145248c8966affb5d594d8bb795b673c3339354c091e1bdba3b4b"

--- a/share/node-build/13.10.1
+++ b/share/node-build/13.10.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-binary aix-ppc64 "https://nodejs.org/dist/v13.10.1/node-v13.10.1-aix-ppc64.tar.gz#6e0a311b0e8ef5fb3ede6745dc19fd2d37b6120b66a0fd3bcb82178361d2bc6f"
 binary darwin-x64 "https://nodejs.org/dist/v13.10.1/node-v13.10.1-darwin-x64.tar.gz#a6a66fdc79e70267fc191f10ee045793240974e1268fdea6c2d28afbc1d635e8"
 binary linux-arm64 "https://nodejs.org/dist/v13.10.1/node-v13.10.1-linux-arm64.tar.gz#2106cf90ddbe47957b7782caed787cf4927656087d28ec7eb11f0d44c49234e9"
 binary linux-armv7l "https://nodejs.org/dist/v13.10.1/node-v13.10.1-linux-armv7l.tar.gz#cf02c306b2d789969e9cc9bd0990858ad3cfc96049a933b7dd66599ffe23cb8c"

--- a/share/node-build/13.11.0
+++ b/share/node-build/13.11.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-binary darwin-x64 "https://nodejs.org/dist/v13.11.0/node-v13.11.0-darwin-x64.tar.gz#2d87989fb1e0d425667c5ca9893cb3ecfb30cd3344d543870246d65f8d9b892f"
 binary linux-arm64 "https://nodejs.org/dist/v13.11.0/node-v13.11.0-linux-arm64.tar.gz#c20c89664b5f06559f0aa2f0ad334d6d8157599b01101719e455b2b500a13c1a"
 binary linux-armv7l "https://nodejs.org/dist/v13.11.0/node-v13.11.0-linux-armv7l.tar.gz#98c59faf01ddb868f3238c802ce420cd4d46f04b6181525e92fd4d728469a7cf"
 binary linux-ppc64le "https://nodejs.org/dist/v13.11.0/node-v13.11.0-linux-ppc64le.tar.gz#103f759336fa74505d949c4cd0307e958b1eaf0ef71c36f0c147e3718af74322"

--- a/share/node-build/13.12.0
+++ b/share/node-build/13.12.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-binary aix-ppc64 "https://nodejs.org/dist/v13.12.0/node-v13.12.0-aix-ppc64.tar.gz#fe07c84054befb425bb8e270337410ed0ce865f910d86e26f37c29d40554f709"
 binary darwin-x64 "https://nodejs.org/dist/v13.12.0/node-v13.12.0-darwin-x64.tar.gz#1fe3103610e8eb66ae71872ea1b4e868a638292a4e7ad0e41976a9fe417a09c7"
 binary linux-arm64 "https://nodejs.org/dist/v13.12.0/node-v13.12.0-linux-arm64.tar.gz#9c28226e84bd44f7309ffdd4deb022fb59479ef0386e82890cd19b02162940f3"
 binary linux-armv7l "https://nodejs.org/dist/v13.12.0/node-v13.12.0-linux-armv7l.tar.gz#bcbae35d05ba7e59aa68fbcd8f78cfcd6034be35da3e1283b527ae0fae802e67"

--- a/share/node-build/13.13.0
+++ b/share/node-build/13.13.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-binary aix-ppc64 "https://nodejs.org/dist/v13.13.0/node-v13.13.0-aix-ppc64.tar.gz#acaeb22af1eb81204d9b73a365bd2355b45625d36c341d9f4b2b3240b1998eac"
 binary darwin-x64 "https://nodejs.org/dist/v13.13.0/node-v13.13.0-darwin-x64.tar.gz#28ae2abedafb250a9bbe706650fd79d2b25273f6445adcc1d85c777359dc5390"
 binary linux-arm64 "https://nodejs.org/dist/v13.13.0/node-v13.13.0-linux-arm64.tar.gz#fd1a25910a77084ecd2f092f74a0bfb68526f219fbd07cec64beaf29c91619a1"
 binary linux-armv7l "https://nodejs.org/dist/v13.13.0/node-v13.13.0-linux-armv7l.tar.gz#0fed3e5f42b69898cca326c17e94eb8f4b279058e5d49b00aa9fa1716c96b865"

--- a/share/node-build/13.14.0
+++ b/share/node-build/13.14.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-binary aix-ppc64 "https://nodejs.org/dist/v13.14.0/node-v13.14.0-aix-ppc64.tar.gz#a1c87a6262d65853d03a84c2037d5989b664f8e06a1ad3d0c7e5a666a3efb18a"
 binary darwin-x64 "https://nodejs.org/dist/v13.14.0/node-v13.14.0-darwin-x64.tar.gz#a56eb353fecd45f731d74fc77c58dde052320c1bc272de9b03151fbaf962feaf"
 binary linux-arm64 "https://nodejs.org/dist/v13.14.0/node-v13.14.0-linux-arm64.tar.gz#4603cc724f3f0551407f1ea41b8fbae83492e80c02d16360cb9722500364f447"
 binary linux-armv7l "https://nodejs.org/dist/v13.14.0/node-v13.14.0-linux-armv7l.tar.gz#d676a6ca4725a70abceda0eb45adcb0c94bb6b0899d76e511d1712e35c88288a"

--- a/share/node-build/13.2.0
+++ b/share/node-build/13.2.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-binary aix-ppc64 "https://nodejs.org/dist/v13.2.0/node-v13.2.0-aix-ppc64.tar.gz#9b5751453a3192a92def580c730302c549486644d8b665dd6fb60e39056bdcae"
 binary darwin-x64 "https://nodejs.org/dist/v13.2.0/node-v13.2.0-darwin-x64.tar.gz#2bcba358ef68ea21655728126c678063c60119e18e65d04f615d6b22dba8f7a5"
 binary linux-arm64 "https://nodejs.org/dist/v13.2.0/node-v13.2.0-linux-arm64.tar.gz#b1634a1c9eb8735b25ad21bce3ab5a86d7471982fe2523eeeaf9d831f807864b"
 binary linux-armv7l "https://nodejs.org/dist/v13.2.0/node-v13.2.0-linux-armv7l.tar.gz#f3e918ac85d51d4e415c40b8c5c346a3b01c3154c78fa1ae0df67607eb82051c"

--- a/share/node-build/13.3.0
+++ b/share/node-build/13.3.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-binary aix-ppc64 "https://nodejs.org/dist/v13.3.0/node-v13.3.0-aix-ppc64.tar.gz#dd9e7f3fb9ef6bd5a27933f66c7dbf4d84aa5b001eab6315595924e5e44e4ae1"
 binary darwin-x64 "https://nodejs.org/dist/v13.3.0/node-v13.3.0-darwin-x64.tar.gz#187ea9028daa6d9abad9c1cbb4e12ba51427c3748da29eae616fa352c0f4cd49"
 binary linux-arm64 "https://nodejs.org/dist/v13.3.0/node-v13.3.0-linux-arm64.tar.gz#7df90bda5d21337c7793b481ee71fd89811c26cd0d6124665a79cd8bffb2f7ba"
 binary linux-armv7l "https://nodejs.org/dist/v13.3.0/node-v13.3.0-linux-armv7l.tar.gz#806cbdb68fe352f68d9b7a34a1d3ff7661a2359062b7a056c3cf28da3306f480"

--- a/share/node-build/13.4.0
+++ b/share/node-build/13.4.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-binary aix-ppc64 "https://nodejs.org/dist/v13.4.0/node-v13.4.0-aix-ppc64.tar.gz#149a3aa1c87ed82305f15fe0a0785aab61792e2b3a50e828efcc515b7c168173"
 binary darwin-x64 "https://nodejs.org/dist/v13.4.0/node-v13.4.0-darwin-x64.tar.gz#4de08a89054416595228d6ff40fcf20c375d00556f2e95dfde8602cbb42c0b6e"
 binary linux-arm64 "https://nodejs.org/dist/v13.4.0/node-v13.4.0-linux-arm64.tar.gz#bd0c4511126bafeadf46079c3bd3c9e143859a509d3d5e0ac119342391ff93ae"
 binary linux-armv7l "https://nodejs.org/dist/v13.4.0/node-v13.4.0-linux-armv7l.tar.gz#0aaaed14375f26484f09a351ea50342b8c22f4ce8772c4b0a3d6e002aa2b5932"

--- a/share/node-build/13.5.0
+++ b/share/node-build/13.5.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-binary aix-ppc64 "https://nodejs.org/dist/v13.5.0/node-v13.5.0-aix-ppc64.tar.gz#1d935f44f67a8c8bf68db3b38c23d38e7502ca9b3481338e7224283b6dd3b353"
 binary darwin-x64 "https://nodejs.org/dist/v13.5.0/node-v13.5.0-darwin-x64.tar.gz#3322c601dc032677e5b5f87f393d4b1d70073bcab24fe74378eff8eb49364001"
 binary linux-arm64 "https://nodejs.org/dist/v13.5.0/node-v13.5.0-linux-arm64.tar.gz#77713ce2b7f78ac96887d338e593eda27c739e95de7e896333198da8909edf40"
 binary linux-armv7l "https://nodejs.org/dist/v13.5.0/node-v13.5.0-linux-armv7l.tar.gz#c48d91ccb705633492f161195be7849fa2fc126e9a53b7db973af318316fb309"

--- a/share/node-build/13.6.0
+++ b/share/node-build/13.6.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-binary aix-ppc64 "https://nodejs.org/dist/v13.6.0/node-v13.6.0-aix-ppc64.tar.gz#2a23aa5541378896ae92b729c279e27f2153904189ec3f641e7c96b53681acc0"
 binary darwin-x64 "https://nodejs.org/dist/v13.6.0/node-v13.6.0-darwin-x64.tar.gz#da13adb864777b322dda7af20410a9b0c63aa69de4b5574008d1e6910768bf69"
 binary linux-arm64 "https://nodejs.org/dist/v13.6.0/node-v13.6.0-linux-arm64.tar.gz#65c648bdcb0efa5d2be4a660903a535a1ffb959079276152d076d89906242d87"
 binary linux-armv7l "https://nodejs.org/dist/v13.6.0/node-v13.6.0-linux-armv7l.tar.gz#ccc50bf8b6fa2a8a9b58048d30203da6c0d9d1931492d89e961f4329e689ac15"

--- a/share/node-build/13.7.0
+++ b/share/node-build/13.7.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-binary aix-ppc64 "https://nodejs.org/dist/v13.7.0/node-v13.7.0-aix-ppc64.tar.gz#50cf1dfcf1cfbc32def91e43f28ea5886135776c7dee5b3f7a4818487028f03b"
 binary darwin-x64 "https://nodejs.org/dist/v13.7.0/node-v13.7.0-darwin-x64.tar.gz#866ea9bdbd7b734c593af96b946397d9c7cb9c291aa8ea52a6a2af271b972169"
 binary linux-arm64 "https://nodejs.org/dist/v13.7.0/node-v13.7.0-linux-arm64.tar.gz#fb492b493e13ddad73533f5b06318b7f46120ff4289475e0e91445370be1b13c"
 binary linux-armv7l "https://nodejs.org/dist/v13.7.0/node-v13.7.0-linux-armv7l.tar.gz#dd31f9b0cc351b4f46e25670a0c41737fc7815b0069da15948ac38cb976a0987"

--- a/share/node-build/13.8.0
+++ b/share/node-build/13.8.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-binary aix-ppc64 "https://nodejs.org/dist/v13.8.0/node-v13.8.0-aix-ppc64.tar.gz#25a267d18f6d7d66528bbe9a9d54730a8a39b27e9d315114ca008a105a01e55c"
 binary darwin-x64 "https://nodejs.org/dist/v13.8.0/node-v13.8.0-darwin-x64.tar.gz#ae480e2b124cb55667763848b8ec0fde1bc35d5e0b76debe881034689a68eaea"
 binary linux-arm64 "https://nodejs.org/dist/v13.8.0/node-v13.8.0-linux-arm64.tar.gz#69a51fa98a9543f09f2a3838a04b49fd774005398de9732caf337e027145c988"
 binary linux-armv7l "https://nodejs.org/dist/v13.8.0/node-v13.8.0-linux-armv7l.tar.gz#228d79dfc07749d90cfa7938cffb7201d8e12ca7f92cba2f1766431b8d2acedf"

--- a/share/node-build/13.9.0
+++ b/share/node-build/13.9.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-binary aix-ppc64 "https://nodejs.org/dist/v13.9.0/node-v13.9.0-aix-ppc64.tar.gz#0330f9649df64a665d073226d27a7ea418e09bb3f3a59abfdbabcffe5efd6d10"
 binary darwin-x64 "https://nodejs.org/dist/v13.9.0/node-v13.9.0-darwin-x64.tar.gz#b2a5a539b9b2d1733bda301913c99d220968de801bf313b762fa932820ea797b"
 binary linux-arm64 "https://nodejs.org/dist/v13.9.0/node-v13.9.0-linux-arm64.tar.gz#8d253978fec837a6cd9d2ba9665bda14d62e7453d44123438971d0026df469dd"
 binary linux-armv7l "https://nodejs.org/dist/v13.9.0/node-v13.9.0-linux-armv7l.tar.gz#562f3704f81b09e476e0a05f752aa68e9c945728c0d07f4390d1200cf246e2c2"

--- a/share/node-build/13.x-dev
+++ b/share/node-build/13.x-dev
@@ -2,9 +2,3 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-install_git "13.x-dev" "https://github.com/nodejs/node.git" "v13.x-staging" standard

--- a/share/node-build/13.x-next
+++ b/share/node-build/13.x-next
@@ -2,9 +2,3 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-install_git "13.x-next" "https://github.com/nodejs/node.git" "v13.x" standard

--- a/share/node-build/14.0.0
+++ b/share/node-build/14.0.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.0.0/node-v14.0.0-aix-ppc64.tar.gz#9d6b1bf5df82fac15ca1df96155092d7463c300b82cae4c25e5e8a13227b7993"
 binary darwin-x64 "https://nodejs.org/dist/v14.0.0/node-v14.0.0-darwin-x64.tar.gz#4e50cec7aeef91c6d00d08a3bab938358da182984aa549c2aeab9868e3342f55"
 binary linux-arm64 "https://nodejs.org/dist/v14.0.0/node-v14.0.0-linux-arm64.tar.gz#4da6fd45e7a26037c82f931f173695547f774b780986d545efc266a5a9b80906"

--- a/share/node-build/14.1.0
+++ b/share/node-build/14.1.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.1.0/node-v14.1.0-aix-ppc64.tar.gz#359a6b81c5ad5918850612faa08c8e2bc9b8d3fe703b915bdd5e7c1df6e0d740"
 binary darwin-x64 "https://nodejs.org/dist/v14.1.0/node-v14.1.0-darwin-x64.tar.gz#7f08bd365df4e7a5625ad393257f48e8cd79f77391ab87a64426b0c6448dd226"
 binary linux-arm64 "https://nodejs.org/dist/v14.1.0/node-v14.1.0-linux-arm64.tar.gz#5f6462c004460673618033efe319c060a9c53b55715cb9aefb7fc5f733aa9d5c"

--- a/share/node-build/14.10.0
+++ b/share/node-build/14.10.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.10.0/node-v14.10.0-aix-ppc64.tar.gz#95947c76445850e23d47a50b2934f03736d88fc7b82d4c99d038500c0e29d8e5"
 binary darwin-x64 "https://nodejs.org/dist/v14.10.0/node-v14.10.0-darwin-x64.tar.gz#8cf72422fb268ecf3bb72c66a61ccf2afb7b8ff358d09b3568d762ea281c86ed"
 binary linux-arm64 "https://nodejs.org/dist/v14.10.0/node-v14.10.0-linux-arm64.tar.gz#842811feed3177bef73b16b24e2b2d2b27f6223ea65da6a397d86b670fd35766"

--- a/share/node-build/14.10.1
+++ b/share/node-build/14.10.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.10.1/node-v14.10.1-aix-ppc64.tar.gz#c2c7ba0d9fd55c1ce89def6775ec1792367ae73645535829a6482f6015c24fef"
 binary darwin-x64 "https://nodejs.org/dist/v14.10.1/node-v14.10.1-darwin-x64.tar.gz#b21ef53d4dc10d7722eca53b4a4b344edbee1917ac21853a7a72345ab36975d0"
 binary linux-arm64 "https://nodejs.org/dist/v14.10.1/node-v14.10.1-linux-arm64.tar.gz#a4d6562d9b4efe577b31381a78595e0417badc0ec44268a159d2bfdae4d8e529"

--- a/share/node-build/14.11.0
+++ b/share/node-build/14.11.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.11.0/node-v14.11.0-aix-ppc64.tar.gz#cb97474a5165b89b2789a8b464727d6756596455648c8dda89f95dfe7c5ef3c0"
 binary darwin-x64 "https://nodejs.org/dist/v14.11.0/node-v14.11.0-darwin-x64.tar.gz#4fcc716046ced78ba786d03f30976182a86bf3927610f0c87c1827d93e7f427c"
 binary linux-arm64 "https://nodejs.org/dist/v14.11.0/node-v14.11.0-linux-arm64.tar.gz#52b67943f63c03a15122ecfb94e7f197be06c6c8992bdd5d77c79960411a31fd"

--- a/share/node-build/14.12.0
+++ b/share/node-build/14.12.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.12.0/node-v14.12.0-aix-ppc64.tar.gz#2f9f3bed29027b30b331c673425edbd7b40be2bf623c4e08acb491a366858062"
 binary darwin-x64 "https://nodejs.org/dist/v14.12.0/node-v14.12.0-darwin-x64.tar.gz#c91a4ea40289886799115a8a309b844975d59d457cbad2060779286f0a8ad01b"
 binary linux-arm64 "https://nodejs.org/dist/v14.12.0/node-v14.12.0-linux-arm64.tar.gz#bd4feec12f8a4847a9f863f8819a74c30cddcd532a358a81b5bff0fb9e453275"

--- a/share/node-build/14.13.0
+++ b/share/node-build/14.13.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.13.0/node-v14.13.0-aix-ppc64.tar.gz#73f7fb1b63c7ffa2ebfddceca64a0bde23cee735398db31eb9006a9272cdfa0e"
 binary darwin-x64 "https://nodejs.org/dist/v14.13.0/node-v14.13.0-darwin-x64.tar.gz#e9fd3fcc5adf3266881a36f72238e65041e2d318509edcbd7e6b2f902b7a7514"
 binary linux-arm64 "https://nodejs.org/dist/v14.13.0/node-v14.13.0-linux-arm64.tar.gz#a9a98ef518c9e75d0a33d8f344f76b037b54e4ad8f8051fbf1506dbfccfb3f25"

--- a/share/node-build/14.13.1
+++ b/share/node-build/14.13.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.13.1/node-v14.13.1-aix-ppc64.tar.gz#1a73710f119692effb1d05307fba02f1834895460935b735af4eb6e2693f987a"
 binary darwin-x64 "https://nodejs.org/dist/v14.13.1/node-v14.13.1-darwin-x64.tar.gz#d7b42f35470e07d27f3c5d9a58ac75de60a2baeb38cdf46831880204fa8b479d"
 binary linux-arm64 "https://nodejs.org/dist/v14.13.1/node-v14.13.1-linux-arm64.tar.gz#5ee6da3c86591763644f40babd2bef5a2476e98ddd6f7f1c5121fc2c81d1d613"

--- a/share/node-build/14.14.0
+++ b/share/node-build/14.14.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.14.0/node-v14.14.0-aix-ppc64.tar.gz#38e9aba76b3c7a75be19f0c44bec9fca6c8c9d3515574fbd209197a82abdb07e"
 binary darwin-x64 "https://nodejs.org/dist/v14.14.0/node-v14.14.0-darwin-x64.tar.gz#c492c905a240eafa5448d6ef8988371afbd76ffa38b7e3deab41bdeed4a580fe"
 binary linux-arm64 "https://nodejs.org/dist/v14.14.0/node-v14.14.0-linux-arm64.tar.gz#de15496b7a311b5819470cc6df5397095b4e154a3479c6ed41075f0de96ec8a1"

--- a/share/node-build/14.15.0
+++ b/share/node-build/14.15.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.15.0/node-v14.15.0-aix-ppc64.tar.gz#7e82b8faf651c80204cd7272e7cd627b6094de04624a6967d555b02150b6bb26"
 binary darwin-x64 "https://nodejs.org/dist/v14.15.0/node-v14.15.0-darwin-x64.tar.gz#1389f50d2f9f4993736d0408300513434d7630c2853634fb13f2b69cc9e69cb9"
 binary linux-arm64 "https://nodejs.org/dist/v14.15.0/node-v14.15.0-linux-arm64.tar.gz#bfb59eb99ab60a673f389e8b172ab288e12c8540e0c76a0ae40d189ba5a36cec"

--- a/share/node-build/14.15.1
+++ b/share/node-build/14.15.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.15.1/node-v14.15.1-aix-ppc64.tar.gz#696acf72b098d65f191db70f6a24ded7b914c4fe340a0a542b14dc57e69fd65b"
 binary darwin-x64 "https://nodejs.org/dist/v14.15.1/node-v14.15.1-darwin-x64.tar.gz#9154d9c3f598d3efe6d163d160a7872ddefffc439be521094ccd528b63480611"
 binary linux-arm64 "https://nodejs.org/dist/v14.15.1/node-v14.15.1-linux-arm64.tar.gz#5ac1aafdb1e6a3c9ae5045b5fb33ae100688cb0dd3259de5b7db25bd7d7edc55"

--- a/share/node-build/14.15.2
+++ b/share/node-build/14.15.2
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.15.2/node-v14.15.2-aix-ppc64.tar.gz#ced5810b721cf1ffd97b3214e6e1749981928d7d787785ab6e93656c7eecef57"
 binary darwin-x64 "https://nodejs.org/dist/v14.15.2/node-v14.15.2-darwin-x64.tar.gz#b3e48891b6290cec6d97f3711cd6298aebfb88642b239c90a4018752be5088ba"
 binary linux-arm64 "https://nodejs.org/dist/v14.15.2/node-v14.15.2-linux-arm64.tar.gz#77277dc58534fa86f56591d952e914e04156ff00e95f31b4a2a34205f7222fa8"

--- a/share/node-build/14.15.3
+++ b/share/node-build/14.15.3
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.15.3/node-v14.15.3-aix-ppc64.tar.gz#98c04e6d867ddd65f59c3079dfc155ed8834a499b55d9fdc50caacd95b5f619f"
 binary darwin-x64 "https://nodejs.org/dist/v14.15.3/node-v14.15.3-darwin-x64.tar.gz#0dfaa48a76b6f4164bdf6fac64b7c88d542d53f04ce0a9bba2bbb565e31fbb2d"
 binary linux-arm64 "https://nodejs.org/dist/v14.15.3/node-v14.15.3-linux-arm64.tar.gz#4e874aa41448bd3b38f5c7d82e94d3fe77e57382f414bda60d597abfd3b6704b"

--- a/share/node-build/14.15.4
+++ b/share/node-build/14.15.4
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.15.4/node-v14.15.4-aix-ppc64.tar.gz#03ac3f7d33f17b762d676988b725c58140b5f9a131c849f9b78cbe7f7f84c234"
 binary darwin-x64 "https://nodejs.org/dist/v14.15.4/node-v14.15.4-darwin-x64.tar.gz#6b0e19e5c2601ef97510f7eb4f52cc8ee261ba14cb05f31eb1a41a5043b0304e"
 binary linux-arm64 "https://nodejs.org/dist/v14.15.4/node-v14.15.4-linux-arm64.tar.gz#b681bda8eaa1ed2ac85e0ed2c2041a0408963c2198a24da183dc3ab60d93d975"

--- a/share/node-build/14.15.5
+++ b/share/node-build/14.15.5
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.15.5/node-v14.15.5-aix-ppc64.tar.gz#cc7dc8f702ab9fe143e4d9cfce33331f630b5ce5df9b76e4353b91fe7d5075ee"
 binary darwin-x64 "https://nodejs.org/dist/v14.15.5/node-v14.15.5-darwin-x64.tar.gz#78e2a63c54f0d3e22f0b3d29a832d0379406a619f1107d6e74679a1e76a132b0"
 binary linux-arm64 "https://nodejs.org/dist/v14.15.5/node-v14.15.5-linux-arm64.tar.gz#a1fb6f28041198971fd95e58638c30565de4ee74bd13db7f30ffd1d1c6820599"

--- a/share/node-build/14.16.0
+++ b/share/node-build/14.16.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.16.0/node-v14.16.0-aix-ppc64.tar.gz#086c8b4aa726c3b197765c9f66e05b25f8e811853d0686dfbf380299b4bf5869"
 binary darwin-x64 "https://nodejs.org/dist/v14.16.0/node-v14.16.0-darwin-x64.tar.gz#14ec767e376d1e2e668f997065926c5c0086ec46516d1d45918af8ae05bd4583"
 binary linux-arm64 "https://nodejs.org/dist/v14.16.0/node-v14.16.0-linux-arm64.tar.gz#2b78771550f8a3e6e990d8e60e9ade82c7a9e2738b6222e92198bcd5ea857ea6"

--- a/share/node-build/14.16.1
+++ b/share/node-build/14.16.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.16.1/node-v14.16.1-aix-ppc64.tar.gz#79d7201c1cc0765248f6b96d6377aa1f02c27c12814275a93cb3eaa2a25eec2c"
 binary darwin-x64 "https://nodejs.org/dist/v14.16.1/node-v14.16.1-darwin-x64.tar.gz#b762b72fc149629b7e394ea9b75a093cad709a9f2f71480942945d8da0fc1218"
 binary linux-arm64 "https://nodejs.org/dist/v14.16.1/node-v14.16.1-linux-arm64.tar.gz#58cb307666ed4aa751757577a563b8a1e5d4ee73a9fac2b495e5c463682a07d1"

--- a/share/node-build/14.17.0
+++ b/share/node-build/14.17.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.17.0/node-v14.17.0-aix-ppc64.tar.gz#fb33407ea6518e5a839875d33a10948c01e36bbdba968831c861a2f5c1d5c3c2"
 binary darwin-x64 "https://nodejs.org/dist/v14.17.0/node-v14.17.0-darwin-x64.tar.gz#7b210652e11d1ee25650c164cf32381895e1dcb3e0ff1d0841d8abc1f47ac73e"
 binary linux-arm64 "https://nodejs.org/dist/v14.17.0/node-v14.17.0-linux-arm64.tar.gz#9d5948d4397815ce7a746618338f79ce5e7e91efec9c165140ba62fd6c17c07a"

--- a/share/node-build/14.17.1
+++ b/share/node-build/14.17.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.17.1/node-v14.17.1-aix-ppc64.tar.gz#b2aaa7d5cffd4ea950aa65e92ffa88781e74b0dd29028963c2b74a58bd72ff04"
 binary darwin-x64 "https://nodejs.org/dist/v14.17.1/node-v14.17.1-darwin-x64.tar.gz#864d09627c8dc9038e0235fccf2110b60c8942713c15352de2d203278798ff0d"
 binary linux-arm64 "https://nodejs.org/dist/v14.17.1/node-v14.17.1-linux-arm64.tar.gz#04e25f5511408288913dd1955f6829431e5096911aa3e35c9cd0ca8b39e6c4c5"

--- a/share/node-build/14.17.2
+++ b/share/node-build/14.17.2
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.17.2/node-v14.17.2-aix-ppc64.tar.gz#fb4348515d67085153c58d7b5114ca71690e3938d6c6000a02a7977cf154290a"
 binary darwin-x64 "https://nodejs.org/dist/v14.17.2/node-v14.17.2-darwin-x64.tar.gz#e45db91fc2136202868a5eb7c6d08b0a2b75394fafdf8538f650fa945b7dee16"
 binary linux-arm64 "https://nodejs.org/dist/v14.17.2/node-v14.17.2-linux-arm64.tar.gz#05117e74f424fd4ab744c3013c77906c5fe4a19fa22ce624a21986ce152fd258"

--- a/share/node-build/14.17.3
+++ b/share/node-build/14.17.3
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.17.3/node-v14.17.3-aix-ppc64.tar.gz#20e2ce162be33e76a256f48f2c33a2a6458e26c9052d58ff63e8458e05f7f08f"
 binary darwin-x64 "https://nodejs.org/dist/v14.17.3/node-v14.17.3-darwin-x64.tar.gz#522f85db1d1fe798cba5f601d1bba7b5203ca8797b2bc934ff6f24263f0b7fb2"
 binary linux-arm64 "https://nodejs.org/dist/v14.17.3/node-v14.17.3-linux-arm64.tar.gz#784ede0c9faa4a71d77659918052cca39981138edde2c799ffdf2b4695c08544"

--- a/share/node-build/14.17.4
+++ b/share/node-build/14.17.4
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.17.4/node-v14.17.4-aix-ppc64.tar.gz#58e4ca29b0585ebeb1dbf5a701d9959dda219b5bdf6d8363213f51a779d395da"
 binary darwin-x64 "https://nodejs.org/dist/v14.17.4/node-v14.17.4-darwin-x64.tar.gz#5c055a295e030cb789e2925b4c0647f7aaf461ffe5f2a08145c0605fb83ad4e0"
 binary linux-arm64 "https://nodejs.org/dist/v14.17.4/node-v14.17.4-linux-arm64.tar.gz#88b130c8f08a2baafb4e4c953ad46ba69cc60210da7d95c558c7ae3456beb825"

--- a/share/node-build/14.17.5
+++ b/share/node-build/14.17.5
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.17.5/node-v14.17.5-aix-ppc64.tar.gz#9085e04afb5ac85f70d9ac1080a486022ad14a2e36c0f668cb8a8c23e7f413cf"
 binary darwin-x64 "https://nodejs.org/dist/v14.17.5/node-v14.17.5-darwin-x64.tar.gz#2e40ab625b45b9bdfcb963ddd4d65d87ddf1dd37a86b6f8b075cf3d77fe9dc09"
 binary linux-arm64 "https://nodejs.org/dist/v14.17.5/node-v14.17.5-linux-arm64.tar.gz#bee6d7fb5dbdd2931e688b33defd449afdfd9cd6e716975864406cda18daca66"

--- a/share/node-build/14.17.6
+++ b/share/node-build/14.17.6
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.17.6/node-v14.17.6-aix-ppc64.tar.gz#8a809d7c75f9e695396b53aa95bcf8ec49b9ec5a993e82c02c2e067f48b89e81"
 binary darwin-x64 "https://nodejs.org/dist/v14.17.6/node-v14.17.6-darwin-x64.tar.gz#e3e4c02240d74fb1dc8a514daa62e5de04f7eaee0bcbca06a366ece73a52ad88"
 binary linux-arm64 "https://nodejs.org/dist/v14.17.6/node-v14.17.6-linux-arm64.tar.gz#3355eae15582be48f6be0910e279abbf2324f4538d3ccb2da7e66edab6e6b0fe"

--- a/share/node-build/14.18.0
+++ b/share/node-build/14.18.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.18.0/node-v14.18.0-aix-ppc64.tar.gz#887bdbc61250431cf2fe062f55124833c02a9386fdd234d11aa868049ac1858e"
 binary darwin-x64 "https://nodejs.org/dist/v14.18.0/node-v14.18.0-darwin-x64.tar.gz#6b9b4d60bcb4eba95488380be8c4da4af98fce3f4a01c9a76db881cbb736656d"
 binary linux-arm64 "https://nodejs.org/dist/v14.18.0/node-v14.18.0-linux-arm64.tar.gz#6261a87bf25d08e7b39017a1486b04c65be3ea0ea8442c090e1e4ec4d4cc6ebd"

--- a/share/node-build/14.18.1
+++ b/share/node-build/14.18.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.18.1/node-v14.18.1-aix-ppc64.tar.gz#01092d92ec076778b9291983fa6854befd19a11655f261a3b3ec1c675154ecfb"
 binary darwin-x64 "https://nodejs.org/dist/v14.18.1/node-v14.18.1-darwin-x64.tar.gz#78731152378577decf681167f4c6be6c31134dfef07403c1cebfbd3289d3886f"
 binary linux-arm64 "https://nodejs.org/dist/v14.18.1/node-v14.18.1-linux-arm64.tar.gz#3fcd1c6c008c2dfddea60ede3c735696982fb038288e45c2d35ef6b2098c8220"

--- a/share/node-build/14.18.2
+++ b/share/node-build/14.18.2
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.18.2/node-v14.18.2-aix-ppc64.tar.gz#841b47d77ea253929e00da489686340edec60bc27e898bd3cf69ec7f4ff9b37b"
 binary darwin-x64 "https://nodejs.org/dist/v14.18.2/node-v14.18.2-darwin-x64.tar.gz#fe6159a973e044e4dfd47a5de86fd34e837279bd424e61af69106c12986a8737"
 binary linux-arm64 "https://nodejs.org/dist/v14.18.2/node-v14.18.2-linux-arm64.tar.gz#e78e18e01a08b2459d738fc5fec6bd79f2b3dccf85e5122cd646b3385964bc1e"

--- a/share/node-build/14.18.3
+++ b/share/node-build/14.18.3
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.18.3/node-v14.18.3-aix-ppc64.tar.gz#4c5ff6f0ee670e6175d4b0b19da4d238b7ccb0bc551e61b296f38da5ef3fee7c"
 binary darwin-x64 "https://nodejs.org/dist/v14.18.3/node-v14.18.3-darwin-x64.tar.gz#623579faa9faf1148e42c84e36c7b701ddded220d1795d94d93ed7561b699407"
 binary linux-arm64 "https://nodejs.org/dist/v14.18.3/node-v14.18.3-linux-arm64.tar.gz#2d071ca1bc1d0ea1eb259e79b81ebb4387237b2f77b3cf616806534e0030eaa8"

--- a/share/node-build/14.19.0
+++ b/share/node-build/14.19.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.19.0/node-v14.19.0-aix-ppc64.tar.gz#bad96e53e403a8bbc3c5b92bf451327f90ddaf37923ef3a91f3f7e267ff68930"
 binary darwin-x64 "https://nodejs.org/dist/v14.19.0/node-v14.19.0-darwin-x64.tar.gz#e4ece4481b948c95f28662e74fc738ad03e07e877d9c9a47e59b4eb099aa1449"
 binary linux-arm64 "https://nodejs.org/dist/v14.19.0/node-v14.19.0-linux-arm64.tar.gz#89c03d1c156c0161c891924d4a309df3308bbf245641413d72affae9b62e97e0"

--- a/share/node-build/14.19.1
+++ b/share/node-build/14.19.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.19.1/node-v14.19.1-aix-ppc64.tar.gz#5b50af3390996a9212ac44d363696fc4b416b8fd882cea9e63201411fa800a92"
 binary darwin-x64 "https://nodejs.org/dist/v14.19.1/node-v14.19.1-darwin-x64.tar.gz#b3159080641c7cf0b9b3826190623c41c28cca26fd137e0c275c3de4b767422a"
 binary linux-arm64 "https://nodejs.org/dist/v14.19.1/node-v14.19.1-linux-arm64.tar.gz#b365659aa9f31c984668ac60b70fcfae90ffabb3dd51b031898b050e403c1794"

--- a/share/node-build/14.19.2
+++ b/share/node-build/14.19.2
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.19.2/node-v14.19.2-aix-ppc64.tar.gz#519f8a87e6181682c4953554262713d9f2632eedb3b149ee2b5189622f6a7139"
 binary darwin-x64 "https://nodejs.org/dist/v14.19.2/node-v14.19.2-darwin-x64.tar.gz#1e80fca29e6876c0312bec825d99a90a562b5501c4d25bf081665b6433c30abf"
 binary linux-arm64 "https://nodejs.org/dist/v14.19.2/node-v14.19.2-linux-arm64.tar.gz#b972847ccd8a699b72f8ac455d4233fa584972e2ebd3dd99768ff5c95334304d"

--- a/share/node-build/14.19.3
+++ b/share/node-build/14.19.3
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.19.3/node-v14.19.3-aix-ppc64.tar.gz#0d6b529f581b4a67f3799888a9f7d95271132f473269b412d6ca89641810ffae"
 binary darwin-x64 "https://nodejs.org/dist/v14.19.3/node-v14.19.3-darwin-x64.tar.gz#6c48c3fff76803376da007dc35e650f2f8777ce3d56ce828c98f9f767b426209"
 binary linux-arm64 "https://nodejs.org/dist/v14.19.3/node-v14.19.3-linux-arm64.tar.gz#a1c837c7ec8a5ab0c4d5028695b05749adf216851fe0b84ef09a9c6eab86ba5d"

--- a/share/node-build/14.2.0
+++ b/share/node-build/14.2.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.2.0/node-v14.2.0-aix-ppc64.tar.gz#9b4461a1af6d6fc012db5c580ece88bb72aaf33307974fe7736e83ec4bca1788"
 binary darwin-x64 "https://nodejs.org/dist/v14.2.0/node-v14.2.0-darwin-x64.tar.gz#2447241aefe71dea8ba1552549e4df2e894d1ac12203630db3af63d4ae35c016"
 binary linux-arm64 "https://nodejs.org/dist/v14.2.0/node-v14.2.0-linux-arm64.tar.gz#2fd9bf7b3fc8a0e72ec27f1d274b8eedd1c81e8af3f82739c787ddc288037a4c"

--- a/share/node-build/14.20.0
+++ b/share/node-build/14.20.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.20.0/node-v14.20.0-aix-ppc64.tar.gz#ce1d48f43d7a0f1709e8ec1776ea67de10104038c4784ebd399fd4971b7cc53c"
 binary darwin-x64 "https://nodejs.org/dist/v14.20.0/node-v14.20.0-darwin-x64.tar.gz#4471111f666f1d1ec549b002e0d416a7222c0fd416aa62c90b19ff3930b07dba"
 binary linux-arm64 "https://nodejs.org/dist/v14.20.0/node-v14.20.0-linux-arm64.tar.gz#d2d15363a2f3a0446983d51a90af7942fe8b1dd4a7f16128dfe718b3bf56dc07"

--- a/share/node-build/14.20.1
+++ b/share/node-build/14.20.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.20.1/node-v14.20.1-aix-ppc64.tar.gz#1140709298833d74fad652fd4f7e3e76eff0ce496756df2acf7b9872c9d0b7e7"
 binary darwin-x64 "https://nodejs.org/dist/v14.20.1/node-v14.20.1-darwin-x64.tar.gz#7fe00e1e5949c9b99d0b888b9d32b8b2f35a117cd3a94a16c0a2524cb71e3c59"
 binary linux-arm64 "https://nodejs.org/dist/v14.20.1/node-v14.20.1-linux-arm64.tar.gz#05fe791367dbce8d76be7e18bac0c9b88a0ed6ab721c31321b96a2dbc31355ce"

--- a/share/node-build/14.21.0
+++ b/share/node-build/14.21.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.21.0/node-v14.21.0-aix-ppc64.tar.gz#eb26168c8e6e251871581a812bd556ed8759189c262af2c6b44331daaab5b1bd"
 binary darwin-x64 "https://nodejs.org/dist/v14.21.0/node-v14.21.0-darwin-x64.tar.gz#027d7e5999ed890d658e87f96a5edb7d9a8f26ee67e732f632a7adb850c43b70"
 binary linux-arm64 "https://nodejs.org/dist/v14.21.0/node-v14.21.0-linux-arm64.tar.gz#a06df30ae4393296872f2a80e73f2eea0634c3490edccb2d80bdee5f1449e96f"

--- a/share/node-build/14.21.1
+++ b/share/node-build/14.21.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.21.1/node-v14.21.1-aix-ppc64.tar.gz#d2c027a4eec38ab0d8a30256832270690c57794173d3f7dc8dd2016b3218e59d"
 binary darwin-x64 "https://nodejs.org/dist/v14.21.1/node-v14.21.1-darwin-x64.tar.gz#8eec964057d0d413f55deb42e00fca0d555de530e42d9d5cbb4ff62914dc79a8"
 binary linux-arm64 "https://nodejs.org/dist/v14.21.1/node-v14.21.1-linux-arm64.tar.gz#f3e6fb4a833c084863e7dfa3a50ac29f53b421ad070748ff9c9a81291284faf8"

--- a/share/node-build/14.21.2
+++ b/share/node-build/14.21.2
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.21.2/node-v14.21.2-aix-ppc64.tar.gz#bbcd546fd41dadb4d0278c7b522282c97c406388628245dcca1a667bb69ca05d"
 binary darwin-x64 "https://nodejs.org/dist/v14.21.2/node-v14.21.2-darwin-x64.tar.gz#4a3e7b12cc24b97331c8424ac9b508c61cc97ed327dafda5f3d785e8230cd7e0"
 binary linux-arm64 "https://nodejs.org/dist/v14.21.2/node-v14.21.2-linux-arm64.tar.gz#bb7ac11ee8ff3a06773028d53443769c4b0c0f0e85ece68921645882b181cf80"

--- a/share/node-build/14.21.3
+++ b/share/node-build/14.21.3
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.21.3/node-v14.21.3-aix-ppc64.tar.gz#41b1e54022e2ed4340ae76ef3cdbb06c6693faaadd869b21c5a04664a34aa12e"
 binary darwin-x64 "https://nodejs.org/dist/v14.21.3/node-v14.21.3-darwin-x64.tar.gz#a024f0dd5a4c1f951b79959c3e991b30a5919a734ab3e197ae0ef439e5a538b5"
 binary linux-arm64 "https://nodejs.org/dist/v14.21.3/node-v14.21.3-linux-arm64.tar.gz#044b7ec3fea04cd3815d26901ee37203dcc942688b72ee6eac96f6a1ca3cc63f"

--- a/share/node-build/14.3.0
+++ b/share/node-build/14.3.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.3.0/node-v14.3.0-aix-ppc64.tar.gz#b9c9b96ecfbf47403b25a7e5779b290e7434ee3e93f8f1a15faa6c7f9a84f953"
 binary darwin-x64 "https://nodejs.org/dist/v14.3.0/node-v14.3.0-darwin-x64.tar.gz#fd6a44303646f28b7e7577de687c2681cb565bef534e84deef44202e7919d7f3"
 binary linux-arm64 "https://nodejs.org/dist/v14.3.0/node-v14.3.0-linux-arm64.tar.gz#b6541c22d25880cf0ec03a41838d763e50a7632761b9e7c49bd1809944eba3dd"

--- a/share/node-build/14.4.0
+++ b/share/node-build/14.4.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.4.0/node-v14.4.0-aix-ppc64.tar.gz#5acdf3a6cf15342b07c9ef5e2292b949178dd69462bd07ea7b5f2d28cfa74296"
 binary darwin-x64 "https://nodejs.org/dist/v14.4.0/node-v14.4.0-darwin-x64.tar.gz#d95eaa6950d67895b5cdd0e2f913d2c44034178234f0cb7436c3397b54f64023"
 binary linux-arm64 "https://nodejs.org/dist/v14.4.0/node-v14.4.0-linux-arm64.tar.gz#5c7d88985ea82ca8ed3453b5bdf36391cf6f8fe63aabfb7661a6040c43769f89"

--- a/share/node-build/14.5.0
+++ b/share/node-build/14.5.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.5.0/node-v14.5.0-aix-ppc64.tar.gz#ee3252a5721ab141b62450d865403ca0c027a8ad036fa86dd4a732157645e692"
 binary darwin-x64 "https://nodejs.org/dist/v14.5.0/node-v14.5.0-darwin-x64.tar.gz#47dfd88abcd4d6d6f7b7516c95645f9760ba9c93d04b51a92895584c945b2953"
 binary linux-arm64 "https://nodejs.org/dist/v14.5.0/node-v14.5.0-linux-arm64.tar.gz#1429266d4f22148dfd6060fb5964c167852ae9b8f4efab47ff6a7656ed94fee5"

--- a/share/node-build/14.6.0
+++ b/share/node-build/14.6.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.6.0/node-v14.6.0-aix-ppc64.tar.gz#5a42400906c4e748930a90ee1137639876839394b5ebab4dbea96eac2fa32be7"
 binary darwin-x64 "https://nodejs.org/dist/v14.6.0/node-v14.6.0-darwin-x64.tar.gz#7907a18605b900ce977ff4c7e67f7507f937f85738659865d31779c3b2990756"
 binary linux-arm64 "https://nodejs.org/dist/v14.6.0/node-v14.6.0-linux-arm64.tar.gz#eb4f98efe22057a831415c2367416330878f0e1ad9a9bb5c25a6631031588075"

--- a/share/node-build/14.7.0
+++ b/share/node-build/14.7.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.7.0/node-v14.7.0-aix-ppc64.tar.gz#c9dc58ddc4eac5db92d7803359d2dc4a90428cc5bab1c91b96c1e2f5717b8caf"
 binary darwin-x64 "https://nodejs.org/dist/v14.7.0/node-v14.7.0-darwin-x64.tar.gz#47c94ec84706fd6851db27af54abdab569941fcbfcdc28e386d8fa7d49c6a619"
 binary linux-arm64 "https://nodejs.org/dist/v14.7.0/node-v14.7.0-linux-arm64.tar.gz#64bb4171ad823fafef3d36eea416e8a5ebefa60ce7043eb52a3ece1060b1a115"

--- a/share/node-build/14.8.0
+++ b/share/node-build/14.8.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.8.0/node-v14.8.0-aix-ppc64.tar.gz#104da9a7138aad8d825a4ced0197529956d5bac11f0c6f443a49360d7cf5556f"
 binary darwin-x64 "https://nodejs.org/dist/v14.8.0/node-v14.8.0-darwin-x64.tar.gz#b6db32f2ff37475ae68502c76fc777a604cbc589bf57158fb4eed4db9ac5f62d"
 binary linux-arm64 "https://nodejs.org/dist/v14.8.0/node-v14.8.0-linux-arm64.tar.gz#ab2e44354f7032a9b3f2e02d078596afb6d9822df8a1e672634d66126d17df7a"

--- a/share/node-build/14.9.0
+++ b/share/node-build/14.9.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v14.9.0/node-v14.9.0-aix-ppc64.tar.gz#d17443e0fa87e1edf441eb134bec95254e2f329c079a29fa8989efa4b3632452"
 binary darwin-x64 "https://nodejs.org/dist/v14.9.0/node-v14.9.0-darwin-x64.tar.gz#8427e07e3ca70d6ccf5274dde535c9a42b7f873f5a086323eaf2406cdb324daf"
 binary linux-arm64 "https://nodejs.org/dist/v14.9.0/node-v14.9.0-linux-arm64.tar.gz#6619a69ffe95c602105484bdecbdccb319e1c0db861203bffb9b6aedfae2c2df"

--- a/share/node-build/14.x-dev
+++ b/share/node-build/14.x-dev
@@ -2,10 +2,4 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 install_git "14.x-dev" "https://github.com/nodejs/node.git" "v14.x-staging" standard

--- a/share/node-build/14.x-next
+++ b/share/node-build/14.x-next
@@ -2,10 +2,4 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 install_git "14.x-next" "https://github.com/nodejs/node.git" "v14.x" standard

--- a/share/node-build/15.0.0
+++ b/share/node-build/15.0.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v15.0.0/node-v15.0.0-aix-ppc64.tar.gz#3d56e708ba3283a4c087c6265936e37c728568aa3636d3487553a728e96750d9"
 binary darwin-x64 "https://nodejs.org/dist/v15.0.0/node-v15.0.0-darwin-x64.tar.gz#f9eee1f659d96991bc629ec1cec986f504242fc0f046f4487d2fe13b9ab37c99"
 binary linux-arm64 "https://nodejs.org/dist/v15.0.0/node-v15.0.0-linux-arm64.tar.gz#2127a2627e3efe839c09d61f99cd99a58a9037dbb668abd21c279c25697522eb"

--- a/share/node-build/15.0.1
+++ b/share/node-build/15.0.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v15.0.1/node-v15.0.1-aix-ppc64.tar.gz#f070380cab039487ae0d16db122c4f6eaf0a165ccbf03685214e3ec5a7e98644"
 binary darwin-x64 "https://nodejs.org/dist/v15.0.1/node-v15.0.1-darwin-x64.tar.gz#8f7e2ddd44d2aef20d568489f2cf844383037725ce2fc04ad722a312ef08b2d0"
 binary linux-arm64 "https://nodejs.org/dist/v15.0.1/node-v15.0.1-linux-arm64.tar.gz#138ea304781fb8f7c830f5800bea61631164b304df99f5a008cc0eeaadbe6548"

--- a/share/node-build/15.1.0
+++ b/share/node-build/15.1.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v15.1.0/node-v15.1.0-aix-ppc64.tar.gz#39b7152a34b5d391355c86b4081639b09795853e3fb1b91b3e86ec3eb78a8d07"
 binary darwin-x64 "https://nodejs.org/dist/v15.1.0/node-v15.1.0-darwin-x64.tar.gz#af4d2208a577501464cf39bff4de4d756b2e15b62ba83ab424ac0b5aa3e45c24"
 binary linux-arm64 "https://nodejs.org/dist/v15.1.0/node-v15.1.0-linux-arm64.tar.gz#292a5ed3db3ae2acc7cc88bf965c8fca3c39068e867f473f1e2c355549d653b3"

--- a/share/node-build/15.10.0
+++ b/share/node-build/15.10.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v15.10.0/node-v15.10.0-aix-ppc64.tar.gz#351ef617dea3ec93819ebb92435b82febaa1de393bdb442dcc129ac76a03014c"
 binary darwin-x64 "https://nodejs.org/dist/v15.10.0/node-v15.10.0-darwin-x64.tar.gz#45ccf8dc5ac539a4f965313593510970a992e5f5dcf8cfacaebec0f99fd546be"
 binary linux-arm64 "https://nodejs.org/dist/v15.10.0/node-v15.10.0-linux-arm64.tar.gz#a9f8c807ec31ed24fe6e0b2d002ce2d1b9f20b7e23a0efe10679331a44b30dba"

--- a/share/node-build/15.11.0
+++ b/share/node-build/15.11.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v15.11.0/node-v15.11.0-aix-ppc64.tar.gz#dbe6ab79a7fcff06e72d5a062c5850132d06ecc79bbda5049d33a0702483f906"
 binary darwin-x64 "https://nodejs.org/dist/v15.11.0/node-v15.11.0-darwin-x64.tar.gz#def5bea3d66e1ca4239d2c6cb22be9b841cd937f037f7b13976960c895ebf803"
 binary linux-arm64 "https://nodejs.org/dist/v15.11.0/node-v15.11.0-linux-arm64.tar.gz#bac8f957c35df2985ab10098d7ee494de28872ce8382df412ef745895f30f0d8"

--- a/share/node-build/15.12.0
+++ b/share/node-build/15.12.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v15.12.0/node-v15.12.0-aix-ppc64.tar.gz#b05beb9caa359aba0402412937a6f7434459adab016021c6e30f4c67b5ab35d9"
 binary darwin-x64 "https://nodejs.org/dist/v15.12.0/node-v15.12.0-darwin-x64.tar.gz#c04a77a3bf4a9ea7f5c0d34773cb8fcc4af594b202fa69ea41edc372ecd28df0"
 binary linux-arm64 "https://nodejs.org/dist/v15.12.0/node-v15.12.0-linux-arm64.tar.gz#cf1e276e381bbe58998feb584f907980ad2c6cd8c88dd4662a089b177b7ab0b2"

--- a/share/node-build/15.13.0
+++ b/share/node-build/15.13.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v15.13.0/node-v15.13.0-aix-ppc64.tar.gz#9476bb2d9cdd50c80a57a941234bbd763a697377e5677befb67b4ead9511a361"
 binary darwin-x64 "https://nodejs.org/dist/v15.13.0/node-v15.13.0-darwin-x64.tar.gz#6e46324c9b0cafb7b37343b85055a878bb89e02643906c82c00c11dbd3ce9514"
 binary linux-arm64 "https://nodejs.org/dist/v15.13.0/node-v15.13.0-linux-arm64.tar.gz#23a0277115cb18c994e8225552a9755811b5ebf87efec0997734b7e361dfd70a"

--- a/share/node-build/15.14.0
+++ b/share/node-build/15.14.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v15.14.0/node-v15.14.0-aix-ppc64.tar.gz#cb133ef05eb9c20c23a2f267f216dca0a66166bb5cdbf1a1871c114a439f8767"
 binary darwin-x64 "https://nodejs.org/dist/v15.14.0/node-v15.14.0-darwin-x64.tar.gz#a3ea5f2da4868de1513664de76ce09cc8234312a0918223b19e40d3ca4890bf2"
 binary linux-arm64 "https://nodejs.org/dist/v15.14.0/node-v15.14.0-linux-arm64.tar.gz#6d5e0074fe4a45d444bc581aa1fd7ce7081b8491b0f785414a6e5cc30c42854a"

--- a/share/node-build/15.2.0
+++ b/share/node-build/15.2.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v15.2.0/node-v15.2.0-aix-ppc64.tar.gz#72d8f863c0e6aa2a971d4ea19d8da1a84f28fc21d5532f8e284a2cfe62e07928"
 binary darwin-x64 "https://nodejs.org/dist/v15.2.0/node-v15.2.0-darwin-x64.tar.gz#31cd7d98b2eeddf0895e75b650d005af0f4103d6ce54a93554b32080a0b79780"
 binary linux-arm64 "https://nodejs.org/dist/v15.2.0/node-v15.2.0-linux-arm64.tar.gz#c8203934787e3e7ab136eff96689d04abedda5e037785a55fdc26a43bbfd867d"

--- a/share/node-build/15.2.1
+++ b/share/node-build/15.2.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v15.2.1/node-v15.2.1-aix-ppc64.tar.gz#7f8276074adb699696b1a159bc2a21b939ab9d6a2997c49a80d967ae460f6c3d"
 binary darwin-x64 "https://nodejs.org/dist/v15.2.1/node-v15.2.1-darwin-x64.tar.gz#2cca29de17ab2d047ca3a793fe15be43e251985dd3b186942b593fa2f0d9e47a"
 binary linux-arm64 "https://nodejs.org/dist/v15.2.1/node-v15.2.1-linux-arm64.tar.gz#1b7c9a5a484e4c1dc3e104d79627e65cd0e39fa84f8115e239355b5bf3b0b16d"

--- a/share/node-build/15.3.0
+++ b/share/node-build/15.3.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v15.3.0/node-v15.3.0-aix-ppc64.tar.gz#5cf19b4cb855147b1fdd0e85b9d283af726e1f9e8f7274e81885a1011b33a672"
 binary darwin-x64 "https://nodejs.org/dist/v15.3.0/node-v15.3.0-darwin-x64.tar.gz#58376f9bf566f89a664dd3c89e087b28fddb2b99a008a4952671d9ec4cf83e42"
 binary linux-arm64 "https://nodejs.org/dist/v15.3.0/node-v15.3.0-linux-arm64.tar.gz#3becebd1e981df27a16bde02b5ead6bd9e6bdc0840477721c6805f9089f6179d"

--- a/share/node-build/15.4.0
+++ b/share/node-build/15.4.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v15.4.0/node-v15.4.0-aix-ppc64.tar.gz#e9630d01ee1ff74445e12ab2f14581b2aea9201eca05b39f8174697afdba74b2"
 binary darwin-x64 "https://nodejs.org/dist/v15.4.0/node-v15.4.0-darwin-x64.tar.gz#503d160016f6a61ec25a9462499721ef96b9ed08e232a420d17541774e079dda"
 binary linux-arm64 "https://nodejs.org/dist/v15.4.0/node-v15.4.0-linux-arm64.tar.gz#0dad2932f7f7e0fc21bca0690d31f065080dbbf448527e982447355ff4bb91bd"

--- a/share/node-build/15.5.0
+++ b/share/node-build/15.5.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v15.5.0/node-v15.5.0-aix-ppc64.tar.gz#14ba6dd3629af5640cf0fde81b86ce9e17bcfdc7b25f7fe2a0a112d422c3d8cb"
 binary darwin-x64 "https://nodejs.org/dist/v15.5.0/node-v15.5.0-darwin-x64.tar.gz#f7b2859579d5c1c6e6935e939e78b5405f21797782b1f3c9607aecd6ad6a3ebf"
 binary linux-arm64 "https://nodejs.org/dist/v15.5.0/node-v15.5.0-linux-arm64.tar.gz#0dd46103a8a6ef1b41642d17fe2b141f1e929f6a605b853a1480a37cb44bde1d"

--- a/share/node-build/15.5.1
+++ b/share/node-build/15.5.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v15.5.1/node-v15.5.1-aix-ppc64.tar.gz#1b56c38c36efb3d23c37fd7b2a46660ca06963d47dfd9160befb80e508169a48"
 binary darwin-x64 "https://nodejs.org/dist/v15.5.1/node-v15.5.1-darwin-x64.tar.gz#4507dab0481b0b5374b5758b1eba7d105c8cbcb173548119b04d9ef7d9f1d40f"
 binary linux-arm64 "https://nodejs.org/dist/v15.5.1/node-v15.5.1-linux-arm64.tar.gz#a2d14db86c6f8a070f227940ea44a3409966f6bed14df0ec6f676fe2e2f601c9"

--- a/share/node-build/15.6.0
+++ b/share/node-build/15.6.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v15.6.0/node-v15.6.0-aix-ppc64.tar.gz#166985455aaf6a16c570045c3381bc7d88a1dfa3f98cf4bb67a699b7240c6bed"
 binary darwin-x64 "https://nodejs.org/dist/v15.6.0/node-v15.6.0-darwin-x64.tar.gz#e79baddd344fd19c68104591964263b14ddc57fb98051bebb744151f21a83667"
 binary linux-arm64 "https://nodejs.org/dist/v15.6.0/node-v15.6.0-linux-arm64.tar.gz#b0660398fe590f8588431a787e9b032c7271a2fa88306c7a26e751571df998e4"

--- a/share/node-build/15.7.0
+++ b/share/node-build/15.7.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v15.7.0/node-v15.7.0-aix-ppc64.tar.gz#b091732d90fe6882850dc5d0973a774030c4d6c32fb303a49f7e7be1918d168e"
 binary darwin-x64 "https://nodejs.org/dist/v15.7.0/node-v15.7.0-darwin-x64.tar.gz#b0f7728bbf428cdd8343e1fae910882d19a3889a04d09afc722c653cf8ab3ef2"
 binary linux-arm64 "https://nodejs.org/dist/v15.7.0/node-v15.7.0-linux-arm64.tar.gz#72853eb858a93d53b0758b86eea0d466296ab275fbb73f2f4d40fad6cd1a0ff9"

--- a/share/node-build/15.8.0
+++ b/share/node-build/15.8.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v15.8.0/node-v15.8.0-aix-ppc64.tar.gz#8a1f2fc0e4aac595f7d82ab9e1a51958aa74bbdfa9bb36090f4a78b5cc776638"
 binary darwin-x64 "https://nodejs.org/dist/v15.8.0/node-v15.8.0-darwin-x64.tar.gz#23f9a8a53d0d63e1d90afe775891088533fc5b277ef83db0cd2fc37951c09595"
 binary linux-arm64 "https://nodejs.org/dist/v15.8.0/node-v15.8.0-linux-arm64.tar.gz#086149a16cf7a092f1e12fa2a91bb6587ce25914bd52c3bcff78b5b5c6222e30"

--- a/share/node-build/15.9.0
+++ b/share/node-build/15.9.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v15.9.0/node-v15.9.0-aix-ppc64.tar.gz#7d160d3accabb6c61a2d54aa0405f08060e0924e079ceccb31763c5666c72358"
 binary darwin-x64 "https://nodejs.org/dist/v15.9.0/node-v15.9.0-darwin-x64.tar.gz#55c6a84ce4d72b886914d4972007e09b72a34ee2483263a0d7218953ab716c70"
 binary linux-arm64 "https://nodejs.org/dist/v15.9.0/node-v15.9.0-linux-arm64.tar.gz#65f3f889e6ac6952a7fa892e5d3ad19759d58771fbf4bc492d5e87117c2072d7"

--- a/share/node-build/16.0.0
+++ b/share/node-build/16.0.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.0.0/node-v16.0.0-aix-ppc64.tar.gz#a6aee31e1fd8f55dc78007de2e4ac0d8e0dadd36beacfbabbaf9ab27a5f1f2f4"
 binary darwin-arm64 "https://nodejs.org/dist/v16.0.0/node-v16.0.0-darwin-arm64.tar.gz#2d6d412abcf7c9375f19fde14086a6423e5bb9415eeca1ccad49638ffc476ea3"
 binary darwin-x64 "https://nodejs.org/dist/v16.0.0/node-v16.0.0-darwin-x64.tar.gz#b00457dd7da6cc00d0248dc57b4ddd01a71eed6009ddadd8c854678232091dfb"

--- a/share/node-build/16.1.0
+++ b/share/node-build/16.1.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.1.0/node-v16.1.0-aix-ppc64.tar.gz#174f356190d82f24a53085d102799fd90e9031003adb891510aeef58bf2cc302"
 binary darwin-arm64 "https://nodejs.org/dist/v16.1.0/node-v16.1.0-darwin-arm64.tar.gz#4ed9f6d78528fc80997a02a461437a3c3e82ba530fe8338ecf970e733883f8a8"
 binary darwin-x64 "https://nodejs.org/dist/v16.1.0/node-v16.1.0-darwin-x64.tar.gz#22525ecc3b91f4d9a5d44dffe061cdb23f1a3e4a5555552e7940987883a93547"

--- a/share/node-build/16.10.0
+++ b/share/node-build/16.10.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.10.0/node-v16.10.0-aix-ppc64.tar.gz#2142ee042206c5064b19fc034d8d03c7291d0177341a3b55f80d0a3b44ee32de"
 binary darwin-arm64 "https://nodejs.org/dist/v16.10.0/node-v16.10.0-darwin-arm64.tar.gz#dfdaf4149365e170929b99692520388e89f618e8d64ddd3ded7126bccf4583ed"
 binary darwin-x64 "https://nodejs.org/dist/v16.10.0/node-v16.10.0-darwin-x64.tar.gz#66a42483908aabd6d5fb19e9f3cebd6927dc84206b75b8801d9e010815083906"

--- a/share/node-build/16.11.0
+++ b/share/node-build/16.11.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.11.0/node-v16.11.0-aix-ppc64.tar.gz#c83419e179b82019daea529c1da187e91b857184adfbf315e267490a47aad957"
 binary darwin-arm64 "https://nodejs.org/dist/v16.11.0/node-v16.11.0-darwin-arm64.tar.gz#b8f75887d6e94f8f38df9b6016258ea742677ffb45e6d513d55dc09bcd9c1fd3"
 binary darwin-x64 "https://nodejs.org/dist/v16.11.0/node-v16.11.0-darwin-x64.tar.gz#abcf083d1c5f83c6d12fbe0f0ff2b3ff61fc0d3e06b43ebbbd0761804c62c468"

--- a/share/node-build/16.11.1
+++ b/share/node-build/16.11.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.11.1/node-v16.11.1-aix-ppc64.tar.gz#f386076358c470150cd8ad5cc18f008ec51d146ad2e66345fcd063f7228a5d95"
 binary darwin-arm64 "https://nodejs.org/dist/v16.11.1/node-v16.11.1-darwin-arm64.tar.gz#5e772e478390fab3001b7148a923e4f22fca50170000f18b28475337d3a97248"
 binary darwin-x64 "https://nodejs.org/dist/v16.11.1/node-v16.11.1-darwin-x64.tar.gz#ba54b8ed504bd934d03eb860fefe991419b4209824280d4274f6a911588b5e45"

--- a/share/node-build/16.12.0
+++ b/share/node-build/16.12.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.12.0/node-v16.12.0-aix-ppc64.tar.gz#d45cc55607bdc730aa6b930be4a067bc56568ff92162608f0f5983879024cd5b"
 binary darwin-arm64 "https://nodejs.org/dist/v16.12.0/node-v16.12.0-darwin-arm64.tar.gz#1d681c528205f56531084a09e9648586f91e68726ee73851c8e4b1098df2f603"
 binary darwin-x64 "https://nodejs.org/dist/v16.12.0/node-v16.12.0-darwin-x64.tar.gz#35ee05c9392742f934a3058fa64837b14e184b26aa9bd621ec499a83f9fdfe67"

--- a/share/node-build/16.13.0
+++ b/share/node-build/16.13.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.13.0/node-v16.13.0-aix-ppc64.tar.gz#eadf10e991a690c2af98b6df8a118336ded513d6b13a83721bb28bec290df908"
 binary darwin-arm64 "https://nodejs.org/dist/v16.13.0/node-v16.13.0-darwin-arm64.tar.gz#46d83fc0bd971db5050ef1b15afc44a6665dee40bd6c1cbaec23e1b40fa49e6d"
 binary darwin-x64 "https://nodejs.org/dist/v16.13.0/node-v16.13.0-darwin-x64.tar.gz#37e09a8cf2352f340d1204c6154058d81362fef4ec488b0197b2ce36b3f0367a"

--- a/share/node-build/16.13.1
+++ b/share/node-build/16.13.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.13.1/node-v16.13.1-aix-ppc64.tar.gz#b1986cc40595c615fa5c51e29148c41c9e2446c479cdb99575a033f30c5f419c"
 binary darwin-arm64 "https://nodejs.org/dist/v16.13.1/node-v16.13.1-darwin-arm64.tar.gz#2d27c10c49af87a8d87bce4d32ca0e37afbc8dcc73d524ec7de3506c6309d4fc"
 binary darwin-x64 "https://nodejs.org/dist/v16.13.1/node-v16.13.1-darwin-x64.tar.gz#a139fc6a4c8daf160989420535378d69b53a0d9f5ae43871e9befeb2b8a44187"

--- a/share/node-build/16.13.2
+++ b/share/node-build/16.13.2
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.13.2/node-v16.13.2-aix-ppc64.tar.gz#54078953e99360087e1c300f7cc36165b838229034c451367428b40095656133"
 binary darwin-arm64 "https://nodejs.org/dist/v16.13.2/node-v16.13.2-darwin-arm64.tar.gz#09d300008ad58792c12622a5eafdb14c931587bb88713df4df64cdf4ff2188d1"
 binary darwin-x64 "https://nodejs.org/dist/v16.13.2/node-v16.13.2-darwin-x64.tar.gz#900a952bb77533d349e738ff8a5179a4344802af694615f36320a888b49b07e6"

--- a/share/node-build/16.14.0
+++ b/share/node-build/16.14.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.14.0/node-v16.14.0-aix-ppc64.tar.gz#e31a1478b50814848089bc11fb58d463c180ac5e08ec95f6bd314b2a7209d23a"
 binary darwin-arm64 "https://nodejs.org/dist/v16.14.0/node-v16.14.0-darwin-arm64.tar.gz#56e547d22bc7be8aa40c8cfd604c156a5bcf8692f643ec1801c1fa2390498542"
 binary darwin-x64 "https://nodejs.org/dist/v16.14.0/node-v16.14.0-darwin-x64.tar.gz#26702ab17903ad1ea4e13133bd423c1176db3384b8cf08559d385817c9ca58dc"

--- a/share/node-build/16.14.1
+++ b/share/node-build/16.14.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.14.1/node-v16.14.1-aix-ppc64.tar.gz#b7bb8e48e0d84cf63c0a024b0867f4a62ec5d4a48753015b60789ee70012c3c8"
 binary darwin-arm64 "https://nodejs.org/dist/v16.14.1/node-v16.14.1-darwin-arm64.tar.gz#8f6d45796f3d996484dcf53bb0e53cd019cd0ef7a1a247bd0178ebaa7e63a184"
 binary darwin-x64 "https://nodejs.org/dist/v16.14.1/node-v16.14.1-darwin-x64.tar.gz#af35abd727b051c8cdb8dcda9815ae93f96ef2c224d71f4ec52034a2ab5d8b61"

--- a/share/node-build/16.14.2
+++ b/share/node-build/16.14.2
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.14.2/node-v16.14.2-aix-ppc64.tar.gz#acae171e4d58905e7e4c712a614de17bdf6a6720addbb5e440a94efda78807e4"
 binary darwin-arm64 "https://nodejs.org/dist/v16.14.2/node-v16.14.2-darwin-arm64.tar.gz#a66d9217d2003bd416d3dd06dfd2c7a044c4c9ff2e43a27865790bd0d59c682d"
 binary darwin-x64 "https://nodejs.org/dist/v16.14.2/node-v16.14.2-darwin-x64.tar.gz#d3076ca7fcc7269c8ff9b03fe7d1c277d913a7e84a46a14eff4af7791ff9d055"

--- a/share/node-build/16.15.0
+++ b/share/node-build/16.15.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.15.0/node-v16.15.0-aix-ppc64.tar.gz#237a2b77ef1ec74343329c8c701d0f41feb946ede0a2cbc7292175b34cc638f6"
 binary darwin-arm64 "https://nodejs.org/dist/v16.15.0/node-v16.15.0-darwin-arm64.tar.gz#ad8d8fc5330ef47788f509c2af398c8060bb59acbe914070d0df684cd2d8d39b"
 binary darwin-x64 "https://nodejs.org/dist/v16.15.0/node-v16.15.0-darwin-x64.tar.gz#a6bb12bbf979d32137598e49d56d61bcddf8a8596c3442b44a9b3ace58dd4de8"

--- a/share/node-build/16.15.1
+++ b/share/node-build/16.15.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.15.1/node-v16.15.1-aix-ppc64.tar.gz#31dec4d81fb154120055132bf21b0664c34ca6e1f66def9438bd19e2c5aff0ca"
 binary darwin-arm64 "https://nodejs.org/dist/v16.15.1/node-v16.15.1-darwin-arm64.tar.gz#7f492d01bed05c982fd55d6ba68711fe29bd7a1bb97b528909ac5aa9e3ab951d"
 binary darwin-x64 "https://nodejs.org/dist/v16.15.1/node-v16.15.1-darwin-x64.tar.gz#965f4c44d53be8c7fd718ecb8ca3889c49e9877e68382851e8bf3b9b26eb3b69"

--- a/share/node-build/16.16.0
+++ b/share/node-build/16.16.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.16.0/node-v16.16.0-aix-ppc64.tar.gz#6050ce2c71ef0acca9bc09a0dbbc19b243d1915839b3a349f08ac92672c09ff7"
 binary darwin-arm64 "https://nodejs.org/dist/v16.16.0/node-v16.16.0-darwin-arm64.tar.gz#167721c2d72402e54adc0f8c87ca840796216c4d98946509d73221b771ad3e4c"
 binary darwin-x64 "https://nodejs.org/dist/v16.16.0/node-v16.16.0-darwin-x64.tar.gz#982edd0fad364ad6e2d72161671544ab9399bd0ca8c726bde3cd07775c4c709a"

--- a/share/node-build/16.17.0
+++ b/share/node-build/16.17.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.17.0/node-v16.17.0-aix-ppc64.tar.gz#19d8bd771213d4f55b4aa5f661212f4bc5aeb4bd53928eb922af3a5538df75c7"
 binary darwin-arm64 "https://nodejs.org/dist/v16.17.0/node-v16.17.0-darwin-arm64.tar.gz#96eefac1e168ec1bf39c5ae1e7b2760522624adfbe2e0c92875cd33ef9a07792"
 binary darwin-x64 "https://nodejs.org/dist/v16.17.0/node-v16.17.0-darwin-x64.tar.gz#b85eaa537f9d60a68c704e23839db65b5a75f14b37d6855c5d4e31a6bcef26c6"

--- a/share/node-build/16.17.1
+++ b/share/node-build/16.17.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.17.1/node-v16.17.1-aix-ppc64.tar.gz#dfb37570ef34ac04f34c26d0ec558df60a9665df5961c01c1657c0ca495f2f01"
 binary darwin-arm64 "https://nodejs.org/dist/v16.17.1/node-v16.17.1-darwin-arm64.tar.gz#f9f02f7872e2e8ee54320fce13deb9d56904f32bb0615b6e21aa3371d8899150"
 binary darwin-x64 "https://nodejs.org/dist/v16.17.1/node-v16.17.1-darwin-x64.tar.gz#3db26761ad8493b894d42260d7e65094b7af9bc473588739e61bc1c32d6ff955"

--- a/share/node-build/16.18.0
+++ b/share/node-build/16.18.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.18.0/node-v16.18.0-aix-ppc64.tar.gz#b7ee0afbd7b091cdff83fff76e6159a63307361599d8b0f68c767bcdf5932462"
 binary darwin-arm64 "https://nodejs.org/dist/v16.18.0/node-v16.18.0-darwin-arm64.tar.gz#8ceee891d0171381520e9017326589a9a616d6be2689493304970290d9b6e3b2"
 binary darwin-x64 "https://nodejs.org/dist/v16.18.0/node-v16.18.0-darwin-x64.tar.gz#bd1476e95856879710026a344572c1b77add48da0f2d15bda48513d0b2667ed5"

--- a/share/node-build/16.18.1
+++ b/share/node-build/16.18.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.18.1/node-v16.18.1-aix-ppc64.tar.gz#aeca357b0135f704ec8862727be5601d336024d217b33ae4aa37c87337329be7"
 binary darwin-arm64 "https://nodejs.org/dist/v16.18.1/node-v16.18.1-darwin-arm64.tar.gz#71720bb0a80cf158d8fdf492def08048befd953ad45e2458b1d095e32c612ba7"
 binary darwin-x64 "https://nodejs.org/dist/v16.18.1/node-v16.18.1-darwin-x64.tar.gz#c190e106d4ac6177d1db3a5a739d39dd68bd276ba17f3d3c84039a93717e081e"

--- a/share/node-build/16.19.0
+++ b/share/node-build/16.19.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.19.0/node-v16.19.0-aix-ppc64.tar.gz#2697295a083b1be572a98f632f28c510e5eb5af526bbdf4ca1b5060abc01d24e"
 binary darwin-arm64 "https://nodejs.org/dist/v16.19.0/node-v16.19.0-darwin-arm64.tar.gz#5c9434fbb0f323fecf3d261b23a2e544919380c5043d0046d9745682fefd9cde"
 binary darwin-x64 "https://nodejs.org/dist/v16.19.0/node-v16.19.0-darwin-x64.tar.gz#491e5a5592eca1961dcbb1fae28567428ce56ce9cc7977b04041e163e0c1670c"

--- a/share/node-build/16.19.1
+++ b/share/node-build/16.19.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.19.1/node-v16.19.1-aix-ppc64.tar.gz#b93adce984bca2712bf4e48c49f828cd1ae1a8d89e6ebd9e4fecb2165cf6b438"
 binary darwin-arm64 "https://nodejs.org/dist/v16.19.1/node-v16.19.1-darwin-arm64.tar.gz#168f787f457bf645f3fc41e7419b62071db7d42519ce461b1d7ebfc0acbdbfb1"
 binary darwin-x64 "https://nodejs.org/dist/v16.19.1/node-v16.19.1-darwin-x64.tar.gz#d7f683b2a8f78db8a28235a175e130c760f0d3cd335404e02f223e3a9adc30c7"

--- a/share/node-build/16.2.0
+++ b/share/node-build/16.2.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.2.0/node-v16.2.0-aix-ppc64.tar.gz#149f3f7be5996d6f26a86f97daeaa24bf585e9517ea283cd60676a0c81943a95"
 binary darwin-arm64 "https://nodejs.org/dist/v16.2.0/node-v16.2.0-darwin-arm64.tar.gz#451d87c07c522e24152a584b2d5461d4e3a7c690bd8882bef9ae8bf6b19d1dfd"
 binary darwin-x64 "https://nodejs.org/dist/v16.2.0/node-v16.2.0-darwin-x64.tar.gz#3fc49b69de9491b45491f880217f8220d489b28ba3c1fff53e849dcf3ad77343"

--- a/share/node-build/16.20.0
+++ b/share/node-build/16.20.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.20.0/node-v16.20.0-aix-ppc64.tar.gz#87f579933a45a4ad77dffd60e6f78cfb2c3f2d3a762824c90d75fea3062352a6"
 binary darwin-arm64 "https://nodejs.org/dist/v16.20.0/node-v16.20.0-darwin-arm64.tar.gz#15d0857009f13e85057010b605e57b418318fdf422b5f9dd7e0ef32115da9c10"
 binary darwin-x64 "https://nodejs.org/dist/v16.20.0/node-v16.20.0-darwin-x64.tar.gz#263d5b4871972028e204087fc8a67e21d8a0e2a420d1247375089ec8fd12759e"

--- a/share/node-build/16.20.1
+++ b/share/node-build/16.20.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.20.1/node-v16.20.1-aix-ppc64.tar.gz#46a7761a7f4a5c836ee045004ff5ea14819ac7e97c45d6f8731f276c2ac4099d"
 binary darwin-arm64 "https://nodejs.org/dist/v16.20.1/node-v16.20.1-darwin-arm64.tar.gz#5f6b31c5a75567d382ba67220f3d7a2d9bb0c03d8af9307cd35a9cb32a6fde9d"
 binary darwin-x64 "https://nodejs.org/dist/v16.20.1/node-v16.20.1-darwin-x64.tar.gz#d1f9c2a7c3a0fe09860f701af5fb8ff9ac72d72faa7ebabfeb5794503e79f955"

--- a/share/node-build/16.20.2
+++ b/share/node-build/16.20.2
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.20.2/node-v16.20.2-aix-ppc64.tar.gz#e3866679e6fbb13f5156c328bb77623b4d63493c8aaa448686a2bc53007005b8"
 binary darwin-arm64 "https://nodejs.org/dist/v16.20.2/node-v16.20.2-darwin-arm64.tar.gz#6a5c4108475871362d742b988566f3fe307f6a67ce14634eb3fbceb4f9eea88c"
 binary darwin-x64 "https://nodejs.org/dist/v16.20.2/node-v16.20.2-darwin-x64.tar.gz#d7a46eaf2b57ffddeda16ece0d887feb2e31a91ad33f8774da553da0249dc4a6"

--- a/share/node-build/16.3.0
+++ b/share/node-build/16.3.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.3.0/node-v16.3.0-aix-ppc64.tar.gz#4241dc60ff8bb1748391fd16cde459a486824e23b96b13c223fb97b3fecd9fe9"
 binary darwin-arm64 "https://nodejs.org/dist/v16.3.0/node-v16.3.0-darwin-arm64.tar.gz#aeac294dbe54a4dfd222eedfbae704b185c40702254810e2c5917f6dbc80e017"
 binary darwin-x64 "https://nodejs.org/dist/v16.3.0/node-v16.3.0-darwin-x64.tar.gz#3e075bcfb6130dda84bfd04633cb228ec71e72d9a844c57efb7cfff130b4be89"

--- a/share/node-build/16.4.0
+++ b/share/node-build/16.4.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.4.0/node-v16.4.0-aix-ppc64.tar.gz#7695554a71873ea2393248438508c5d73a4fc195f760a9317e33670826ab691f"
 binary darwin-arm64 "https://nodejs.org/dist/v16.4.0/node-v16.4.0-darwin-arm64.tar.gz#771469be99d6af048d9b192cd7b338c68a4604e0fcc7f8804278c91b5ad3f74f"
 binary darwin-x64 "https://nodejs.org/dist/v16.4.0/node-v16.4.0-darwin-x64.tar.gz#95c81b54ea3069fcf230664d5d80b10e46f8fff5163644b7076fe48df13fc2fb"

--- a/share/node-build/16.4.1
+++ b/share/node-build/16.4.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.4.1/node-v16.4.1-aix-ppc64.tar.gz#d0f079c4bc78ee9e1eb646434bc52730c59e433f75febee70ee5506a5526eead"
 binary darwin-arm64 "https://nodejs.org/dist/v16.4.1/node-v16.4.1-darwin-arm64.tar.gz#c6e2a79873c4afbd9fcd7e9d2889e2a7b84860bea472a07ccbe33387397990f5"
 binary darwin-x64 "https://nodejs.org/dist/v16.4.1/node-v16.4.1-darwin-x64.tar.gz#c78fecdfb062c51ba0432d1c6bb8f30eb14daf47001a5f68d17b3ae6d4d9eb31"

--- a/share/node-build/16.4.2
+++ b/share/node-build/16.4.2
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.4.2/node-v16.4.2-aix-ppc64.tar.gz#face4ef55857571cefeac04be0b9381cb4ec97512fd5f843a7c44d5cea467b95"
 binary darwin-arm64 "https://nodejs.org/dist/v16.4.2/node-v16.4.2-darwin-arm64.tar.gz#94f2890a3f68044bb89891d25063cc07bcd1e3754d27cfbcdeffeb0dc8cff592"
 binary darwin-x64 "https://nodejs.org/dist/v16.4.2/node-v16.4.2-darwin-x64.tar.gz#51baebe96a70287fcbabafaca4c1704c610514e629e7c895b1d145ea0adc9ce6"

--- a/share/node-build/16.5.0
+++ b/share/node-build/16.5.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.5.0/node-v16.5.0-aix-ppc64.tar.gz#3d134a7499d7b022febaa50d1923fb799c8edd9c2478be180eb88bfee06165b1"
 binary darwin-arm64 "https://nodejs.org/dist/v16.5.0/node-v16.5.0-darwin-arm64.tar.gz#4296521e8b5d73d4c3b9b7f6f9f666e577342ea92a520f33040f1a252387d079"
 binary darwin-x64 "https://nodejs.org/dist/v16.5.0/node-v16.5.0-darwin-x64.tar.gz#b779bd40b7c9366adcbe4f9fd2afd9ee5f085e333200380b34d285eb32c121bc"

--- a/share/node-build/16.6.0
+++ b/share/node-build/16.6.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.6.0/node-v16.6.0-aix-ppc64.tar.gz#ed07957f3c6075294cb1c5ed5760b8471c6fab880fd85bb29dabd44d64d12869"
 binary darwin-arm64 "https://nodejs.org/dist/v16.6.0/node-v16.6.0-darwin-arm64.tar.gz#07720d1bc18dca0bb3abdcd3c2e4f39a7cb532ca7f56c48bd42a4233de7fcd89"
 binary darwin-x64 "https://nodejs.org/dist/v16.6.0/node-v16.6.0-darwin-x64.tar.gz#4dc28f83bc1165ae28c937458b7277b4af3ff8c6e61cccf2d9b87b4bfbcbffec"

--- a/share/node-build/16.6.1
+++ b/share/node-build/16.6.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.6.1/node-v16.6.1-aix-ppc64.tar.gz#02581dbbfc2886dec326c3fca70c0f17e82491563057889dc630e5c055754c02"
 binary darwin-arm64 "https://nodejs.org/dist/v16.6.1/node-v16.6.1-darwin-arm64.tar.gz#8b766a2bcc686f968146b09892f24cfbeaebb547a4d50744d9af80def5221613"
 binary darwin-x64 "https://nodejs.org/dist/v16.6.1/node-v16.6.1-darwin-x64.tar.gz#bca84deb7bf6c57537b3af44997d985045c95b5048fc5665cdc7f54d5c147516"

--- a/share/node-build/16.6.2
+++ b/share/node-build/16.6.2
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.6.2/node-v16.6.2-aix-ppc64.tar.gz#2a51635501451a88f6addc192a79b6d36cc40dcf3a198a54037ab26fa6305043"
 binary darwin-arm64 "https://nodejs.org/dist/v16.6.2/node-v16.6.2-darwin-arm64.tar.gz#29e46e83f6837ff1c815c49f590c25fa51b0811a6590c62120a9d464ba431fc6"
 binary darwin-x64 "https://nodejs.org/dist/v16.6.2/node-v16.6.2-darwin-x64.tar.gz#74e95aca0ea88ed2d9270dccc1e3e62500912be5fef1528bb11f178c468f312c"

--- a/share/node-build/16.7.0
+++ b/share/node-build/16.7.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.7.0/node-v16.7.0-aix-ppc64.tar.gz#4c706dbaebab5c5787d36238b32405143742050fb0faccc81d9da6ebf05e8304"
 binary darwin-arm64 "https://nodejs.org/dist/v16.7.0/node-v16.7.0-darwin-arm64.tar.gz#969875c1a6b2790663d7b25d7641d1e3919225659921a98d2f1e4711bbec5ef3"
 binary darwin-x64 "https://nodejs.org/dist/v16.7.0/node-v16.7.0-darwin-x64.tar.gz#c9bf23c765c584f635a4065d58dadff9737aeb605676d1e45873eba66adaab8a"

--- a/share/node-build/16.8.0
+++ b/share/node-build/16.8.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.8.0/node-v16.8.0-aix-ppc64.tar.gz#cc9e8e2600c2ad9ee80be45a850453a5f0237650f8bd4364db4a9f941a5b6e57"
 binary darwin-arm64 "https://nodejs.org/dist/v16.8.0/node-v16.8.0-darwin-arm64.tar.gz#891e72d166abbb1b838b5113cc8cfaf2fe905dfe77afe84a5af56e426ff74ddf"
 binary darwin-x64 "https://nodejs.org/dist/v16.8.0/node-v16.8.0-darwin-x64.tar.gz#9c013cb82830ab5adb9630ff28046f420a7805bb4a930ec2b3f5b162c5f6de88"

--- a/share/node-build/16.9.0
+++ b/share/node-build/16.9.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.9.0/node-v16.9.0-aix-ppc64.tar.gz#d4c91b7321877945403162bb330aa5c30323773aece0bbc65fefb1efd2be8a53"
 binary darwin-arm64 "https://nodejs.org/dist/v16.9.0/node-v16.9.0-darwin-arm64.tar.gz#13105eb6623f474e4596c725bd4d6fcd500c68155f9f954bd3332c46f5df7378"
 binary darwin-x64 "https://nodejs.org/dist/v16.9.0/node-v16.9.0-darwin-x64.tar.gz#37cea8ce6f88c501ed2ed191fc4335e5c4ecbeb0e85247c07b35825f07a60351"

--- a/share/node-build/16.9.1
+++ b/share/node-build/16.9.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v16.9.1/node-v16.9.1-aix-ppc64.tar.gz#92e602c856d91394223aeae0a9df8ba9dc1d8535a56c8e58561e319caba272c0"
 binary darwin-arm64 "https://nodejs.org/dist/v16.9.1/node-v16.9.1-darwin-arm64.tar.gz#cf7ec489e2250e9837cb608cb14123ea6645b14943dbfdc9de206d62f0de6fa2"
 binary darwin-x64 "https://nodejs.org/dist/v16.9.1/node-v16.9.1-darwin-x64.tar.gz#90ff3ce95882ad41ae5c7a2f4f7303e9ba445caf5ef41d270a385c0a76e43bc6"

--- a/share/node-build/17.0.0
+++ b/share/node-build/17.0.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v17.0.0/node-v17.0.0-aix-ppc64.tar.gz#ab2a9b508665f88d6516a6322971bbb988dddf311cd26edcaea374ff06ee8f14"
 binary darwin-arm64 "https://nodejs.org/dist/v17.0.0/node-v17.0.0-darwin-arm64.tar.gz#bba3a1d2638ee194f82a6173296bebabf1b28897a5cd41bbc146629ac05e0751"
 binary darwin-x64 "https://nodejs.org/dist/v17.0.0/node-v17.0.0-darwin-x64.tar.gz#091f29119bfb2a9004171f4626e0e76021f7f8db07148bd45caa6a61eb2a4e3d"

--- a/share/node-build/17.0.1
+++ b/share/node-build/17.0.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v17.0.1/node-v17.0.1-aix-ppc64.tar.gz#fa09aa43637816e27d240d551416c8b32d5503e1a6371d01fe60d3700e146ec3"
 binary darwin-arm64 "https://nodejs.org/dist/v17.0.1/node-v17.0.1-darwin-arm64.tar.gz#b49c65be9112f7e5de4e39f4f01e541ee73b3d28d3e2bbd3ea85a86952d0dc2d"
 binary darwin-x64 "https://nodejs.org/dist/v17.0.1/node-v17.0.1-darwin-x64.tar.gz#0dfe6f904f3f20652e3d34c60885b790603f120d5d51a53031355827a4eaf6a9"

--- a/share/node-build/17.1.0
+++ b/share/node-build/17.1.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v17.1.0/node-v17.1.0-aix-ppc64.tar.gz#dfeb027e2dd37b099bf326238a24959bee2818a4544a63d8a3f7ff88e026b050"
 binary darwin-arm64 "https://nodejs.org/dist/v17.1.0/node-v17.1.0-darwin-arm64.tar.gz#5e89e1cd17c58ef795d3bb420dd2a473c72a642422328c66dec59eb6d9243408"
 binary darwin-x64 "https://nodejs.org/dist/v17.1.0/node-v17.1.0-darwin-x64.tar.gz#5255978096ea249a8b155f6cc7f8f81e3bc2f7e9371c9f263bdb484359d740b2"

--- a/share/node-build/17.2.0
+++ b/share/node-build/17.2.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v17.2.0/node-v17.2.0-aix-ppc64.tar.gz#1fcfaad85f298d45e8e8c86bc007b536117583040ba1a9e3d2323152dcf6a0d3"
 binary darwin-arm64 "https://nodejs.org/dist/v17.2.0/node-v17.2.0-darwin-arm64.tar.gz#436d2c069069302615d24fd663494277eca183af25776fb4ce40008422666c6e"
 binary darwin-x64 "https://nodejs.org/dist/v17.2.0/node-v17.2.0-darwin-x64.tar.gz#6fc9e1c428cc6427d4926e8895dfc5c476718b2d02c3c5c1b6aa845c13602caa"

--- a/share/node-build/17.3.0
+++ b/share/node-build/17.3.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v17.3.0/node-v17.3.0-aix-ppc64.tar.gz#5300264598a643445378a51bf1d62242281ae602045934bf6fcacf6f6ba3abda"
 binary darwin-arm64 "https://nodejs.org/dist/v17.3.0/node-v17.3.0-darwin-arm64.tar.gz#b504ba3628337f7ac2c67d04bf30e56082942345aa1a50e0e464f51df6662ff3"
 binary darwin-x64 "https://nodejs.org/dist/v17.3.0/node-v17.3.0-darwin-x64.tar.gz#d4fa7d01c3b08cecdb71eee1da27a5e0e2d31bd25ad3bee1807df95811c2ce3f"

--- a/share/node-build/17.3.1
+++ b/share/node-build/17.3.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v17.3.1/node-v17.3.1-aix-ppc64.tar.gz#499156d09a9f9d589af9da091c57ba545c33a1fac6915d0687c1b27dbe91d77e"
 binary darwin-arm64 "https://nodejs.org/dist/v17.3.1/node-v17.3.1-darwin-arm64.tar.gz#e664dd753777c813d893aad2b797847e2f0dc4c537cfefc377e3c88716934d38"
 binary darwin-x64 "https://nodejs.org/dist/v17.3.1/node-v17.3.1-darwin-x64.tar.gz#a5d08b39a3f4af25c512247a2604eb84ffd41cbf66426d91df6ef165be94ae08"

--- a/share/node-build/17.4.0
+++ b/share/node-build/17.4.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v17.4.0/node-v17.4.0-aix-ppc64.tar.gz#91688cbeac365a5dde54f8615845f99c0b999599bd9924340ba5aa1ae9f590ff"
 binary darwin-arm64 "https://nodejs.org/dist/v17.4.0/node-v17.4.0-darwin-arm64.tar.gz#9bd53805faf6df658ecd4f54321b25eff89818efdcb52c20435ff1703fd7064c"
 binary darwin-x64 "https://nodejs.org/dist/v17.4.0/node-v17.4.0-darwin-x64.tar.gz#27e24d9f7a9a83bb59353249cce7cff16067e0483a627b5b9a1f1478101e64ee"

--- a/share/node-build/17.5.0
+++ b/share/node-build/17.5.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v17.5.0/node-v17.5.0-aix-ppc64.tar.gz#5608146533a5ff53d9fc737e1edef90da564ff89c979f15f317c0af861747da6"
 binary darwin-arm64 "https://nodejs.org/dist/v17.5.0/node-v17.5.0-darwin-arm64.tar.gz#b5b5d8557d1556cc8224e0e0b0711b6baba79be74b22e6eaf9870ac71fcd757a"
 binary darwin-x64 "https://nodejs.org/dist/v17.5.0/node-v17.5.0-darwin-x64.tar.gz#c5863c6ecdd6a3a1d14ef5d75135a82d33b68afb7a6a47558b86c72463d26877"

--- a/share/node-build/17.6.0
+++ b/share/node-build/17.6.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v17.6.0/node-v17.6.0-aix-ppc64.tar.gz#484d55ba3921f3ab056957517cd39f72cb787e21c1ceb91135e8d9d4c6a56efa"
 binary darwin-arm64 "https://nodejs.org/dist/v17.6.0/node-v17.6.0-darwin-arm64.tar.gz#801ec54f30e43c0513aa390b0a5e67afd2287c3bd81861afa744df6e7e8c109f"
 binary darwin-x64 "https://nodejs.org/dist/v17.6.0/node-v17.6.0-darwin-x64.tar.gz#0a88e772b11eb0145272ee70bf2785f1c159ce6783237dc7b4f865ce97c8f916"

--- a/share/node-build/17.7.0
+++ b/share/node-build/17.7.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v17.7.0/node-v17.7.0-aix-ppc64.tar.gz#ad28001c3acf8b46696dc48aa72b58eccdd13e71d3772904c2993f9d206ebd62"
 binary darwin-arm64 "https://nodejs.org/dist/v17.7.0/node-v17.7.0-darwin-arm64.tar.gz#4badbaf77e80cdc7333fdddbfaea80bf019adc4d09f71378ffa7e903eebd3b33"
 binary darwin-x64 "https://nodejs.org/dist/v17.7.0/node-v17.7.0-darwin-x64.tar.gz#6cf672f1b26105ea42f36f6834fb1a7ede86f6a39aee497e69e1dd319775b1fc"

--- a/share/node-build/17.7.1
+++ b/share/node-build/17.7.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v17.7.1/node-v17.7.1-aix-ppc64.tar.gz#0711b683f653ce65c1232f208d2f01df2261f44c8627ed989efe1f57ce5bca79"
 binary darwin-arm64 "https://nodejs.org/dist/v17.7.1/node-v17.7.1-darwin-arm64.tar.gz#d5bb0974a881e017a178b33dab1e90d1fe1e183602d1e86b62fed1e2ea1960a6"
 binary darwin-x64 "https://nodejs.org/dist/v17.7.1/node-v17.7.1-darwin-x64.tar.gz#94bfec7b7c034da3b626de77b9c8e6ba26418b160e805fc8a8106fbb0b797355"

--- a/share/node-build/17.7.2
+++ b/share/node-build/17.7.2
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v17.7.2/node-v17.7.2-aix-ppc64.tar.gz#a70a82872ce0c37c47356fbb216b434aed578a730ca6dd359f2f21f74a2b8c20"
 binary darwin-arm64 "https://nodejs.org/dist/v17.7.2/node-v17.7.2-darwin-arm64.tar.gz#9b078739799239adb3a0aea051e3cf60be886f28bb39d34d75780297dddd7af1"
 binary darwin-x64 "https://nodejs.org/dist/v17.7.2/node-v17.7.2-darwin-x64.tar.gz#57be6ba9e505c6b4b3b59c2878a1679fa11c1160773ec2d082cff74ed79e5ea1"

--- a/share/node-build/17.8.0
+++ b/share/node-build/17.8.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v17.8.0/node-v17.8.0-aix-ppc64.tar.gz#d3b95026bd938623491f72285df414fe4e77db6cb724d4af9c18a63e698834aa"
 binary darwin-arm64 "https://nodejs.org/dist/v17.8.0/node-v17.8.0-darwin-arm64.tar.gz#b0bdcddc070a559018f876e0810a678415f99d69ed6e4df15fd1c7cf5fc2e45f"
 binary darwin-x64 "https://nodejs.org/dist/v17.8.0/node-v17.8.0-darwin-x64.tar.gz#f253b705284f35f3ccea03ed7b97b8d5bd8002cfea3bb734289e2e9b38d0844b"

--- a/share/node-build/17.9.0
+++ b/share/node-build/17.9.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v17.9.0/node-v17.9.0-aix-ppc64.tar.gz#0e6d3b1677c1b9b1228a0df241ae2fa72952a35dba5d1fe165b0cac5a8e230db"
 binary darwin-arm64 "https://nodejs.org/dist/v17.9.0/node-v17.9.0-darwin-arm64.tar.gz#bad50341f8a1fd737c53efc01aa3f4eaf63df5601adf9ba036a8adb695d13428"
 binary darwin-x64 "https://nodejs.org/dist/v17.9.0/node-v17.9.0-darwin-x64.tar.gz#0920116e6507fdc8dcf16bdd717e08797b6d1b97a7a6990294bbf62da9471256"

--- a/share/node-build/19.0.0
+++ b/share/node-build/19.0.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v19.0.0/node-v19.0.0-aix-ppc64.tar.gz#6c01d2537f0f906d252d8a2b6fbf830e3080844d06ec59c48b902e99e0dc101f"
 binary darwin-arm64 "https://nodejs.org/dist/v19.0.0/node-v19.0.0-darwin-arm64.tar.gz#e30054d93857d3b2f55d22a4305e379ba9544adea885428900ff57bae465435e"
 binary darwin-x64 "https://nodejs.org/dist/v19.0.0/node-v19.0.0-darwin-x64.tar.gz#a1b46d199bbc307f6ef8621b118e71356c626a279eb421c6b3ce7a7741573041"

--- a/share/node-build/19.0.1
+++ b/share/node-build/19.0.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v19.0.1/node-v19.0.1-aix-ppc64.tar.gz#479408f8ee19ae11aa49ad36b0f95ccea4e27000c84f743101c88b1f6b4e9493"
 binary darwin-arm64 "https://nodejs.org/dist/v19.0.1/node-v19.0.1-darwin-arm64.tar.gz#96bcdf51e92320a79ada8ef9f97ab6eda8426e84fb2aad4b290719d8d749f4de"
 binary darwin-x64 "https://nodejs.org/dist/v19.0.1/node-v19.0.1-darwin-x64.tar.gz#55dffff4ef8e82c6e241d89fd124c7620dff83880c5e33c4ec2b19bd2d6399aa"

--- a/share/node-build/19.1.0
+++ b/share/node-build/19.1.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v19.1.0/node-v19.1.0-aix-ppc64.tar.gz#d1b2b585c25c846bb0453313d1d5dab8e82713e72c5cb01199a6e6b545816b84"
 binary darwin-arm64 "https://nodejs.org/dist/v19.1.0/node-v19.1.0-darwin-arm64.tar.gz#d05a4a3c9f081c7fbab131f447714fa708328c5c1634c278716adfbdbae0ff26"
 binary darwin-x64 "https://nodejs.org/dist/v19.1.0/node-v19.1.0-darwin-x64.tar.gz#63f4284fa1474b779f0e4fa93985ddc2efa227484476f33d923ae44922637080"

--- a/share/node-build/19.2.0
+++ b/share/node-build/19.2.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v19.2.0/node-v19.2.0-aix-ppc64.tar.gz#8b5ab2cec5a20df8e99242b248a6345f4a393facd29a5b077ba6d7dafd629b4c"
 binary darwin-arm64 "https://nodejs.org/dist/v19.2.0/node-v19.2.0-darwin-arm64.tar.gz#394341380de1b1c6e5a5ab8af86e08e8f097ba7d101d4315bdd7cdcf3b306467"
 binary darwin-x64 "https://nodejs.org/dist/v19.2.0/node-v19.2.0-darwin-x64.tar.gz#e3cfa8f82ea334c3c23bc1d9c9c3a87c4ffff8d29eab17e6bb9d53008103b08b"

--- a/share/node-build/19.3.0
+++ b/share/node-build/19.3.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v19.3.0/node-v19.3.0-aix-ppc64.tar.gz#a5ff43eab40dfa812eeb804a7e064cc9e549e04347f0a0e2250a2a8253eaee6f"
 binary darwin-arm64 "https://nodejs.org/dist/v19.3.0/node-v19.3.0-darwin-arm64.tar.gz#a50be904794d083fa8ecd4113845cea37968cbe3e5c1e758b0ec6215e1e7495e"
 binary darwin-x64 "https://nodejs.org/dist/v19.3.0/node-v19.3.0-darwin-x64.tar.gz#d9692a5f153d2527ec43860e40fa0e77825543f554384aa8d26d33417ffb9069"

--- a/share/node-build/19.4.0
+++ b/share/node-build/19.4.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v19.4.0/node-v19.4.0-aix-ppc64.tar.gz#9fb2fbb9339fe8f3e436b82253c4c53b75b2364c02d9f6857d20efdd90e56479"
 binary darwin-arm64 "https://nodejs.org/dist/v19.4.0/node-v19.4.0-darwin-arm64.tar.gz#9b6bfec4787ec5e500d21e835467fc4bb67689ef7d30a66e31d5bc372405eb42"
 binary darwin-x64 "https://nodejs.org/dist/v19.4.0/node-v19.4.0-darwin-x64.tar.gz#13ec36d26994432731c33a24b55e29a0137e688386adb3254f54ecdbb5ab19c7"

--- a/share/node-build/19.5.0
+++ b/share/node-build/19.5.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v19.5.0/node-v19.5.0-aix-ppc64.tar.gz#6ef2fe701f73e4b42c0e621ca4d3790fd2e1beea6bf0aab1f9351e48ee44c9f2"
 binary darwin-arm64 "https://nodejs.org/dist/v19.5.0/node-v19.5.0-darwin-arm64.tar.gz#6b2ee18d9e888840411086151ab7f2fe519ff9b9292ed450aa98838b7eb58009"
 binary darwin-x64 "https://nodejs.org/dist/v19.5.0/node-v19.5.0-darwin-x64.tar.gz#ebb3798171ce65fb11420aa21696ef6aadc9a1969998d6e00bbea46961c07045"

--- a/share/node-build/19.6.0
+++ b/share/node-build/19.6.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v19.6.0/node-v19.6.0-aix-ppc64.tar.gz#daf3e11e64932a0b53ed3fccd9424948b81328056dca8fd36496fe11c0907a00"
 binary darwin-arm64 "https://nodejs.org/dist/v19.6.0/node-v19.6.0-darwin-arm64.tar.gz#a759366eea06f3433f1f1f7778b6e22d68bbf75661a2de1cd03fc85e30f649cf"
 binary darwin-x64 "https://nodejs.org/dist/v19.6.0/node-v19.6.0-darwin-x64.tar.gz#6b97f9e434a3a3b4cfef35ae1881ced9e80adc3fb536b3060d2ceda5c446a6d3"

--- a/share/node-build/19.6.1
+++ b/share/node-build/19.6.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v19.6.1/node-v19.6.1-aix-ppc64.tar.gz#0b84f9d4189adf1b3d955384db1aba971b4e5ac2dedadeaffa3c76b0efa8fade"
 binary darwin-arm64 "https://nodejs.org/dist/v19.6.1/node-v19.6.1-darwin-arm64.tar.gz#f95951571baaf2180ce41eb5f3e878f6580bc5b203d79fedb479bf5a1b147138"
 binary darwin-x64 "https://nodejs.org/dist/v19.6.1/node-v19.6.1-darwin-x64.tar.gz#a79442a282dec5a6bb1cb73adb926dbc4aa97fa3960193b9ecf56cc76fd6c114"

--- a/share/node-build/19.7.0
+++ b/share/node-build/19.7.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v19.7.0/node-v19.7.0-aix-ppc64.tar.gz#af6a7a636db2a10bfd563181095ed9bcce4a2e49b519649ed0620d48509c1afc"
 binary darwin-arm64 "https://nodejs.org/dist/v19.7.0/node-v19.7.0-darwin-arm64.tar.gz#7a96935baf731d0917a96370dda707b8195ae0a123d6c5ff777d41c3fdda949d"
 binary darwin-x64 "https://nodejs.org/dist/v19.7.0/node-v19.7.0-darwin-x64.tar.gz#2b8593445a4ffc6f42020827dce134497204d55d1ac4a705c0919583d2e6a781"

--- a/share/node-build/19.8.0
+++ b/share/node-build/19.8.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v19.8.0/node-v19.8.0-aix-ppc64.tar.gz#531b19242e504e985599413f59b06d2c6be8089678c03c5523272ef7dabd0d1b"
 binary darwin-arm64 "https://nodejs.org/dist/v19.8.0/node-v19.8.0-darwin-arm64.tar.gz#a4cd2534f84d4c1399ac6bc970492440bb35c91b08023703f09346d02973b148"
 binary darwin-x64 "https://nodejs.org/dist/v19.8.0/node-v19.8.0-darwin-x64.tar.gz#ebcba3767de967593624be989aaaf143d53ed81aeb5e7d861d1abb6b0bd6db57"

--- a/share/node-build/19.8.1
+++ b/share/node-build/19.8.1
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v19.8.1/node-v19.8.1-aix-ppc64.tar.gz#7b1e7e54d14ba09a5fd39dcfbecc94ea5f8dd873288ecf8ddef4a4a113b9aaec"
 binary darwin-arm64 "https://nodejs.org/dist/v19.8.1/node-v19.8.1-darwin-arm64.tar.gz#aafae50af9af911771c766e529eb2522a14bc4695331260e4280be7f526dcaf4"
 binary darwin-x64 "https://nodejs.org/dist/v19.8.1/node-v19.8.1-darwin-x64.tar.gz#f19cb444924dc0168696445ea7b8ec0b0ccdb5c84c59f289aaa847dc20a9defc"

--- a/share/node-build/19.9.0
+++ b/share/node-build/19.9.0
@@ -2,12 +2,6 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
-
-before_install_package() {
-  build_package_warn_lts_maintenance "$1"
-}
-
-
 binary aix-ppc64 "https://nodejs.org/dist/v19.9.0/node-v19.9.0-aix-ppc64.tar.gz#86a6024daff66e468c5feb15648ce03d6072ef88834f9d453ef6b5de5e7255de"
 binary darwin-arm64 "https://nodejs.org/dist/v19.9.0/node-v19.9.0-darwin-arm64.tar.gz#13f7f0e57a2123e55a3172b65e08bc2a51fb52bf366a83d7dda12456ebdc3da0"
 binary darwin-x64 "https://nodejs.org/dist/v19.9.0/node-v19.9.0-darwin-x64.tar.gz#4f1a5b72ef0bcb6757e5daaf3fcf2c26fa35dc5d5fdff7692b63775ed51934a4"


### PR DESCRIPTION
The script that adds EOL warnings is not properly replacing the LTS maintenance warning that it supersedes. So we have a bunch of build definitions that are incorrectly printing LTS-maintenance warnings when in fact the versions are EOL. (The EOL message is being overridden by the LTS-maint warning.)