### PR TITLE
pull ruby build

### DIFF
--- a/bin/node-build
+++ b/bin/node-build
@@ -732,11 +732,6 @@ build_package_autoconf() {
   } >&4 2>&1
 }
 
-clean_prefix_path() {
-  # Make sure there are no leftover files in $PREFIX_PATH
-  rm -rf "$PREFIX_PATH"
-}
-
 build_package_copy_to() {
   to="$1"
   mkdir -p "$to"
@@ -744,7 +739,6 @@ build_package_copy_to() {
 }
 
 build_package_copy() {
-  clean_prefix_path
   build_package_copy_to "$PREFIX_PATH"
 }
 

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -23,13 +23,15 @@ fi
 
 remove_commands_from_path() {
   local path cmd
-  local paths=( $(command -v "$@" | sed 's!/[^/]*$!!' | sort -u) )
   local NEWPATH=":$PATH:"
-  for path in "${paths[@]}"; do
-    local tmp_path="$(mktemp -d "$BATS_TMPDIR/path.XXXXX")"
-    ln -fs "$path"/* "$tmp_path/"
-    for cmd; do rm -f "$tmp_path/$cmd"; done
-    NEWPATH="${NEWPATH/:$path:/:$tmp_path:}"
+  while PATH="${NEWPATH#:}" command -v "$@" >/dev/null; do
+    local paths=( $(PATH="${NEWPATH#:}" command -v "$@" | sed 's!/[^/]*$!!' | sort -u) )
+    for path in "${paths[@]}"; do
+      local tmp_path="$(mktemp -d "$TMP/path.XXXXX")"
+      ln -fs "$path"/* "$tmp_path/"
+      for cmd; do rm -f "$tmp_path/$cmd"; done
+      NEWPATH="${NEWPATH/:$path:/:$tmp_path:}"
+    done
   done
   echo "${NEWPATH#:}"
 }


### PR DESCRIPTION
merges ruby-build v20210801

<details>
<summary>ruby-build commits</summary>

- **Fix hashes for TruffleRuby 21.1.0**
- **ruby-build 20210526**
- **Added JRuby 9.2.18.0**
- **Add jruby-dev**
- **ruby-build 20210611**
- **Add JRuby 9.2.19.0**
- **Add Ruby 2.6.8, 2.7.4, 3.0.2**
- **ruby-build 20210707**
- **Handle multiple directories in PATH having an executable for remove_commands_from_path**
- **Test Linux in GitHub Actions too**
- **Run script/mirror verify on GitHub Actions too**
- **Only do script/mirror update on TravisCI**
- **:fire: Travis CI**
- **Update ruby-build download mirror in GitHub Actions**
- **Tweak `script/mirror`**
- **Enable manual dispatch of `script/mirror update` in Actions**
- **Add TruffleRuby 21.2.0**
- **ruby-build 20210720**
- **Rename the mirror workflow name for clarity**
- **Ensure it is safe to remove the prefix path for TruffleRuby or error**
- **ruby-build 20210726**
- **Use latest bump-homebrew-formula-action**
- **Fix mirror job in Actions**
- **Disable progress output when uploading to S3**
- **TruffleRuby 21.2+ adds support for linux-aarch64**
- **ruby-build 20210801**
</details>