### PR TITLE
Remove edge builds for deleted branches

### DIFF
--- a/share/node-build/0.10-dev
+++ b/share/node-build/0.10-dev
@@ -1,5 +1,0 @@
-before_install_package() {
-  build_package_warn_eol "$1"
-}
-
-install_git "0.10-dev" "https://github.com/nodejs/node.git" "v0.10-staging" standard

--- a/share/node-build/0.12-dev
+++ b/share/node-build/0.12-dev
@@ -1,5 +1,0 @@
-before_install_package() {
-  build_package_warn_eol "$1"
-}
-
-install_git "0.12-dev" "https://github.com/nodejs/node.git" "v0.12-staging" standard

--- a/share/node-build/10.x-dev
+++ b/share/node-build/10.x-dev
@@ -1,5 +1,0 @@
-before_install_package() {
-  build_package_warn_eol "$1"
-}
-
-install_git "10.x-dev" "https://github.com/nodejs/node.git" "v10.x-staging" standard

--- a/share/node-build/11.x-dev
+++ b/share/node-build/11.x-dev
@@ -1,5 +1,0 @@
-before_install_package() {
-  build_package_warn_eol "$1"
-}
-
-install_git "11.x-dev" "https://github.com/nodejs/node.git" "v11.x-staging" standard

--- a/share/node-build/12.x-dev
+++ b/share/node-build/12.x-dev
@@ -1,4 +1,0 @@
-before_install_package() {
-  build_package_warn_eol "$1"
-}
-

--- a/share/node-build/13.x-dev
+++ b/share/node-build/13.x-dev
@@ -1,4 +1,0 @@
-before_install_package() {
-  build_package_warn_eol "$1"
-}
-

--- a/share/node-build/14.x-dev
+++ b/share/node-build/14.x-dev
@@ -1,5 +1,0 @@
-before_install_package() {
-  build_package_warn_eol "$1"
-}
-
-install_git "14.x-dev" "https://github.com/nodejs/node.git" "v14.x-staging" standard

--- a/share/node-build/4.x-dev
+++ b/share/node-build/4.x-dev
@@ -1,5 +1,0 @@
-before_install_package() {
-  build_package_warn_eol "$1"
-}
-
-install_git "4.x-dev" "https://github.com/nodejs/node.git" "v4.x-staging" standard

--- a/share/node-build/6.x-dev
+++ b/share/node-build/6.x-dev
@@ -1,5 +1,0 @@
-before_install_package() {
-  build_package_warn_eol "$1"
-}
-
-install_git "6.x-dev" "https://github.com/nodejs/node.git" "v6.x-staging" standard

--- a/share/node-build/7.x-dev
+++ b/share/node-build/7.x-dev
@@ -1,5 +1,0 @@
-before_install_package() {
-  build_package_warn_eol "$1"
-}
-
-install_git "7.x-dev" "https://github.com/nodejs/node.git" "v7.x-staging" standard

--- a/share/node-build/8.x-dev
+++ b/share/node-build/8.x-dev
@@ -1,5 +1,0 @@
-before_install_package() {
-  build_package_warn_eol "$1"
-}
-
-install_git "8.x-dev" "https://github.com/nodejs/node.git" "v8.x-staging" standard

--- a/share/node-build/9.x-dev
+++ b/share/node-build/9.x-dev
@@ -1,5 +1,0 @@
-before_install_package() {
-  build_package_warn_eol "$1"
-}
-
-install_git "9.x-dev" "https://github.com/nodejs/node.git" "v9.x-staging" standard


### PR DESCRIPTION
Nodejs has long-since deleted the staging branches for these builds,
so there is no way for them to build.

The `*-next` variants still exist as the corresponding `v*.x` branches still
exist in the nodejs git repo.

Theoretically, anyone who wanted to smoothly deprecate these could
extract these files to a separate build-defs repo and either point the
package at the correct git sha or tag to replicate their last-good
state. But presently I don't think it's worth the trouble.

Alternatively, we could keep the files and "tombstone" them with some error messaging. Again, probably not worth the trouble.
