### PR TITLE
Bump version when defs are modified on main

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,5 +1,6 @@
 name: Version Bump
 on:
+  push: { branches: main, paths: [share/node-build]}
   schedule: [{ cron: '0 10 * * *' }] # daily: https://crontab.guru/#0_10_*_*_*
   workflow_dispatch:
     inputs:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,6 +1,6 @@
 name: Version Bump
 on:
-  push: { branches: main, paths: [share/node-build]}
+  push: { branches: main, paths: share/node-build}
   schedule: [{ cron: '0 10 * * *' }] # daily: https://crontab.guru/#0_10_*_*_*
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Presently, the scraper runs on a schedule and PRs are opened to include new build definitions.

Once those PRs are merged, there is a scheduled (daily) job to bump node-build's version which then triggers a release.

This change will allow the version bump to be triggered automatically when definitions are updated in share/node-build (in pushes to `main`).