### PR TITLE
ci: fix failing Differential ShellCheck workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,9 @@
 name: Test
 on:
   push:
+    branches: [ main, v5 ]
   pull_request:
+    branches: [ main, v5 ]
   schedule: [{ cron: "0 0 10 * *" }] # monthly https://crontab.guru/#0_0_10_*_*
   workflow_dispatch:
 


### PR DESCRIPTION
Differential ShellCheck requires a specified branch in the workflow file. To avoid this error:

```
fatal: Invalid revision range e7d05fd3533403e8aa79d4c22b31d106ec3877ac..cdb538f5c530addbc82c353a94e5d29844d043d4
```

This should resolve the issue described in:
- https://github.com/redhat-plumbers-in-action/differential-shellcheck/issues/586