### PR TITLE
pull ruby build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,10 @@
 > TODO
 > Use one of the scripts `script/update-*` to add a new Node version.
 
+## Updating OpenSSL
+
+Use `script/update-openssl`.
+
 ## Git configuration for fetching rbenv upstream
 
 In order to continually pull changes from rbenv/ruby-build into node-build, it is necessary to add rbenv/ruby-build as a git remote.

--- a/bin/node-build
+++ b/bin/node-build
@@ -1034,6 +1034,10 @@ if [ -n "$VERBOSE" ]; then
   tail -f "$LOG_PATH" &
   TAIL_PID=$!
   trap "kill $TAIL_PID" SIGINT SIGTERM EXIT
+else
+  if [ -z "$NODE_BUILD_TESTING" ]; then
+    echo "To follow progress, use 'tail -f $LOG_PATH' or pass --verbose" >&2
+  fi
 fi
 
 export LDFLAGS="-L${PREFIX_PATH}/lib ${LDFLAGS}"

--- a/script/update-openssl
+++ b/script/update-openssl
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+
+raise "Usage: #{$0} NEW_VERSION SHA" unless ARGV.size == 2
+new_version, sha = ARGV
+
+major_minor = new_version.split('.')[0..1].join('.')
+
+Dir.glob('share/ruby-build/*') do |file|
+  contents = File.read(file)
+
+  openssl_package = "\"openssl-#{major_minor}"
+
+  next unless contents.include? openssl_package
+
+  lines = contents.lines
+  line = lines.find { |line| line.include? openssl_package }
+  old_version = line[/"openssl-([\d.]+[a-z]?)"/, 1] or raise
+  line.gsub!(old_version, new_version)
+  line.sub!(/\.tar\.gz#(\h+)"/, ".tar.gz##{sha}\"")
+  File.write(file, lines.join)
+end

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -3,6 +3,7 @@
 BATS_TMPDIR="$BATS_TEST_DIRNAME/tmp"
 export NODE_BUILD_CURL_OPTS=
 export NODE_BUILD_HTTP_CLIENT="curl"
+export NODE_BUILD_TESTING=true
 
 load ../node_modules/bats-support/load
 load ../node_modules/bats-assert/load


### PR DESCRIPTION
merges ruby-build v20220910.1

<details>
<summary>ruby-build commits</summary>

- **Add JRuby 9.2.21.0 and 9.3.6.0**
- **Add mruby-3.1.0**
- **Add picoruby-3.0.0**
- **ruby-build 20220630**
- **Use OpenSSL 3.0.5**
- **Use OpenSSL 1.1.1q**
- **Fixed version name**
- **Add script to update openssl**
- **Install openssl 1 when openssl is 3**
- **Install openssl whenever the system version does not match**
- **Cleanup**
- **ruby-build 20220710**
- **Use OpenSSL 3.x with Ruby 3.1.x**
- **Update update-cruby to be clear which openssl line should be used**
- **ruby-build 20220713**
- **For Ruby 3.2.0-dev, install YJIT by default if rustc 1.60+ is available**
- **Don't auto-enable YJIT except on x86_64**
- **Restructure build_package_enable_yjit to be cleaner and to exit before later checks if possible.**
- **build_package_enable_yjit should echo to stderr, not stdout**
- **Update bin/ruby-build**
- **Update bin/ruby-build**
- **Update bin/ruby-build**
- **Remove extra paren**
- **Apply patch for implicitly declaration error of OpenSSL 1.1.1q**
- **Use inline patch instead of curl download**
- **ruby-build 20220721**
- **Only check the opensslv.h header to find the system openssl version**
- **ruby-build 20220725**
- **TruffleRuby 22.2+ is available on darwin-aarch64**
- **Add TruffleRuby 22.2.0**
- **ruby-build 20220726**
- **Show the log file to make it easy to follow progress**
- **Add JRuby 9.3.7.0 (#2026)**
- **ruby-build 20220825**
- **YJIT support arm64 and aarch64 arch**
- **Followed up https://github.com/rbenv/ruby-build/pull/2028**
- **Use `-o` for or condition**
- **`uname -m` is aarch64 on Linux**
- **Relax rustc version from 1.58.1**
- **Fix * regex usage of bash**
- **Fix required rustc version for YJIT in output**
- **Added 3.2.0-preview2**
- **ruby-build 20220909**
- **bash didn't provide \d**
- **not needed +**
- **ruby-build 20220910**
- **enable YJIT with 3.2.0-preview2**
- **ruby-build 20220910.1**
</details>