### PR TITLE
new -dev and -next builds

### DIFF
--- a/share/node-build/1.x-next
+++ b/share/node-build/1.x-next
@@ -1,0 +1,5 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_git "1.x-next" "https://github.com/nodejs/node.git" "v1.x" standard

--- a/share/node-build/12.x-next
+++ b/share/node-build/12.x-next
@@ -2,3 +2,4 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
+install_git "12.x-next" "https://github.com/nodejs/node.git" "v12.x" standard

--- a/share/node-build/13.x-next
+++ b/share/node-build/13.x-next
@@ -2,3 +2,4 @@ before_install_package() {
   build_package_warn_eol "$1"
 }
 
+install_git "13.x-next" "https://github.com/nodejs/node.git" "v13.x" standard

--- a/share/node-build/15.x-next
+++ b/share/node-build/15.x-next
@@ -1,0 +1,5 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_git "15.x-next" "https://github.com/nodejs/node.git" "v15.x" standard

--- a/share/node-build/16.x-dev
+++ b/share/node-build/16.x-dev
@@ -1,0 +1,5 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_git "16.x-dev" "https://github.com/nodejs/node.git" "v16.x-staging" standard

--- a/share/node-build/16.x-next
+++ b/share/node-build/16.x-next
@@ -1,0 +1,5 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_git "16.x-next" "https://github.com/nodejs/node.git" "v16.x" standard

--- a/share/node-build/17.x-next
+++ b/share/node-build/17.x-next
@@ -1,0 +1,5 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_git "17.x-next" "https://github.com/nodejs/node.git" "v17.x" standard

--- a/share/node-build/18.x-dev
+++ b/share/node-build/18.x-dev
@@ -1,0 +1,5 @@
+before_install_package() {
+  build_package_warn_lts_maintenance "$1"
+}
+
+install_git "18.x-dev" "https://github.com/nodejs/node.git" "v18.x-staging" standard

--- a/share/node-build/18.x-next
+++ b/share/node-build/18.x-next
@@ -1,0 +1,5 @@
+before_install_package() {
+  build_package_warn_lts_maintenance "$1"
+}
+
+install_git "18.x-next" "https://github.com/nodejs/node.git" "v18.x" standard

--- a/share/node-build/19.x-next
+++ b/share/node-build/19.x-next
@@ -1,0 +1,5 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_git "19.x-next" "https://github.com/nodejs/node.git" "v19.x" standard

--- a/share/node-build/20.x-dev
+++ b/share/node-build/20.x-dev
@@ -1,0 +1,1 @@
+install_git "20.x-dev" "https://github.com/nodejs/node.git" "v20.x-staging" standard

--- a/share/node-build/20.x-next
+++ b/share/node-build/20.x-next
@@ -1,0 +1,1 @@
+install_git "20.x-next" "https://github.com/nodejs/node.git" "v20.x" standard

--- a/share/node-build/21.x-dev
+++ b/share/node-build/21.x-dev
@@ -1,0 +1,5 @@
+before_install_package() {
+  build_package_warn_lts_maintenance "$1"
+}
+
+install_git "21.x-dev" "https://github.com/nodejs/node.git" "v21.x-staging" standard

--- a/share/node-build/21.x-next
+++ b/share/node-build/21.x-next
@@ -1,0 +1,5 @@
+before_install_package() {
+  build_package_warn_lts_maintenance "$1"
+}
+
+install_git "21.x-next" "https://github.com/nodejs/node.git" "v21.x" standard

--- a/share/node-build/22.x-dev
+++ b/share/node-build/22.x-dev
@@ -1,0 +1,1 @@
+install_git "22.x-dev" "https://github.com/nodejs/node.git" "v22.x-staging" standard

--- a/share/node-build/22.x-next
+++ b/share/node-build/22.x-next
@@ -1,0 +1,1 @@
+install_git "22.x-next" "https://github.com/nodejs/node.git" "v22.x" standard

--- a/share/node-build/3.x-next
+++ b/share/node-build/3.x-next
@@ -1,0 +1,5 @@
+before_install_package() {
+  build_package_warn_eol "$1"
+}
+
+install_git "3.x-next" "https://github.com/nodejs/node.git" "v3.x" standard


### PR DESCRIPTION
Adds (and fixes) missing -dev or -next builds for a bunch of old EOL nodes, some recently in LTS maintenance, and even the latest Current nodes.