### PR TITLE
pull ruby build

### DIFF
--- a/bin/node-build
+++ b/bin/node-build
@@ -703,10 +703,11 @@ build_package_standard_build() {
       export CC=clang
     fi
     ${!PACKAGE_CONFIGURE:-./configure} --prefix="${!PACKAGE_PREFIX_PATH:-$PREFIX_PATH}" \
-      $CONFIGURE_OPTS ${!PACKAGE_CONFIGURE_OPTS} ${!PACKAGE_CONFIGURE_OPTS_ARRAY} || return 1
+      "${!PACKAGE_CONFIGURE_OPTS_ARRAY}" $CONFIGURE_OPTS ${!PACKAGE_CONFIGURE_OPTS} || return 1
   ) >&4 2>&1
 
-  "$MAKE" $MAKE_OPTS ${!PACKAGE_MAKE_OPTS} ${!PACKAGE_MAKE_OPTS_ARRAY} >&4 2>&1
+  { "$MAKE" "${!PACKAGE_MAKE_OPTS_ARRAY}" $MAKE_OPTS ${!PACKAGE_MAKE_OPTS}
+  } >&4 2>&1
 }
 
 build_package_standard_install() {
@@ -717,7 +718,8 @@ build_package_standard_install() {
   local PACKAGE_MAKE_INSTALL_OPTS="${package_var_name}_MAKE_INSTALL_OPTS"
   local PACKAGE_MAKE_INSTALL_OPTS_ARRAY="${package_var_name}_MAKE_INSTALL_OPTS_ARRAY[@]"
 
-  "$MAKE" install $MAKE_INSTALL_OPTS ${!PACKAGE_MAKE_INSTALL_OPTS} ${!PACKAGE_MAKE_INSTALL_OPTS_ARRAY} >&4 2>&1
+  { "$MAKE" install "${!PACKAGE_MAKE_INSTALL_OPTS_ARRAY}" $MAKE_INSTALL_OPTS ${!PACKAGE_MAKE_INSTALL_OPTS}
+  } >&4 2>&1
 }
 
 build_package_standard() {
@@ -819,7 +821,9 @@ build_package_ldflags_dirs() {
 }
 
 build_package_enable_shared() {
+  if [[ " ${NODE_CONFIGURE_OPTS} " != *" --disable-shared"* ]]; then
     package_option node configure --enable-shared
+  fi
 }
 
 apply_node_patch() {


### PR DESCRIPTION
[ruby-build 20210510](
https://github.com/rbenv/ruby-build/releases/tag/v20210510)

* Join *_OPTS variables after *_OPTS_ARRAY variables

  This for instance allows `NODE_CONFIGURE_OPTS` to override
  what's set by the definition.

  For instance `enable_shared` can be disabled with `NODE_CONFIGURE_OPTS='--disable-shared'`

* Do not append `--enable-shared` if NODE_CONFIGURE_OPTS include `--disable-shared`

<details>
<summary>ruby-build commits</summary>

- **Join *_OPTS variables after *_OPTS_ARRAY variables**
- **Do not append `--enable-shared` if RUBY_CONFIGURE_OPTS include `--disable-shared`**
- **ruby-build 20210510**
</details>