### PR TITLE
pull ruby build

### DIFF
--- a/bin/node-build
+++ b/bin/node-build
@@ -245,10 +245,6 @@ install_git() {
   install_package_using "git" 2 "$@"
 }
 
-install_svn() {
-  install_package_using "svn" 2 "$@"
-}
-
 install_binary() {
   local url name
 
@@ -606,23 +602,6 @@ fetch_git() {
     fi
   else
     echo "error: please install \`git\` and try again" >&2
-    exit 1
-  fi
-}
-
-fetch_svn() {
-  local package_name="$1"
-  local svn_url="$2"
-  local svn_rev="$3"
-
-  echo "Checking out ${svn_url}..." >&2
-
-  if type svn &>/dev/null; then
-    svn co -r "$svn_rev" "$svn_url" "${package_name}" >&4 2>&1
-  elif type svnlite &>/dev/null; then
-    svnlite co -r "$svn_rev" "$svn_url" "${package_name}" >&4 2>&1
-  else
-    echo "error: please install Subversion and try again" >&2
     exit 1
   fi
 }

--- a/bin/nodenv-install
+++ b/bin/nodenv-install
@@ -103,7 +103,7 @@ for option in "${OPTIONS[@]}"; do
     ;;
   "l" | "list" )
     node-build --list
-    [ -t 1 ] && {
+    [ ! -t 1 ] || {
       echo
       echo "Only latest stable releases for each Node implementation are shown."
       echo "Use 'nodenv install --list-all / -L' to show all local versions."

--- a/test/nodenv.bats
+++ b/test/nodenv.bats
@@ -32,7 +32,8 @@ stub_node_build() {
   stub_node_build 'echo node-build "$@"'
 
   run nodenv-install 4.1.2
-  assert_success <<OUT
+  assert_success
+  assert_output <<OUT
 node-build 4.1.2 ${NODENV_ROOT}/versions/4.1.2
 
 NOTE: to activate this Node version as the new default, run: nodenv global 4.1.2
@@ -51,6 +52,16 @@ OUT
 
   unstub node-build
   unstub nodenv-local
+}
+
+@test "list latest versions" {
+  stub_node_build "--list : echo 4.1.2"
+
+  run nodenv-install --list
+  assert_success
+  assert_output "4.1.2"
+
+  unstub node-build
 }
 
 @test "list available versions" {


### PR DESCRIPTION
merges [ruby-build 20230124](https://github.com/rbenv/ruby-build/releases/tag/v20230124)

<details>
<summary>ruby-build commits</summary>

- **Fix `rbenv install --list` exit status**
- **ruby-build 20221004**
- **Add JRuby 9.3.9.0**
- **ruby-build 20221025**
- **Add TruffleRuby and TruffleRuby GraalVM 22.3.0**
- **ruby-build 20221026**
- **Use OpenSSL 3.0.7 for ruby 3.1**
- **ruby-build 20221101**
- **Mark Ruby 2.6 as EOL**
- **Mark Ruby 2.7 as unsupported**
- **Add definition for Ruby 3.2.0-preview3**
- **Update to openssl 1.1.1s**
- **Do not automatically enable YJIT nor attempt to detect rustc**
- **ruby-build 20221116**
- **truffleruby+graalvm-dev builds are now based on Java 17**
- **ruby-build 20221121**
- **JRuby 9.4.0.0**
- **ruby-build 20221123**
- **Add definition for Ruby 3.1.3, 3.0.5, and 2.7.7**
- **ruby-build 20221124**
- **Add definition for Ruby 3.2.0 RC 1**
- **ruby-build 20221206**
- **Added 3.2.0**
- **ruby-build 20221225**
- **Development of 3.3.0 started.**
- **Warn EOL status for all of rbx packages**
- **Removed rbx updater**
- **Fixes #2119**
- **Use git instead of svn**
- **Completely removed subversion feature**
- **Add TruffleRuby and TruffleRuby GraalVM 22.3.1**
- **ruby-build 20230124**
</details>