### PR TITLE
pull ruby build

### DIFF
--- a/bin/node-build
+++ b/bin/node-build
@@ -794,12 +794,12 @@ require_java7() {
 
 # Kept for backward compatibility
 require_gcc() {
-  local stub=1
+  :
 }
 
 # Kept for backward compatibility
 require_llvm() {
-  local stub=1
+  :
 }
 
 # Ensure that directories listed in LDFLAGS exist

--- a/bin/node-build
+++ b/bin/node-build
@@ -787,6 +787,21 @@ fix_jxcore_directory_structure() {
   } >&4
 }
 
+# Kept for backward compatibility
+require_java7() {
+  require_java 7
+}
+
+# Kept for backward compatibility
+require_gcc() {
+  local stub=1
+}
+
+# Kept for backward compatibility
+require_llvm() {
+  local stub=1
+}
+
 # Ensure that directories listed in LDFLAGS exist
 build_package_ldflags_dirs() {
   local arg dir

--- a/test/build.bats
+++ b/test/build.bats
@@ -185,6 +185,7 @@ OUT
   stub_make_install
 
   export -n MAKE_OPTS
+  export NODE_CONFIGURE_OPTS="--with-openssl-dir=/test"
   run_inline_definition <<DEF
 install_package "node-v4.0.0" "http://nodejs.org/dist/v4.0.0/node-v4.0.0.tar.gz"
 DEF
@@ -195,7 +196,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-node-v4.0.0: --prefix=$INSTALL_ROOT
+node-v4.0.0: --prefix=$INSTALL_ROOT --with-openssl-dir=/test
 make -j 1
 make install
 OUT


### PR DESCRIPTION
merges [ruby-build 20230919](https://github.com/rbenv/ruby-build/releases/tag/v20230919)

<details>
<summary>ruby-build commits</summary>

- **Show openssl version used from homebrew by default**
- **Use OpenSSL-3.1.2**
- **Use OpenSSL-1.1.1v**
- **Avoid test failure when stubbing FreeBSD environment**
- **Remove `require_llvm` implementation**
- **Remove `require_gcc` implementation**
- **Display the actual error when testing for Ruby's openssl extension (#2223)**
- **Update URLs for truffleruby+graalvm-dev**
- **ruby-build 20230904**
- **Bump actions/checkout from 3 to 4**
- **Add JRuby 9.3.11.0**
- **ruby-build 20230912**
- **workaround jruby#7799 by updating rubygems for JRuby 9.2.x (#2246)**
- **Added 3.3.0-preview2**
- **Bump openssl-1.1.1w**
- **ruby-build 20230914**
- **Use the TruffleRuby JVM Standalones for truffleruby+graalvm-dev**
- **Update URLs for truffleruby+graalvm-dev**
- **ruby-build 20230914.1**
- **Add TruffleRuby and TruffleRuby GraalVM 23.1.0**
- **ruby-build 20230919**
</details>