### PR TITLE
pull ruby build

### DIFF
--- a/bin/node-build
+++ b/bin/node-build
@@ -109,6 +109,15 @@ is_mac() {
   [ $# -eq 0 ] || test "$(osx_version)" "$@"
 }
 
+is_freebsd() {
+  [ "$(uname -s)" = "FreeBSD" ]
+}
+
+freebsd_package_prefix() {
+  local package="$1"
+  pkg info --prefix "$package" 2>/dev/null | cut -wf2
+}
+
 #  9.1  -> 901
 # 10.9  -> 1009
 # 10.10 -> 1010
@@ -972,7 +981,7 @@ if [ -n "$noexec" ]; then
 fi
 
 if [ -z "$MAKE" ]; then
-  if [ "FreeBSD" = "$(uname -s)" ]; then
+  if is_freebsd; then
     # node needs gmake on FreeBSD : https://github.com/nodejs/node/blob/0229e378e80948428cf7baa7b176939e879497cc/BSDmakefile#L7
     export MAKE="gmake"
   else


### PR DESCRIPTION
Merges [ruby-build v20230717](https://github.com/rbenv/ruby-build/releases/tag/v20230717)

<details>
<summary>ruby-build commits</summary>

- **Fall back on shasum if sha256sum is unavailable**
- **Mark EOL warning to Ruby 2.7**
- **Mark EOL warning to preview versions of Ruby 2.6**
- **Fix uploading SARIF reports from Differential Shellcheck**
- **Fix compilation of Ruby 3.2.x on FreeBSD (#2187)**
- **Fix truffleruby+graalvm-dev download URLs**
- **ruby-build 20230424**
- **Add TruffleRuby 23.0.0-preview1**
- **Add TruffleRuby+GraalVM 23.0.0-preview1**
- **ruby-build 20230428**
- **Added Ruby 3.3.0-preview1**
- **Update OpenSSL package for 3.3.0-preview1**
- **ruby-build 20230512**
- **Add JRuby 9.4.3.0**
- **ruby-build 20230608**
- **Add TruffleRuby and TruffleRuby+GraalVM 23.0.0**
- **ruby-build 20230614**
- **Print a message about the new distribution and license when installing TruffleRuby 23.0**
- **ruby-build 20230615**
- **Use OpenSSL-3.1.1**
- **Use OpenSSL-1.1.1u**
- **ruby-build 20230710**
- **Follow truffleruby dev standalones rename**
- **ruby-build 20230717**
</details>